### PR TITLE
fix: add performer to Observation and remove versionId from Bundle meta #1322

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.524.0</version>
+	<version>0.525.0</version>
 	<packaging>war</packaging>
 	<name>Tech by Design Hub (Prime)</name>
 	<description>Tech by Design Hub (Primary)</description>

--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/BundleConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/BundleConverter.java
@@ -39,7 +39,6 @@ public class BundleConverter {
         bundle.setType(Bundle.BundleType.TRANSACTION);
         Meta meta = new Meta();
         meta.setLastUpdated(new Date());
-        meta.setVersionId(igVersion);
         if (StringUtils.isNotEmpty(baseFHIRUrl)) {
             meta.setProfile(List.of(new CanonicalType(FHIRUtil.getProfileUrl(baseFHIRUrl,ResourceType.Bundle.name().toLowerCase()))));
         } else {

--- a/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
+++ b/hub-prime/src/main/java/org/techbd/service/converters/shinny/ScreeningResponseObservationConverter.java
@@ -162,11 +162,10 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                         if (encounterId != null) {
                             observation.setEncounter(new Reference("Encounter/" + encounterId));
                         }
-                        //  This is Temporarily commented out as IG 1.4.1 need not go to production as of today(09/04/2025)
-                        // String organizationId = idsGenerated.getOrDefault(CsvConstants.ORGANIZATION_ID, null);
-                        // if (organizationId != null) {
-                        //     observation.addPerformer(new Reference("Organization/" + organizationId));
-                        // }
+                        String organizationId = idsGenerated.getOrDefault(CsvConstants.ORGANIZATION_ID, null);
+                        if (organizationId != null) {
+                            observation.addPerformer(new Reference("Organization/" + organizationId));
+                        }
                         CodeableConcept interpretation = new CodeableConcept();
                         interpretation.addCoding(
                                 new Coding("http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",


### PR DESCRIPTION
- Added performer reference to Observation using ORGANIZATION_ID in ScreeningResponseObservationConverter.java  
- Removed meta.setVersionId(igVersion) from BundleConverter.java to avoid setting versionId in generated Bundle
