### PR TITLE
feat: support configurable HAPI validation severity filtering via header or YAML #1309

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.484.0</version>
+	<version>0.484.1</version>
 	<packaging>war</packaging>
 	<name>Tech by Design Hub (Prime)</name>
 	<description>Tech by Design Hub (Primary)</description>

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/AppConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/AppConfig.java
@@ -50,6 +50,15 @@ public class AppConfig {
     private String igVersion;
     private CsvValidation csv;
     private Map<String, FhirV4Config> igPackages;
+    private String validationSeverityLevel;
+
+    public String getValidationSeverityLevel() {
+        return validationSeverityLevel;
+    }
+
+    public void setValidationSeverityLevel(String validationSeverityLevel) {
+        this.validationSeverityLevel = validationSeverityLevel;
+    }
 
     @Getter
     @Setter

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FHIRService.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FHIRService.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -1296,7 +1297,7 @@ public class FHIRService {
 
 		try {
 			Map<String, Object> extractedOutcome = Optional
-					.ofNullable(extractIssueAndDisposition(interactionId, payloadWithDisposition))
+					.ofNullable(extractIssueAndDisposition(interactionId, payloadWithDisposition, request))
 					.filter(outcome -> !outcome.isEmpty())
 					.orElseGet(() -> {
 						LOG.warn(
@@ -1343,58 +1344,93 @@ public class FHIRService {
 	}
 
 	@SuppressWarnings("unchecked")
-	public Map<String, Object> extractIssueAndDisposition(String interactionId,
-			Map<String, Object> operationOutcomePayload) {
-		LOG.debug("FHIRService:: extractResourceTypeAndDisposition BEGIN for interaction id : {}",
-				interactionId);
+    public Map<String, Object> extractIssueAndDisposition(String interactionId,
+            Map<String, Object> operationOutcomePayload, HttpServletRequest request) {
+        LOG.debug("FHIRService:: extractResourceTypeAndDisposition BEGIN for interaction id : {}",
+                interactionId);
 
-		if (operationOutcomePayload == null) {
-			LOG.warn("FHIRService:: operationOutcomePayload is null for interaction id : {}",
-					interactionId);
-			return null;
-		}
+        if (operationOutcomePayload == null) {
+            LOG.warn("FHIRService:: operationOutcomePayload is null for interaction id : {}",
+                    interactionId);
+            return null;
+        }
 
-		return Optional.ofNullable(operationOutcomePayload.get("OperationOutcome"))
-				.filter(Map.class::isInstance)
-				.map(Map.class::cast)
-				.flatMap(operationOutcomeMap -> {
-					List<?> validationResults = (List<?>) operationOutcomeMap
+        return Optional.ofNullable(operationOutcomePayload.get("OperationOutcome"))
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .flatMap(operationOutcomeMap -> {
+                    List<?> validationResults = (List<?>) operationOutcomeMap
 							.get("validationResults");
-					if (validationResults == null || validationResults.isEmpty()) {
-						return Optional.empty();
-					}
+                    if (validationResults == null || validationResults.isEmpty()) {
+                        return Optional.empty();
+                    }
 
-					// Extract the first validationResult
-					Map<String, Object> validationResult = (Map<String, Object>) validationResults
+                    // Extract the first validationResult
+                    Map<String, Object> validationResult = (Map<String, Object>) validationResults
 							.get(0);
 
-					// Navigate to operationOutcome.issue
-					Map<String, Object> operationOutcome = (Map<String, Object>) validationResult
-							.get("operationOutcome");
-					List<?> issues = operationOutcome != null
-							? (List<?>) operationOutcome.get("issue")
-							: null;
+                    // Navigate to operationOutcome.issue
+                    Map<String, Object> operationOutcome = (Map<String, Object>) validationResult
+                            .get("operationOutcome");
+                    List<Map<String, Object>> issuesRaw = operationOutcome != null
+                            ? (List<Map<String, Object>>) operationOutcome.get("issue")
+                            : null;
 
-					// Prepare the result
-					Map<String, Object> result = new HashMap<>();
-					result.put("resourceType", operationOutcomeMap.get("resourceType"));
-					result.put("issue", issues);
+                    String headerSeverityLevelValue = request.getHeader("X-TechBD-Validation-Severity-Level");
+                    String validationSeverityLevel = appConfig.getValidationSeverityLevel();
+                    if (headerSeverityLevelValue != null && !headerSeverityLevelValue.isEmpty()) {
+                        validationSeverityLevel = headerSeverityLevelValue;
+                    }
+                    List<Map<String, Object>> filteredIssues = new ArrayList<>();
+                    if (issuesRaw != null) {
+                        String severityLevel = Optional.ofNullable(validationSeverityLevel)
+                                .orElse("error").toLowerCase();
+                        Set<String> allowedSeverities = switch (severityLevel) {
+                            case "fatal" -> Set.of("fatal");
+                            case "error" -> Set.of("fatal", "error");
+                            case "warning" -> Set.of("fatal", "error", "warning");
+                            case "information" -> Set.of("fatal", "error", "warning", "information");
+                            default -> Set.of("fatal", "error");
+                        };
 
-					// Add techByDesignDisposition if available
-					List<?> techByDesignDisposition = (List<?>) operationOutcomeMap
-							.get("techByDesignDisposition");
-					if (techByDesignDisposition != null && !techByDesignDisposition.isEmpty()) {
-						result.put("techByDesignDisposition", techByDesignDisposition);
-					}
+                        for (Map<String, Object> issue : issuesRaw) {
+                            String severity = (String) issue.get("severity");
+                            if (severity != null && allowedSeverities.contains(severity.toLowerCase())) {
+                                filteredIssues.add(issue);
+                            }
+                        }
+                    }
 
-					return Optional.of(result);
-				})
-				.orElseGet(() -> {
-					LOG.warn("FHIRService:: Missing required fields in operationOutcome for interaction id : {}",
-							interactionId);
-					return null;
-				});
-	}
+                    // If no issues match, add an informational entry
+                    if (filteredIssues.isEmpty()) {
+                        Map<String, Object> infoIssue = new HashMap<>();
+                        infoIssue.put("severity", "information");
+                        infoIssue.put("diagnostics",
+                                "Validation successful. No issues found at or above severity level: "
+                                        + validationSeverityLevel);
+                        infoIssue.put("code", "informational");
+                        filteredIssues.add(infoIssue);
+                    }
+
+                    // Prepare the result
+                    Map<String, Object> result = new HashMap<>();
+                    result.put("resourceType", operationOutcomeMap.get("resourceType"));
+                    result.put("issue", filteredIssues);
+
+                    // Add techByDesignDisposition if available
+                    List<?> techByDesignDisposition = (List<?>) operationOutcomeMap.get("techByDesignDisposition");
+                    if (techByDesignDisposition != null && !techByDesignDisposition.isEmpty()) {
+                        result.put("techByDesignDisposition", techByDesignDisposition);
+                    }
+
+                    return Optional.of(result);
+                })
+                .orElseGet(() -> {
+                    LOG.warn("FHIRService:: Missing required fields in operationOutcome for interaction id : {}",
+                            interactionId);
+                    return null;
+                });
+    }
 
 	private Map<String, Object> appendToBundlePayload(String interactionId, Map<String, Object> payload,
 			Map<String, Object> extractedOutcome) {

--- a/hub-prime/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/hub-prime/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -573,5 +573,10 @@
     "name": "org.techbd.service.http.hub.prime.structureDefinitionsUrls.observationSexualOrientation",
     "type": "java.lang.String",
     "description": "A description for 'org.techbd.service.http.hub.prime.structureDefinitionsUrls.observationSexualOrientation'"
+  },
+  {
+    "name": "org.techbd.service.http.hub.prime.validation-severity-level",
+    "type": "java.lang.String",
+    "description": "A description for 'org.techbd.service.http.hub.prime.validation-severity-level'"
   }
 ]}

--- a/hub-prime/src/main/resources/application.yml
+++ b/hub-prime/src/main/resources/application.yml
@@ -86,6 +86,7 @@ org:
             version: @project.version@
             fhirVersion: r4
             igVersion: 1.3.0
+            validation-severity-level: error  # Possible values: fatal, error, warning, information
             ig-packages:
               fhir-v4:
                 shinny-packages:


### PR DESCRIPTION
- Added support for filtering OperationOutcome issues based on severity level (error, warning, info)
- Implemented filtering logic in FHIRService
- Introduced optional header `X-TechBD-Validation-Severity-Level` to override default
- Default severity level configurable via `application.yml`