### PR TITLE
fix: make AG Grid 'Equals' and 'Does not equal' filters case insensitive #1201

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.477.0</version>
+	<version>0.478.0</version>
 	<packaging>war</packaging>
 	<name>Tech by Design Hub (Prime)</name>
 	<description>Tech by Design Hub (Primary)</description>

--- a/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
+++ b/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
@@ -432,7 +432,7 @@ public final class JooqRowsSupplier implements TabularRowsSupplier<JooqRowsSuppl
             case "equals" ->
                 dslField.equalIgnoreCase(filter.toString());
             case "notEqual" ->
-                dslField.notEqual(DSL.param(field, filter));
+                DSL.condition("{0} NOT ILIKE {1}", dslField, DSL.param(field, filter));
             case "number" ->
                 dslField.eq(DSL.param(field, filter));
             case "date" ->


### PR DESCRIPTION
- Ensure that the AG Grid filter options 'Equals' and 'Does not equal' perform case-insensitive comparisons. 