### PR TITLE
revert: rollback IG version to 1.4.2 in PROD #1425

### DIFF
--- a/hub-prime/src/main/resources/application.yml
+++ b/hub-prime/src/main/resources/application.yml
@@ -85,7 +85,7 @@ org:
           prime:
             version: @project.version@
             fhirVersion: r4
-            igVersion: 1.4.5
+            igVersion: 1.4.2
             validation-severity-level: error  # Possible values: fatal, error, warning, information
             ig-packages:
               fhir-v4:
@@ -94,10 +94,10 @@ org:
                 # Example: shinny-v1-2-3 for version 1.2.3
                 # Any new version for test-shinny should follow the naming convention: test-shinny-v<version> in kebab-case
                 # Example: test-shinny-v1-3-0 for version 1.3.0
-                  test-shinny-v1-4-5:
+                  test-shinny-v1-4-2:
                     profile-base-url: http://test.shinny.org/us/ny/hrsn
-                    package-path: ig-packages/shin-ny-ig/test-shinny/v1.4.5
-                    ig-version: 1.4.5
+                    package-path: ig-packages/shin-ny-ig/test-shinny/v1.4.2
+                    ig-version: 1.4.2
                   shinny-v1-4-5:
                     profile-base-url: http://shinny.org/us/ny/hrsn
                     package-path: ig-packages/shin-ny-ig/shinny/v1.4.5

--- a/hub-prime/src/test/java/org/techbd/orchestrate/fhir/IgPublicationIssuesTest.java
+++ b/hub-prime/src/test/java/org/techbd/orchestrate/fhir/IgPublicationIssuesTest.java
@@ -874,12 +874,12 @@ public class IgPublicationIssuesTest {
         // Shinny Packages
         Map<String, Map<String, String>> shinnyPackages = new HashMap<>();
 
-        // Shinny version 1.4.5
+        // Shinny version 1.4.2
         Map<String, String> shinnyV123 = new HashMap<>();
         shinnyV123.put("profile-base-url", "http://shinny.org/us/ny/hrsn");
-        shinnyV123.put("package-path", "ig-packages/shin-ny-ig/shinny/v1.4.5");
-        shinnyV123.put("ig-version", "1.4.5");
-        shinnyPackages.put("shinny-v1-4-5", shinnyV123);
+        shinnyV123.put("package-path", "ig-packages/shin-ny-ig/shinny/v1.4.2");
+        shinnyV123.put("ig-version", "1.4.2");
+        shinnyPackages.put("shinny-v1-4-2", shinnyV123);
 
         // Test Shinny version 1.4.5
         Map<String, String> testShinnyV130 = new HashMap<>();
@@ -896,7 +896,7 @@ public class IgPublicationIssuesTest {
     }
 
     private String getIgVersion() {
-        final String igVersion = "1.4.5";
+        final String igVersion = "1.4.2";
         return igVersion;
     }
 


### PR DESCRIPTION
- Reverted IG version from 1.4.5 back to 1.4.2 in `application.yml`.
- Updated the JUnit test file to reflect the correct IG version (1.4.2).