### PR TITLE
fix: modified the duration calculation in interaction_observe view to use extract(epoch) for more accurate millisecond values #108

### DIFF
--- a/udi-prime/src/main/postgres/ingestion-center/001_idempotent_interaction.psql
+++ b/udi-prime/src/main/postgres/ingestion-center/001_idempotent_interaction.psql
@@ -367,7 +367,7 @@ SELECT sihr.sat_interaction_http_request_id AS interaction_http_request_id,
     sihr.hub_interaction_id AS interaction_id,
     headers.start_time,
     headers.finish_time,
-   (headers.finish_time::timestamp - headers.start_time::timestamp) AS duration_millisecs,
+    EXTRACT(EPOCH FROM (headers.finish_time::timestamp without time zone - headers.start_time::timestamp without time zone)) * 1000 AS duration_millisecs,
     (sihr.payload -> 'request'::text) ->> 'requestUri'::text AS uri
    FROM techbd_udi_ingress.sat_interaction_http_request sihr
      JOIN LATERAL ( SELECT max(


### PR DESCRIPTION
**Description:**
This PR modifies the 'interaction_observe' view to improve the accuracy of the duration calculation. 

**Changes:**
Updated the calculation of 'duration_millisecs' to use EXTRACT(EPOCH) for more precise millisecond values.