### PR TITLE
fix: handle 'notBlank' and 'blank' filters correctly for 'request_time' field in AG Grid filters #1201

### DIFF
--- a/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
+++ b/hub-prime/src/main/java/lib/aide/tabular/JooqRowsSupplier.java
@@ -426,7 +426,8 @@ public final class JooqRowsSupplier implements TabularRowsSupplier<JooqRowsSuppl
             case "blank" ->
                 dslField.isNull();
             case "notBlank" ->
-                 dslField.isNotNull().and(DSL.condition("TRIM({0}) <> ''", dslField));
+                dslField.isNotNull()
+                        .and(DSL.condition("TRIM(CAST({0} AS VARCHAR)) <> ''", dslField));
             case "like" ->
                 dslField.likeIgnoreCase("%" + filter + "%");
             case "equals" ->


### PR DESCRIPTION
- The 'blank' and 'notBlank' filters work globally for all fields, including both date and string fields. 

- This ensures consistent behavior across the application and improves filter reliability.