### PR TITLE
test: uncomment IgPublicationIssuesTest code, update with latest IG profile URL, add UV-SDC packages, and clear validation session #732

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.334.0</version>
+	<version>0.335.0</version>
 	<packaging>war</packaging>
 	<name>Tech by Design Hub (Prime)</name>
 	<description>Tech by Design Hub (Primary)</description>

--- a/hub-prime/src/test/java/org/techbd/orchestrate/fhir/IgPublicationIssuesTest.java
+++ b/hub-prime/src/test/java/org/techbd/orchestrate/fhir/IgPublicationIssuesTest.java
@@ -14,10 +14,11 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.techbd.orchestrate.fhir.OrchestrationEngine.ValidationIssue;
+import org.techbd.orchestrate.fhir.OrchestrationEngine.ValidationResult;
 
 public class IgPublicationIssuesTest {
     private OrchestrationEngine engine;
-    private static final String FHIR_PROFILE_URL = "https://shinny.org/ImplementationGuide/HRSN/StructureDefinition-SHINNYBundleProfile.json";
+    private static final String FHIR_PROFILE_URL = "https://shinny.org/us/ny/hrsn/StructureDefinition-SHINNYBundleProfile.json";
     private static final Predicate<ValidationIssue> IS_UNEXPECTED_IG_ISSUE = issue -> issue.getMessage()
             .contains("has not been checked because it is unknown") ||
             issue.getMessage().contains("Unknown profile") ||
@@ -56,236 +57,236 @@ public class IgPublicationIssuesTest {
         engine = new OrchestrationEngine();
     }
 
-    // @Test
-    // void testBundle_AHCHRSNScreeningResponseExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
-    //             URL_AHCHRSNSCREENINGRESPONSE_EXAMPLE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
+    @Test
+    void testBundle_AHCHRSNScreeningResponseExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
+                URL_AHCHRSNSCREENINGRESPONSE_EXAMPLE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
 
-    // }
+    }
 
-    // @Test
-    // void testBundle_AHCHRSNQuestionnaireResponseExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
-    //             URL_AHCHRSNQUESTIONAIRE_EXAMPLE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
-    // }
+    @Test
+    void testBundle_AHCHRSNQuestionnaireResponseExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
+                URL_AHCHRSNQUESTIONAIRE_EXAMPLE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
+    }
 
-    // @Test
-    // void testBundle_ObservationAssessmentFoodInsecurityExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
-    //             URL_OBSERVATION_ASSESSMENT_FOOD_SECURITY_EXAMPLE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_DIAGNOSIS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_US_CORE_CONDITION_CATEGORY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
-    // }
+    @Test
+    void testBundle_ObservationAssessmentFoodInsecurityExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
+                URL_OBSERVATION_ASSESSMENT_FOOD_SECURITY_EXAMPLE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_DIAGNOSIS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_US_CORE_CONDITION_CATEGORY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
+    }
 
-    // @Test
-    // void testBundle_ServiceRequestExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
-    //             URL_SERVICE_REQUEST_EXAMPLE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_SDOH_SERVICE_REQUEST);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
-    // }
+    @Test
+    void testBundle_ServiceRequestExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
+                URL_SERVICE_REQUEST_EXAMPLE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_SDOH_SERVICE_REQUEST);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
+    }
 
-    // @Test
-    // void testBundle_TaskCompletedExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
-    //             URL_TASK_COMPLETED_EXAMPLE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_SDOH_SERVICE_REQUEST);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
-    // }
+    @Test
+    void testBundle_TaskCompletedExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
+                URL_TASK_COMPLETED_EXAMPLE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_SDOH_SERVICE_REQUEST);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
+    }
 
-    // @Test
-    // void testBundle_TaskExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(URL_TASK_EXAMPLE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_SDOH_REFERAL_MANAGEMENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
-    // }
+    @Test
+    void testBundle_TaskExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(URL_TASK_EXAMPLE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_SDOH_REFERAL_MANAGEMENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
+    }
 
