### PR TITLE
feat: add methods for fetching FHIR profile version

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.65.1</version>
+	<version>0.65.2</version>
 	<packaging>war</packaging>
 	<name>TechBD Hub (Prime)</name>
 	<description>TechBD Hub (Primary)</description>

--- a/hub-prime/src/main/java/org/inferno/validator/Validator.java
+++ b/hub-prime/src/main/java/org/inferno/validator/Validator.java
@@ -35,7 +35,6 @@ public class Validator {
   private final Map<String, NpmPackage> loadedPackages;
 
   private static String assignedUrlFrom = null;
-  private static String vesrionFrom = null;
   
   private static final Logger LOGGER = LoggerFactory.getLogger(Validator.class);
 
@@ -116,14 +115,6 @@ public class Validator {
 
   public static void setAssignedUrlFrom(String assignedUrlFrom) {
     Validator.assignedUrlFrom = assignedUrlFrom;
-  }
-
-  public   String getVersionFrom() {
-    return vesrionFrom;
-  }
-
-  public static void setVersionFrom(String vesrionFrom) {
-    Validator.vesrionFrom = vesrionFrom;
   }
 
   /**
@@ -253,7 +244,6 @@ public class Validator {
       StructureDefinition sd = (StructureDefinition)resource;
       LOGGER.info("Loaded profile from file, url: " + sd.getUrl() + " version: " + sd.getVersion());
       setAssignedUrlFrom(sd.getUrl());
-      setVersionFrom(sd.getVersion());
     } else if (resource != null) {
       LOGGER.info("Loaded resource from file but it wasn't a StructureDefinition, it was a "
         + resource.fhirType());

--- a/hub-prime/src/main/java/org/techbd/orchestrate/fhir/OrchestrationEngine.java
+++ b/hub-prime/src/main/java/org/techbd/orchestrate/fhir/OrchestrationEngine.java
@@ -147,11 +147,11 @@ public class OrchestrationEngine {
         String fhirProfileVersion = client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::body)
                 .thenApply(responseBody -> {
-                    ObjectMapper objectMapper = new ObjectMapper();
+                    final var objectMapper = new ObjectMapper();
 
                     try {
                         // Read JSON response and parse it into a JsonNode
-                        JsonNode rootNode = objectMapper.readTree(responseBody);
+                        final var rootNode = objectMapper.readTree(responseBody);
 
                         // Get the value of the "version" key from FHIR IG profile JSON
                         JsonNode versionNode = rootNode.path("version");
@@ -746,7 +746,7 @@ public class OrchestrationEngine {
 
                 OperationOutcome oo = validator.validate(payloadContent, fhirBundleProfile);
                 ArrayNode issueArray = displayValidationErrors(oo, false);
-                ObjectMapper mapper = new ObjectMapper();
+                final var mapper = new ObjectMapper();
                 String responseBody = mapper.writeValueAsString(issueArray);
 
                 final Instant completedAt = Instant.now();


### PR DESCRIPTION
 - Add method to fetch FHIR profile version
 - Improve performance by caching the FHIR profile version to reduce redundant network calls.
- Utilize HttpClient for asynchronous HTTP requests to fetch the FHIR profile version from the provided URL.
- Parse the JSON response using ObjectMapper to extract the "version" field.
- Ensure the method waits for the asynchronous operation to complete using join().
- remove fetching version from Validator class
- refactor code to enhances code readability and leverages Java's type inference for local variables.