### PR TITLE
fix: Revert to static birth sex extension URL in PatientConverter #1181

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/PatientConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/PatientConverter.java
@@ -177,7 +177,7 @@ public class PatientConverter extends BaseConverter {
         
 
         if (StringUtils.isNotEmpty(demographicData.getSexAtBirthCode())) {
-            Extension birthSexExtension = new Extension(demographicData.getSexAtBirthCodeSystem());
+            Extension birthSexExtension = new Extension("http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex");
             birthSexExtension.setValue(new CodeType(demographicData.getSexAtBirthCode())); // Use CodeType for valueCode
             patient.addExtension(birthSexExtension);
         }

--- a/hub-prime/src/test/resources/org/techbd/csv/generated-json/patient.json
+++ b/hub-prime/src/test/resources/org/techbd/csv/generated-json/patient.json
@@ -33,7 +33,7 @@
       "valueString": "Hispanic or Latino"
     } ]
   }, {
-    "url": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
     "valueCode": "M"
   }, {
     "url": "http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-personal-pronouns",


### PR DESCRIPTION
- Changed birth sex extension URL back to "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
- Reverted dynamic assignment from demographicData.getSexAtBirthCodeSystem()
- Updated patient.json test output to reflect the change