### PR TITLE
fix: handle empty request and confirm extensions in CSV validate API

### DIFF
--- a/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/CsvController.java
+++ b/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/CsvController.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -24,41 +26,59 @@ import jakarta.servlet.http.HttpServletResponse;
 @RestController
 @Tag(name = "Tech by Design Hub CSV Endpoints", description = "Tech by Design Hub CSV Endpoints")
 public class CsvController {
-        private static final Logger log = LoggerFactory.getLogger(CsvController.class);
-        private final CsvService csvService;
+  private static final Logger log = LoggerFactory.getLogger(CsvController.class);
+  private final CsvService csvService;
 
-        public CsvController(CsvService csvService) {
-                this.csvService = csvService;
-        }
+  public CsvController(CsvService csvService) {
+    this.csvService = csvService;
+  }
 
-        @PostMapping(value = {"/flatfile/csv/Bundle/$validate", "/flatfile/csv/Bundle/$validate/"}, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        @ResponseBody
-        public Object handleCsvUpload(
-                        @Parameter(description = "ZIP file containing CSV data. Must not be null.", required = true) @RequestPart("file") @Nonnull MultipartFile file,
-                        @Parameter(description = "Tenant ID, a mandatory parameter.", required = true) @RequestHeader(value = Configuration.Servlet.HeaderName.Request.TENANT_ID) String tenantId,
-                        HttpServletRequest request,
-                        HttpServletResponse response)
-                        throws Exception {
-                if (tenantId == null || tenantId.trim().isEmpty()) {
-                        log.error("CsvController: handleCsvUpload:: Tenant ID is missing or empty");
-                        throw new IllegalArgumentException("Tenant ID must be provided");
-                }
-                return csvService.validateCsvFile(file,request, response, tenantId);
-        }
+  @PostMapping(value = { "/flatfile/csv/Bundle/$validate",
+      "/flatfile/csv/Bundle/$validate/" }, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @ResponseBody
+  public Object handleCsvUpload(
+      @Parameter(description = "ZIP file containing CSV data. Must not be null.", required = true) @RequestPart("file") @Nonnull MultipartFile file,
+      @Parameter(description = "Tenant ID, a mandatory parameter.", required = true) @RequestHeader(value = Configuration.Servlet.HeaderName.Request.TENANT_ID) String tenantId,
+      HttpServletRequest request,
+      HttpServletResponse response)
+      throws Exception {
 
-        @PostMapping(value = { "/flatfile/csv/Bundle", "/flatfile/csv/Bundle/" }, consumes = {
-                        MediaType.MULTIPART_FORM_DATA_VALUE })
-        @ResponseBody
-        @Async
-        public List<Object> handleCsvUploadAndConversion(
-                        @Parameter(description = "ZIP file containing CSV data. Must not be null.", required = true) @RequestPart("file") @Nonnull MultipartFile file,
-                        @Parameter(description = "Parameter to specify the Tenant ID. This is a <b>mandatory</b> parameter.", required = true) @RequestHeader(value = Configuration.Servlet.HeaderName.Request.TENANT_ID, required = true) String tenantId,
-                        HttpServletRequest request,
-                        HttpServletResponse response) throws Exception {
+    // Validate file presence
+    if (file == null || file.isEmpty() || file.getOriginalFilename() == null
+        || file.getOriginalFilename().trim().isEmpty()) {
+      log.error("CsvController: handleCsvUpload:: Uploaded file is missing or empty");
+      return new ResponseEntity<>(
+          "{\"status\":\"Error\",\"message\":\"Validation Error: Uploaded file is missing or empty.\"}",
+          HttpStatus.BAD_REQUEST);
+    }
+    // Validate file extension
+    String originalFilename = file.getOriginalFilename();
+    if (!originalFilename.toLowerCase().endsWith(".zip")) {
+      log.error("CsvController: handleCsvUpload:: Uploaded file is not a .zip file. Filename: " + originalFilename);
+      return new ResponseEntity<>(
+          "{\"status\":\"Error\",\"message\":\"Validation Error: Uploaded file must have a .zip extension.\"}",
+          HttpStatus.BAD_REQUEST);
+    }
+    if (tenantId == null || tenantId.trim().isEmpty()) {
+      log.error("CsvController: handleCsvUpload:: Tenant ID is missing or empty");
+      throw new IllegalArgumentException("Tenant ID must be provided");
+    }
+    return csvService.validateCsvFile(file, request, response, tenantId);
+  }
 
-                if (tenantId == null || tenantId.trim().isEmpty()) {
-                        throw new IllegalArgumentException("Tenant ID must be provided");
-                }
-                return csvService.processZipFile(file,request,response,tenantId);
-        }
+  @PostMapping(value = { "/flatfile/csv/Bundle", "/flatfile/csv/Bundle/" }, consumes = {
+      MediaType.MULTIPART_FORM_DATA_VALUE })
+  @ResponseBody
+  @Async
+  public List<Object> handleCsvUploadAndConversion(
+      @Parameter(description = "ZIP file containing CSV data. Must not be null.", required = true) @RequestPart("file") @Nonnull MultipartFile file,
+      @Parameter(description = "Parameter to specify the Tenant ID. This is a <b>mandatory</b> parameter.", required = true) @RequestHeader(value = Configuration.Servlet.HeaderName.Request.TENANT_ID, required = true) String tenantId,
+      HttpServletRequest request,
+      HttpServletResponse response) throws Exception {
+
+    if (tenantId == null || tenantId.trim().isEmpty()) {
+      throw new IllegalArgumentException("Tenant ID must be provided");
+    }
+    return csvService.processZipFile(file, request, response, tenantId);
+  }
 }


### PR DESCRIPTION
handle empty request and confirm extensions in CSV validate API

- Ensures empty requests are properly handled.
- Adds logic for confirming extensions during validation.
- Resolves issue #745.