### PR TITLE
refactor: Replace lastUpdated with encounterStartDatetime in EncounterConverter & set static consent policy authority #1181

### DIFF
--- a/hub-prime/src/main/java/org/techbd/model/csv/ScreeningProfileData.java
+++ b/hub-prime/src/main/java/org/techbd/model/csv/ScreeningProfileData.java
@@ -108,9 +108,6 @@ public class ScreeningProfileData {
     @CsvBindByName(column = "SCREENING_ENTITY_ID")
     private String screeningEntityId;
 
-    @CsvBindByName(column = "SCREENING_ENTITY_CODE")
-    private String screeningEntityCode;
-
     @CsvBindByName(column = "SCREENING_ENTITY_ID_CODE_SYSTEM")
     private String screeningEntityIdCodeSystem;
 

--- a/hub-prime/src/main/java/org/techbd/model/csv/ScreeningProfileData.java
+++ b/hub-prime/src/main/java/org/techbd/model/csv/ScreeningProfileData.java
@@ -78,9 +78,6 @@ public class ScreeningProfileData {
     @CsvBindByName(column = "CONSENT_STATUS")
     private String consentStatus;
 
-    @CsvBindByName(column = "CONSENT_POLICY_AUTHORITY")
-    private String consentPolicyAuthority;
-
     @CsvBindByName(column = "CONSENT_DATE_TIME")
     private String consentDateTime;
 

--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/ConsentConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/ConsentConverter.java
@@ -187,7 +187,7 @@ public class ConsentConverter extends BaseConverter {
     
     private void populateConsentPolicy(Consent consent, ScreeningProfileData screeningResourceData) {
         Consent.ConsentPolicyComponent policyComponent = new Consent.ConsentPolicyComponent();
-        policyComponent.setAuthority(screeningResourceData.getConsentPolicyAuthority());
+        policyComponent.setAuthority("urn:uuid:d1eaac1a-22b7-4bb6-9c62-cc95d6fdf1a5");
         consent.getPolicy().add(policyComponent);
     }
     

--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/EncounterConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/EncounterConverter.java
@@ -77,7 +77,7 @@ public class EncounterConverter extends BaseConverter {
 
         Meta meta = encounter.getMeta();
 
-        meta.setLastUpdated(new Date()); // TODO: Replace with value from CSV once the column is added and populated
+        meta.setLastUpdated(DateUtil.parseDate(screeningProfileData.getEncounterStartDatetime()));
 
         populateEncounterStatus(encounter, screeningProfileData);
 

--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/OrganizationConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/OrganizationConverter.java
@@ -96,19 +96,27 @@ public class OrganizationConverter extends BaseConverter {
 
     private static void populateOrganizationIdentifier(Organization organization, ScreeningProfileData data) {
         if (StringUtils.isNotEmpty(data.getFacilityId())) {
-    
+
+            Map<String, String> systemToCodeMap = Map.of(
+                    "http://hl7.org/fhir/sid/us-npi", "NPI",
+                    "http://www.medicaid.gov/", "MA",
+                    "http://www.irs.gov/", "TAX");
+
+            String system = data.getScreeningEntityIdCodeSystem(); // System comes from CSV
+            String code = systemToCodeMap.getOrDefault(system, "UNKNOWN");
+
             Identifier identifier = new Identifier();
             Coding coding = new Coding();
-            coding.setSystem(data.getScreeningEntityIdCodeSystem());
-            coding.setCode(data.getScreeningEntityCode());
+            coding.setSystem(system);
+            coding.setCode(code);
             CodeableConcept type = new CodeableConcept();
             type.addCoding(coding);
             identifier.setType(type);
-            identifier.setSystem(data.getScreeningEntityIdCodeSystem());
+            identifier.setSystem(system);
             identifier.setValue(data.getScreeningEntityId());
             organization.addIdentifier(identifier);
         }
-    }
+    }    
 
     private static void populateOrganizationType(Organization organization, QeAdminData data) {
         if (StringUtils.isNotEmpty(data.getOrganizationTypeCode()) || StringUtils.isNotEmpty(data.getOrganizationTypeDisplay())) {

--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -367,8 +368,21 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                 if (encounterId != null){
                         groupObservation.setEncounter( new Reference("Encounter/" + encounterId));
                 }
-                groupObservation.setEffective(new DateTimeType(new Date()));
-                groupObservation.setIssued(new Date());
+                
+                String screeningStartDateTime = groupData.stream()
+                        .map(ScreeningObservationData::getScreeningStartDateTime)
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null);
+
+                if (screeningStartDateTime != null) {
+                    Date parsedDate = DateUtil.parseDate(screeningStartDateTime);
+                    if (parsedDate != null) {
+                        groupObservation.setEffective(new DateTimeType(parsedDate));
+                        groupObservation.setIssued(parsedDate);
+                    }
+                }       
+                
                 CodeableConcept interpretation = new CodeableConcept();
                 interpretation.addCoding(
                                 new Coding("http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",

--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
@@ -384,9 +384,21 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                 }       
                 
                 CodeableConcept interpretation = new CodeableConcept();
-                interpretation.addCoding(
-                                new Coding("http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                                "POS", "Positive"));
+
+                boolean hasPositiveInterpretation = groupData.stream()
+                        .map(ScreeningObservationData::getPotentialNeedIndicated)
+                        .filter(Objects::nonNull)
+                        .anyMatch(indicated -> indicated.equalsIgnoreCase("POS"));
+
+                if (hasPositiveInterpretation) {
+                    interpretation.addCoding(new Coding(
+                            "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                            "POS", "Positive"));
+                } else {
+                    interpretation.addCoding(new Coding(
+                            "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                            "NEG", "Negative"));
+                }
                 groupObservation.addInterpretation(interpretation);
 
                 // Add member references using observationId directly from the model


### PR DESCRIPTION
- **EncounterConverter.java**: Updated `lastUpdated` to use `screeningProfileData.getEncounterStartDatetime()` instead of the current timestamp.
- **ConsentConverter.java**: Removed `CONSENT_POLICY_AUTHORITY` field from `ScreeningProfileData.java` and replaced it with a static UUID (`urn:uuid:d1eaac1a-22b7-4bb6-9c62-cc95d6fdf1a5`) in `populateConsentPolicy()`.
- Ensured consistency in encounter datetime handling and consent policy authority assignment.
