### PR TITLE
feat: Introduce SchemaSpy docs browser #102

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.111.0</version>
+	<version>0.112.0</version>
 	<packaging>war</packaging>
 	<name>TechBD Hub (Prime)</name>
 	<description>TechBD Hub (Primary)</description>

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DocsController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DocsController.java
@@ -203,4 +203,10 @@ public class DocsController {
     public String projects(final Model model, final HttpServletRequest request) {
         return presentation.populateModel("page/docs/project", model, request);
     }
+
+    @RouteMapping(label = "Schema", title = "Schema", siblingOrder = 50)
+    @GetMapping("/docs/schema")
+    public String schemaSpy(final Model model, final HttpServletRequest request) {
+        return presentation.populateModel("page/docs/schema", model, request);
+    }
 }

--- a/hub-prime/src/main/resources/templates/page/docs/schema.html
+++ b/hub-prime/src/main/resources/templates/page/docs/schema.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{layout/docs}">
+
+<head>
+    <title>Documentation</title>
+</head>
+
+<body>
+    <div layout:fragment="content">
+        <iframe th:src="@{/maven-site/schemaSpy/index.html}" class="w-full min-h-screen"></iframe>
+    </div>
+</body>
+
+</html>

--- a/udi-prime/udictl.ts
+++ b/udi-prime/udictl.ts
@@ -182,7 +182,7 @@ const CLI = new Command()
           })
        )
       .command("docs", "Generate documentation artifacts")
-        .option("--schemaspy-dest <path:string>", "Generate SchemaSpy documentation", { default: cleanableTarget("/docs/schema-spy") })
+        .option("--schemaspy-dest <path:string>", "Generate SchemaSpy documentation", { default: cleanableTarget("../../hub-prime/target/site/schemaSpy") })
         .option("-c, --conn-id <id:string>", "pgpass connection ID to use for SchemaSpy database credentials", { required: true, default: "UDI_PRIME_DESTROYABLE_DEVL" })
         .option("--serve <port:number>", "Serve generated documentation at port")
         .action(async (options) => {


### PR DESCRIPTION
- Added a new 'Schema' tab in the Documentation section of TechBD Hub.
- Enabled static browsing of SchemaSpy-generated documentation located in target/site/schemaSpy.