### PR TITLE
fix: update  HAPI version to 8.0.0 in HapiValidationEngine #1348

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.527.0</version>
+	<version>0.528.0</version>
 	<packaging>war</packaging>
 	<name>Tech by Design Hub (Prime)</name>
 	<description>Tech by Design Hub (Primary)</description>

--- a/hub-prime/src/main/java/org/techbd/orchestrate/fhir/OrchestrationEngine.java
+++ b/hub-prime/src/main/java/org/techbd/orchestrate/fhir/OrchestrationEngine.java
@@ -291,7 +291,7 @@ public class OrchestrationEngine {
             this.engineConstructedAt = Instant.now();
             this.observability = new Observability(HapiValidationEngine.class.getName(),
                     "HAPI version %s (FHIR version %s)"
-                            .formatted("7.6.1", fhirContext.getVersion().getVersion().getFhirVersionString()),
+                            .formatted("8.0.0", fhirContext.getVersion().getVersion().getFhirVersionString()),
                     engineInitAt, engineConstructedAt);
             this.igPackages = builder.igPackages;
             this.igVersion = builder.igVersion;


### PR DESCRIPTION
 This update aligns the  version reference with the upgraded dependency in pom.xml.