### PR TITLE
refactor: use dynamic extension URL and add display for preferred language #1181

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/PatientConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/PatientConverter.java
@@ -177,7 +177,7 @@ public class PatientConverter extends BaseConverter {
         
 
         if (StringUtils.isNotEmpty(demographicData.getSexAtBirthCode())) {
-            Extension birthSexExtension = new Extension("http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex");
+            Extension birthSexExtension = new Extension(demographicData.getSexAtBirthCodeSystem());
             birthSexExtension.setValue(new CodeType(demographicData.getSexAtBirthCode())); // Use CodeType for valueCode
             patient.addExtension(birthSexExtension);
         }
@@ -362,6 +362,7 @@ public class PatientConverter extends BaseConverter {
                     Coding coding = new Coding();
                     coding.setSystem(data.getPreferredLanguageCodeSystem());
                     coding.setCode(languageCode);
+                    coding.setDisplay(data.getPreferredLanguageCodeDescription());
                     CodeableConcept language = new CodeableConcept();
                     language.addCoding(coding);
                     PatientCommunicationComponent communication = new PatientCommunicationComponent();

--- a/hub-prime/src/test/resources/org/techbd/csv/generated-json/patient.json
+++ b/hub-prime/src/test/resources/org/techbd/csv/generated-json/patient.json
@@ -33,7 +33,7 @@
       "valueString": "Hispanic or Latino"
     } ]
   }, {
-    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+    "url": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
     "valueCode": "M"
   }, {
     "url": "http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-personal-pronouns",
@@ -114,7 +114,8 @@
     "language": {
       "coding": [ {
         "system": "urn:ietf:bcp:47",
-        "code": "en"
+        "code": "en",
+        "display": "English"
       } ]
     },
     "preferred": true


### PR DESCRIPTION
- Replaced hardcoded birth sex extension URL with value from demographicData
- Added display field for preferred language code in PatientConverter
- Updated patient.json test output to reflect changes