### PR TITLE
fix: resolve warnings while building the project  #215

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -66,6 +66,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -75,6 +81,12 @@
 			<groupId>com.github.bxforce</groupId>
 			<artifactId>commons-vfs2-spring-boot-starter</artifactId>
 			<version>1.0.1-RELEASE</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.thymeleaf.extras</groupId>
@@ -159,7 +171,7 @@
 			<version>3.2.0-M2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.hibernate</groupId>
+			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-core</artifactId>
 			<version>6.0.0.Final</version>
 		</dependency>


### PR DESCRIPTION
Resolved 

- Artifact relocation warning

[WARNING] The artifact org.hibernate:hibernate-core:jar:6.0.0.Final has been relocated to org.hibernate.orm:hibernate-core:jar:6.0.0.Final

- Commons Logging conflict warning:

Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from class path in order to avoid potential conflicts