-    // @Test
-    // void testBundle_TaskOutputProcedureExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
-    //             URL_TASK_OUTPUT_PROCEDURE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
-    // }
+    @Test
+    void testBundle_TaskOutputProcedureExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
+                URL_TASK_OUTPUT_PROCEDURE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
+    }
 
-    // @Test
-    // void testBundle_NYScreeningResponseExample() throws IOException {
-    //     final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
-    //             URL_NYSSCREENING_RESPONSE_EXAMPLE);
-    //     final long unexpectedIgIssues = results.stream()
-    //             .flatMap(result -> result.getIssues().stream())
-    //             .filter(IS_UNEXPECTED_IG_ISSUE)
-    //             .map(issue -> issue.getMessage().trim())
-    //             .distinct()
-    //             .count();
-    //     final var softly = new SoftAssertions();
-    //     softly.assertThat(results).hasSize(1);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
-    //     assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
-    //     softly.assertThat(unexpectedIgIssues).isZero()
-    //             .withFailMessage("There should be no IG publication issues");
-    //     throwEachAssertionError(softly);
-    // }
+    @Test
+    void testBundle_NYScreeningResponseExample() throws IOException {
+        final List<OrchestrationEngine.ValidationResult> results = getValidationErrors(
+                URL_NYSSCREENING_RESPONSE_EXAMPLE);
+        final long unexpectedIgIssues = results.stream()
+                .flatMap(result -> result.getIssues().stream())
+                .filter(IS_UNEXPECTED_IG_ISSUE)
+                .map(issue -> issue.getMessage().trim())
+                .distinct()
+                .count();
+        final var softly = new SoftAssertions();
+        softly.assertThat(results).hasSize(1);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_PERSONAL_PRONOUNS);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTS_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHINNY_MIDDLE_NAME);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_COUNTY);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_PATIENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ENCOUNTER);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_CONSENT);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_ORGANIZATION);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_QUESTIONAIRE_RESPONSE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_SHNNY_BUNDLE_PROFILE);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_NLM_VALUE_SET);
+        assertUnexpectedIgError(softly, results, ERROR_MESSAGE_CTM_CTS_VALUE_SET);
+        softly.assertThat(unexpectedIgIssues).isZero()
+                .withFailMessage("There should be no IG publication issues");
+        throwEachAssertionError(softly);
+    }
 
     private void throwEachAssertionError(final SoftAssertions softly) {
         final List<AssertionError> errors = softly.assertionErrorsCollected();
@@ -317,7 +318,9 @@ public class IgPublicationIssuesTest {
                 .addHapiValidationEngine()
                 .build();
         engine.orchestrate(session);
-        return engine.getSessions().get(0).getValidationResults();
+        List<ValidationResult> results = engine.getSessions().get(0).getValidationResults();
+        engine.clear(session);
+        return results;
     }
 
     private Map<String, Map<String, String>> getIgPackages() {
@@ -327,6 +330,7 @@ public class IgPublicationIssuesTest {
         igMap.put("shinNy", "ig-packages/shin-ny-ig/v1.1.0");
         igMap.put("usCore", "ig-packages/fhir-v4/us-core/stu-7.0.0");
         igMap.put("sdoh", "ig-packages/fhir-v4/sdoh-clinicalcare/stu-2.2.0");
+        igMap.put("uvSdc", "ig-packages/fhir-v4/uv-sdc/stu-3.0.0");
         igPackages.put("fhir-v4", igMap);
 
         return igPackages;


### PR DESCRIPTION
- Uncommented previously disabled code in IgPublicationIssuesTest.
- Updated to the latest Implementation Guide (IG) profile URL.
- Added UV-SDC packages to support extended validation capabilities.
- Implemented session clearing  after retrieving validation results to optimize memory usage.