### PR TITLE
fix: restore IG version to 1.4.5 across all environments #1425

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.549.0</version>
+	<version>0.550.0</version>
 	<packaging>war</packaging>
 	<name>Tech by Design Hub (Prime)</name>
 	<description>Tech by Design Hub (Primary)</description>

--- a/hub-prime/src/main/resources/application-phiqa.yml
+++ b/hub-prime/src/main/resources/application-phiqa.yml
@@ -41,7 +41,7 @@ org:
           prime:
             defaultDatalakeApiUrl: https://qa.hrsn.nyehealth.org/HRSNBundle
             igVersion: 1.3.0
-            baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+            baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
             structureDefinitionsUrls:
               bundle: /StructureDefinition/SHINNYBundleProfile
               patient: /StructureDefinition/shinny-patient

--- a/hub-prime/src/main/resources/application-phiqa.yml
+++ b/hub-prime/src/main/resources/application-phiqa.yml
@@ -40,7 +40,7 @@ org:
         hub:
           prime:
             defaultDatalakeApiUrl: https://qa.hrsn.nyehealth.org/HRSNBundle
-            igVersion: 1.3.0
+            igVersion: 1.4.5
             baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
             structureDefinitionsUrls:
               bundle: /StructureDefinition/SHINNYBundleProfile

--- a/hub-prime/src/main/resources/application.yml
+++ b/hub-prime/src/main/resources/application.yml
@@ -85,7 +85,7 @@ org:
           prime:
             version: @project.version@
             fhirVersion: r4
-            igVersion: 1.4.2
+            igVersion: 1.4.5
             validation-severity-level: error  # Possible values: fatal, error, warning, information
             ig-packages:
               fhir-v4:
@@ -94,10 +94,10 @@ org:
                 # Example: shinny-v1-2-3 for version 1.2.3
                 # Any new version for test-shinny should follow the naming convention: test-shinny-v<version> in kebab-case
                 # Example: test-shinny-v1-3-0 for version 1.3.0
-                  test-shinny-v1-4-2:
+                  test-shinny-v1-4-5:
                     profile-base-url: http://test.shinny.org/us/ny/hrsn
-                    package-path: ig-packages/shin-ny-ig/test-shinny/v1.4.2
-                    ig-version: 1.4.2
+                    package-path: ig-packages/shin-ny-ig/test-shinny/v1.4.5
+                    ig-version: 1.4.5
                   shinny-v1-4-5:
                     profile-base-url: http://shinny.org/us/ny/hrsn
                     package-path: ig-packages/shin-ny-ig/shinny/v1.4.5
@@ -107,7 +107,7 @@ org:
                   us-core: ig-packages/fhir-v4/us-core/stu-7.0.0
                   sdoh: ig-packages/fhir-v4/sdoh-clinicalcare/stu-2.2.0
                   uv-sdc: ig-packages/fhir-v4/uv-sdc/stu-3.0.0
-            baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+            baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
             structureDefinitionsUrls:
               bundle: /StructureDefinition/SHINNYBundleProfile
               patient: /StructureDefinition/shinny-patient

--- a/hub-prime/src/test/java/org/techbd/orchestrate/fhir/IgPublicationIssuesTest.java
+++ b/hub-prime/src/test/java/org/techbd/orchestrate/fhir/IgPublicationIssuesTest.java
@@ -877,9 +877,9 @@ public class IgPublicationIssuesTest {
         // Shinny version 1.4.2
         Map<String, String> shinnyV123 = new HashMap<>();
         shinnyV123.put("profile-base-url", "http://shinny.org/us/ny/hrsn");
-        shinnyV123.put("package-path", "ig-packages/shin-ny-ig/shinny/v1.4.2");
-        shinnyV123.put("ig-version", "1.4.2");
-        shinnyPackages.put("shinny-v1-4-2", shinnyV123);
+        shinnyV123.put("package-path", "ig-packages/shin-ny-ig/shinny/v1.4.5");
+        shinnyV123.put("ig-version", "1.4.5");
+        shinnyPackages.put("shinny-v1-4-5", shinnyV123);
 
         // Test Shinny version 1.4.5
         Map<String, String> testShinnyV130 = new HashMap<>();
@@ -896,7 +896,7 @@ public class IgPublicationIssuesTest {
     }
 
     private String getIgVersion() {
-        final String igVersion = "1.4.2";
+        final String igVersion = "1.4.5";
         return igVersion;
     }
 


### PR DESCRIPTION
- Re-applied IG version 1.4.5 to the test file after unintended rollback.
- Ensured both PROD and test environments consistently use version 1.4.5.
- Updated `baseFHIRURL` to http://shinny.org/us/ny/hrsn in application.yml and application-phiqa.yml.
- Cleaned up incorrect reversion from previous commit.