### PR TITLE
refactor: streamline CustomParserErrorHandler with necessary parse error overrides only #1357

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>org.techbd</groupId>
 	<artifactId>hub-prime</artifactId>
-	<version>0.552.0</version>
+	<version>0.553.0</version>
 	<packaging>war</packaging>
 	<name>Tech by Design Hub (Prime)</name>
 	<description>Tech by Design Hub (Primary)</description>

--- a/hub-prime/src/main/java/org/techbd/orchestrate/fhir/CustomParserErrorHandler.java
+++ b/hub-prime/src/main/java/org/techbd/orchestrate/fhir/CustomParserErrorHandler.java
@@ -31,51 +31,9 @@ public class CustomParserErrorHandler extends LenientErrorHandler {
     }
 
     @Override
-    public void unknownAttribute(IParseLocation theLocation, String theAttributeName) {
-        addIssue(OperationOutcome.IssueSeverity.INFORMATION, OperationOutcome.IssueType.INVALID,
-                "Unknown attribute: " + theAttributeName);
-    }
-
-    @Override
     public void unknownElement(IParseLocation theLocation, String theElementName) {
         addIssue(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.INVALID,
                 "Unknown element '" + theElementName + "' found while parsing");
-    }
-
-    @Override
-    public void unexpectedRepeatingElement(IParseLocation theLocation, String theElementName) {
-        addIssue(OperationOutcome.IssueSeverity.WARNING, OperationOutcome.IssueType.STRUCTURE,
-                "Unexpected repeating element: " + theElementName);
-    }
-
-    @Override
-    public void unknownReference(IParseLocation theLocation, String theReference) {
-        addIssue(OperationOutcome.IssueSeverity.INFORMATION, OperationOutcome.IssueType.NOTFOUND,
-                "Unknown reference: " + theReference);
-    }
-
-    @Override
-    public void extensionContainsValueAndNestedExtensions(IParseLocation theLocation) {
-        addIssue(OperationOutcome.IssueSeverity.WARNING, OperationOutcome.IssueType.STRUCTURE,
-                "Extension has both value and nested extensions");
-    }
-
-    @Override
-    public void invalidValue(IParseLocation theLocation, String theValue, String theError) {
-        addIssue(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.INVALID,
-                "Invalid value: " + theValue + " - Error: " + theError);
-    }
-
-    @Override
-    public void containedResourceWithNoId(IParseLocation theLocation) {
-        addIssue(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.REQUIRED,
-                "Contained resource missing ID");
-    }
-
-    @Override
-    public void missingRequiredElement(IParseLocation theLocation, String theElementName) {
-        addIssue(OperationOutcome.IssueSeverity.ERROR, OperationOutcome.IssueType.REQUIRED,
-                "Missing required element: " + theElementName);
     }
 
     @Override


### PR DESCRIPTION
- Removed unused or redundant overridden methods from the custom error handler
- Retained essential parse error handling for better diagnostics and FHIR compliance