### PR TITLE
feat: add new row for "Original FHIR Payload" in interactions #1

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.96.0</version>
+	<version>0.97.0</version>
 	<packaging>war</packaging>
 	<name>TechBD Hub (Prime)</name>
 	<description>TechBD Hub (Primary)</description>

--- a/hub-prime/src/main/java/org/techbd/orchestrate/fhir/OrchestrationEngine.java
+++ b/hub-prime/src/main/java/org/techbd/orchestrate/fhir/OrchestrationEngine.java
@@ -22,8 +22,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.commons.text.StringEscapeUtils;
-import org.springframework.cache.annotation.Cacheable;
-import org.techbd.conf.Configuration;
 import org.techbd.util.JsonText.JsonTextSerializer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FhirController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FhirController.java
@@ -166,7 +166,7 @@ public class FhirController {
                                 Map.of("nature", "Original FHIR Payload", "tenant_id", tenantId)));
                         payloadRIHR.setContentType(MimeTypeUtils.APPLICATION_JSON_VALUE);
                         try {
-                            // input FHIR Bundle JSON payload from the server
+                            // input FHIR Bundle JSON payload
                             payloadRIHR.setPayload(Configuration.objectMapper.readTree(payload));
                         } catch (JsonProcessingException jpe) {
                             // in case the payload is not JSON store the string


### PR DESCRIPTION
- Removed previous implementation where the payload was added to an existing row in a different column.
- Added a new row to the interactions table with the nature "Original FHIR Payload" to store the input FHIR payload for the Bundle API.
