### PR TITLE
docs: update patient resource in the xslt file with proper tags #947

### DIFF
--- a/support/specifications/ccda/cda-phi-filter.xslt
+++ b/support/specifications/ccda/cda-phi-filter.xslt
@@ -54,6 +54,7 @@
                             <streetAddressLine><xsl:value-of select="hl7:addr/hl7:streetAddressLine"/></streetAddressLine>
                             <city><xsl:value-of select="hl7:addr/hl7:city"/></city>
                             <state><xsl:value-of select="hl7:addr/hl7:state"/></state>
+                            <county><xsl:value-of select="hl7:addr/hl7:county"/></county>
                             <postalCode><xsl:value-of select="hl7:addr/hl7:postalCode"/></postalCode>
                         </addr>
                         <telecom>


### PR DESCRIPTION
updated extension tag to include ssn number, mrn number and medicaid number.
Added condition to check the availability of data to display the tags.
Updated the structure of the patient resource.