### PR TITLE
fix: make 'Equals' and 'Does Not Equal' filters case insensitive across all tabs and fix 'Not Blank' filter functionalit y in AG Grid #1201

### DIFF
--- a/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
+++ b/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
@@ -426,7 +426,7 @@ public final class JooqRowsSupplier implements TabularRowsSupplier<JooqRowsSuppl
             case "blank" ->
                 dslField.isNull();
             case "notBlank" ->
-                dslField.isNotNull();
+                 dslField.isNotNull().and(DSL.condition("TRIM({0}) <> ''", dslField));
             case "like" ->
                 dslField.likeIgnoreCase("%" + filter + "%");
             case "equals" ->
@@ -440,8 +440,8 @@ public final class JooqRowsSupplier implements TabularRowsSupplier<JooqRowsSuppl
             case "contains" ->
                 dslField.likeIgnoreCase("%" + filter + "%");
             case "notContains" ->
-                dslField.notLikeIgnoreCase("%" + filter + "%");
-            case "startsWith" ->
+                dslField.notLikeIgnoreCase("%" + filter + "%");  // Only works if supported
+             case "startsWith" ->
                 dslField.startsWithIgnoreCase(filter);
             case "endsWith" ->
                 dslField.endsWithIgnoreCase(filter);

--- a/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplierForSP.java
+++ b/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplierForSP.java
@@ -151,13 +151,13 @@ public class JooqRowsSupplierForSP {
                     case "notContains" ->
                         DSL.field(column).notContains((String) condition.filter());
                     case "equals" ->
-                        DSL.field(column).eq((String) condition.filter());
+                        DSL.field(column).equalIgnoreCase((String) condition.filter());
                     case "notEqual" ->
-                        DSL.field(column).ne((String) condition.filter());
+                        DSL.lower(DSL.field(column, String.class)).ne(DSL.lower(DSL.val((String) condition.filter())));
                     case "startsWith" ->
-                        DSL.field(column).startsWith((String) condition.filter());
+                        DSL.field(column).startsWithIgnoreCase((String) condition.filter());
                     case "endsWith" ->
-                        DSL.field(column).endsWith((String) condition.filter());
+                        DSL.field(column).endsWithIgnoreCase((String) condition.filter());
                     case "blank" ->
                         DSL.field(column).isNull();
                     case "notBlank" ->
@@ -238,13 +238,13 @@ public class JooqRowsSupplierForSP {
                     case "notContains" ->
                         DSL.field(column).notContains((String) filterModel.filter());
                     case "equals" ->
-                        DSL.field(column).eq((String) filterModel.filter());
+                        DSL.field(column).equalIgnoreCase((String) filterModel.filter());
                     case "notEqual" ->
-                        DSL.field(column).ne((String) filterModel.filter());
+                        DSL.lower(DSL.field(column, String.class)).ne(DSL.lower(DSL.val((String) filterModel.filter())));
                     case "startsWith" ->
-                        DSL.field(column).startsWith((String) filterModel.filter());
+                        DSL.field(column).startsWithIgnoreCase((String) filterModel.filter());
                     case "endsWith" ->
-                        DSL.field(column).endsWith((String) filterModel.filter());
+                        DSL.field(column).endsWithIgnoreCase((String) filterModel.filter());
                     case "blank" ->
                         DSL.field(column).isNull();
                     case "notBlank" ->


### PR DESCRIPTION
- This PR addresses ticket Correct the AG Grid filter issues in TechBD Hub #1201 by updating the AG Grid filtering logic to ensure that the 'Equals' and 'Does Not Equal' filters are case insensitive across all tabs. Additionally, it fixes the functionality of the 'Not Blank' filter