### PR TITLE
fix:  Updated Screening Identifier #1181

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
@@ -91,9 +91,10 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
 
                 for (ScreeningObservationData data : screeningObservationDataList) {
                         Observation observation = new Observation();
-                        String observationId = CsvConversionUtil
-                                        .sha256(data.getQuestionCodeDescription().replace(" ", "") +
-                                                        data.getQuestionCode() + data.getEncounterId());
+                        String observationId = data.getScreeningIdentifier();
+                        // CsvConversionUtil
+                        //                 .sha256(data.getQuestionCodeDescription().replace(" ", "") +
+                        //                                 data.getQuestionCode() + data.getEncounterId());
                         observation.setId(observationId);
                         data.setObservationId(observationId);
                         String fullUrl = "http://shinny.org/us/ny/hrsn/Observation/" + observationId;

--- a/hub-prime/src/test/resources/org/techbd/csv/generated-json/screening-response.json
+++ b/hub-prime/src/test/resources/org/techbd/csv/generated-json/screening-response.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Observation",
-  "id": "72ab86764cbf6581ee377a546e0243f0df69516839ed68d2c0e0a31f35c645fd",
+  "id": "AHCScreeningGroup96777-8",
   "meta": {
     "lastUpdated": "2024-02-23T05:30:00.000+05:30",
     "profile": [ "http://test.shinny.org/us/ny/hrsn/StructureDefinition/shinny-observation-screening-response" ]


### PR DESCRIPTION
- Changed `observationId` to use `data.getScreeningIdentifier()` instead of SHA-256 hashing