### PR TITLE
feat: update default Data Lake API URL  #307

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.162.0</version>
+	<version>0.163.0</version>
 	<packaging>war</packaging>
 	<name>TechBD Hub (Prime)</name>
 	<description>TechBD Hub (Primary)</description>

--- a/hub-prime/src/main/resources/application.yml
+++ b/hub-prime/src/main/resources/application.yml
@@ -74,7 +74,7 @@ org:
           prime:
             version: @project.version@
             defaultSdohFhirProfileUrl: https://djq7jdt8kb490.cloudfront.net/1115/StructureDefinition-SHINNYBundleProfile.json
-            defaultDatalakeApiUrl: https://40lafnwsw7.execute-api.us-east-1.amazonaws.com/dev
+            defaultDatalakeApiUrl: https://qo5beg39c8.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle
         interactions:
           defaultPersistStrategy: "{ \"nature\": \"fs\" }"
           persist:


### PR DESCRIPTION
update Data Lake API URL to https://qo5beg39c8.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle