### PR TITLE
feat:update sql view for http interactions to include new header content and add 'interaction_observe' view #108

### DIFF
--- a/udi-prime/src/main/postgres/ingestion-center/001_idempotent_interaction.psql
+++ b/udi-prime/src/main/postgres/ingestion-center/001_idempotent_interaction.psql
@@ -13,13 +13,32 @@
  *   several steps or dependent requests to fulfill a single client request.
  ****************************************************************************************/
 DROP VIEW IF EXISTS techbd_udi_ingress.interaction_http_request CASCADE;
-CREATE OR REPLACE VIEW techbd_udi_ingress.interaction_http_request AS 
+CREATE OR REPLACE VIEW techbd_udi_ingress.interaction_http_request AS
 WITH cte_resource_types AS (
     SELECT sat_interaction_http_request_id, 
            string_agg(DISTINCT entry->'resource'->>'resourceType', ', ') AS resource_types
     FROM techbd_udi_ingress.sat_interaction_http_request,
          LATERAL jsonb_array_elements(payload->'entry') AS entry
     GROUP BY sat_interaction_http_request_id   
+), cte_interaction_observe AS (
+SELECT sihr.sat_interaction_http_request_id AS interaction_http_request_id,
+    sihr.hub_interaction_id 				AS interaction_id,
+    headers.start_time						AS start_time,
+    headers.finish_time						AS finish_time,
+    headers.duration_nanosecs 				AS duration_nanosecs,
+    headers.duration_millisecs 				AS duration_millisecs
+FROM 
+    techbd_udi_ingress.sat_interaction_http_request sihr
+JOIN LATERAL (
+    SELECT
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Start-Time' THEN header->>'value' END) AS start_time,
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Finish-Time' THEN header->>'value' END) AS finish_time,
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Duration-Nanosecs' THEN header->>'value' END) AS duration_nanosecs,
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Duration-Millisecs' THEN header->>'value' END) AS duration_millisecs
+    FROM jsonb_array_elements(sihr.payload->'response'->'headers') header
+) headers ON true
+WHERE 1 = 1
+AND sihr.nature ->> 'nature' = 'org.techbd.service.http.Interactions$RequestResponseEncountered'
 )
 SELECT hi.hub_interaction_id AS interaction_id,
     hi.key AS uri,
@@ -42,11 +61,17 @@ SELECT hi.hub_interaction_id AS interaction_id,
     sihr.provenance AS request_provenance,
     jsonb_array_length((((((sihr.payload -> 'response'::text) -> 'responseBody'::text) -> 'OperationOutcome'::text) -> 'validationResults'::text) -> 0) -> 'issues'::text) AS issues_count,
     rtyp.resource_types
+    ,intr_observe.start_time
+	,intr_observe.finish_time
+	,intr_observe.duration_nanosecs
+	,intr_observe.duration_millisecs
    FROM techbd_udi_ingress.hub_interaction hi
   	LEFT JOIN techbd_udi_ingress.sat_interaction_http_request sihr 
     ON hi.hub_interaction_id = sihr.hub_interaction_id
     LEFT OUTER JOIN cte_resource_types rtyp
    	ON rtyp.sat_interaction_http_request_id = sihr.sat_interaction_http_request_id
+   	LEFT OUTER JOIN cte_interaction_observe intr_observe
+   	ON intr_observe.interaction_id = sihr.hub_interaction_id
    ;
 
 /*******************************************************************************************
@@ -122,6 +147,8 @@ SELECT
     LIMIT 1 OFFSET 2) AS third_request
 FROM
     techbd_udi_ingress.hub_interaction hi;
+
+
 /*******************************************************************************************
 This view is to facilitate the analysis and debugging of failed HTTP interactions. 
 This can help in improving the overall reliability and performance of the system by 
@@ -289,7 +316,7 @@ This view combines data from hub_interaction and sat_interaction_http_request ta
 provide a consolidated view of HTTP FHIR requests, including resource types, 
 interaction details, request attributes, and validation issues.
 ******************************************************************************************/
-
+DROP VIEW IF EXISTS techbd_udi_ingress.interaction_http_fhir_request CASCADE;
 CREATE OR REPLACE VIEW techbd_udi_ingress.interaction_http_fhir_request
 AS WITH cte_resource_types AS (
          SELECT sat_interaction_http_request.sat_interaction_http_request_id,
@@ -324,6 +351,46 @@ AS WITH cte_resource_types AS (
      LEFT JOIN cte_resource_types rtyp ON rtyp.sat_interaction_http_request_id = sihr.sat_interaction_http_request_id
      WHERE hi.key IN('/Bundle','/Bundle/$validate')
     ;
+
+/*******************************************************************************************
+This view is to extract observability metrics from HTTP request interactions.This view joins 
+data from sat_interaction_http_request with JSONB headers to retrieve specific observability 
+metrics. Metrics extracted include start time, finish time, duration in nanoseconds, and 
+duration in milliseconds. To optimize the query, use a LATERAL join to extract the JSONB 
+values more efficiently. This approach avoids multiple jsonb_array_elements function calls 
+for each row and reduces repeated scanning of the JSONB arrays.
+******************************************************************************************/
+DROP VIEW IF EXISTS techbd_udi_ingress.interaction_observe CASCADE;
+CREATE OR REPLACE VIEW techbd_udi_ingress.interaction_observe
+AS
+WITH cte_interaction_observe AS (
+SELECT sihr.sat_interaction_http_request_id AS interaction_http_request_id,
+    sihr.hub_interaction_id 				AS interaction_id,
+    headers.start_time						AS start_time,
+    headers.finish_time						AS finish_time,
+    headers.duration_nanosecs 				AS duration_nanosecs,
+    headers.duration_millisecs 				AS duration_millisecs
+FROM 
+    techbd_udi_ingress.sat_interaction_http_request sihr
+JOIN LATERAL (
+    SELECT
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Start-Time' THEN header->>'value' END) AS start_time,
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Finish-Time' THEN header->>'value' END) AS finish_time,
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Duration-Nanosecs' THEN header->>'value' END) AS duration_nanosecs,
+        MAX(CASE WHEN header->>'name' = 'X-Observability-Metric-Interaction-Duration-Millisecs' THEN header->>'value' END) AS duration_millisecs
+    FROM jsonb_array_elements(sihr.payload->'response'->'headers') header
+) headers ON true
+WHERE 1 = 1
+AND sihr.nature ->> 'nature' = 'org.techbd.service.http.Interactions$RequestResponseEncountered'
+)
+SELECT intr_observe.interaction_http_request_id 
+,intr_observe.interaction_id
+,intr_observe.start_time
+,intr_observe.finish_time
+,intr_observe.duration_nanosecs
+,intr_observe.duration_millisecs
+FROM cte_interaction_observe AS intr_observe
+;
 
 /*******************************************************************************************************************************
  * Procedure to register an HTTP interaction, handling potential unique constraint violations


### PR DESCRIPTION
## Summary
This PR updates the SQL view for HTTP interactions to incorporate the header content introduced by the "Integrate reportable interaction timing metrics in UI/UX". Additionally, it adds a new view, 'interaction observe', to further enhance interaction observation and analysis.

## Changes
- Modified the HTTP interactions SQL view to extract and utilize new header content from JSON payloads.
- Added a new view, 'interaction_observe', to facilitate enhanced observation of interactions.

