### PR TITLE
fix: Make AG Grid 'Begins With' and 'Ends With' filters case insensitive #1201

### DIFF
--- a/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
+++ b/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
@@ -442,9 +442,9 @@ public final class JooqRowsSupplier implements TabularRowsSupplier<JooqRowsSuppl
             case "notContains" ->
                 dslField.notLikeIgnoreCase("%" + filter + "%");
             case "startsWith" ->
-                dslField.startsWith(filter);
+                dslField.startsWithIgnoreCase(filter);
             case "endsWith" ->
-                dslField.endsWith(filter);
+                dslField.endsWithIgnoreCase(filter);
             case "lessOrEqual" ->
                 dslField.lessOrEqual(filter);
             case "greatersOrEqual" ->


### PR DESCRIPTION
- This PR addresses ticket #1201 by updating the AG Grid filtering logic to ensure that the 'Begins With' and 'Ends With' filters are case insensitive.