### PR TITLE
test: update CSV conversion test files to use mocks and standardize setup #1467

### DIFF
--- a/hub-prime/src/test/java/org/techbd/service/csv/EncounterConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/EncounterConverterTest.java
@@ -12,10 +12,12 @@ import org.assertj.core.api.SoftAssertions;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Encounter;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +25,9 @@ import org.techbd.model.csv.DemographicData;
 import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
+import org.techbd.service.converters.shinny.CodeLookupService;
 import org.techbd.service.converters.shinny.EncounterConverter;
+import org.techbd.udi.UdiPrimeJpaConfig;
 import org.techbd.util.FHIRUtil;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -33,11 +37,22 @@ import ca.uhn.fhir.parser.IParser;
 class EncounterConverterTest {
     private static final Logger LOG = LoggerFactory.getLogger(EncounterConverterTest.class.getName());
 
+    @Mock
+    UdiPrimeJpaConfig udiPrimeJpaConfig;
+
+    @Mock
+    CodeLookupService codeLookupService;
+
+    @Mock
+    DSLContext dslContext;
+
     @InjectMocks
     private EncounterConverter encounterConverter;
     
     @BeforeEach
     void setUp() throws Exception {
+            encounterConverter = new EncounterConverter(udiPrimeJpaConfig, codeLookupService);
+
             Field profileMapField = FHIRUtil.class.getDeclaredField("PROFILE_MAP");
             profileMapField.setAccessible(true);
             profileMapField.set(null, CsvTestHelper.getProfileMap());
@@ -57,9 +72,7 @@ class EncounterConverterTest {
         final ScreeningProfileData screeningResourceData = CsvTestHelper.createScreeningProfileData();
         final Map<String, String> idsGenerated = new HashMap<>();
 
-        // Instantiate the EncounterConverter
-        EncounterConverter encounterConverter = new EncounterConverter(null, null);
-
+      
         // Call the convert method of the encounter converter
         final BundleEntryComponent result = encounterConverter
                 .convert(bundle, demographicData, qrAdminData, screeningResourceData,

--- a/hub-prime/src/test/java/org/techbd/service/csv/OrganizationConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/OrganizationConverterTest.java
@@ -15,10 +15,12 @@ import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Organization;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +28,9 @@ import org.techbd.model.csv.DemographicData;
 import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
+import org.techbd.service.converters.shinny.CodeLookupService;
 import org.techbd.service.converters.shinny.OrganizationConverter;
+import org.techbd.udi.UdiPrimeJpaConfig;
 import org.techbd.util.FHIRUtil;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -35,6 +39,16 @@ import ca.uhn.fhir.parser.IParser;
 @ExtendWith(MockitoExtension.class)
 class OrganizationConverterTest {
     private static final Logger LOG = LoggerFactory.getLogger(PatientConverterTest.class.getName());
+   
+    @Mock
+    UdiPrimeJpaConfig udiPrimeJpaConfig;
+
+    @Mock
+    CodeLookupService codeLookupService;
+
+    @Mock
+    DSLContext dslContext;
+
     @InjectMocks
     private OrganizationConverter organizationConverter;
 

--- a/hub-prime/src/test/java/org/techbd/service/csv/PatientConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/PatientConverterTest.java
@@ -16,10 +16,12 @@ import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +29,9 @@ import org.techbd.model.csv.DemographicData;
 import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
+import org.techbd.service.converters.shinny.CodeLookupService;
 import org.techbd.service.converters.shinny.PatientConverter;
+import org.techbd.udi.UdiPrimeJpaConfig;
 import org.techbd.util.FHIRUtil;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -36,6 +40,16 @@ import ca.uhn.fhir.parser.IParser;
 @ExtendWith(MockitoExtension.class)
 class PatientConverterTest {
         private static final Logger LOG = LoggerFactory.getLogger(PatientConverterTest.class.getName());
+        
+        @Mock
+        UdiPrimeJpaConfig udiPrimeJpaConfig;
+
+        @Mock
+        CodeLookupService codeLookupService;
+
+        @Mock
+        DSLContext dslContext;
+
         @InjectMocks
         private PatientConverter patientConverter;
 

--- a/hub-prime/src/test/java/org/techbd/service/csv/ProcedureConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/ProcedureConverterTest.java
@@ -1,22 +1,23 @@
 package org.techbd.service.csv;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.lang.reflect.Modifier;
-import java.nio.file.Files;
 
-import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import org.hl7.fhir.r4.model.Procedure;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.Procedure;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -26,13 +27,25 @@ import org.techbd.model.csv.DemographicData;
 import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
+import org.techbd.service.converters.shinny.CodeLookupService;
 import org.techbd.service.converters.shinny.ProcedureConverter;
+import org.techbd.udi.UdiPrimeJpaConfig;
 import org.techbd.util.CsvConstants;
 import org.techbd.util.FHIRUtil;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 
 class ProcedureConverterTest {
+
+    @Mock
+    UdiPrimeJpaConfig udiPrimeJpaConfig;
+
+    @Mock
+    CodeLookupService codeLookupService;
+
+    @Mock
+    DSLContext dslContext;
 
     @InjectMocks
     private ProcedureConverter procedureConverter;

--- a/hub-prime/src/test/java/org/techbd/service/csv/ScreeningResponseObservationConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/ScreeningResponseObservationConverterTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Observation;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -23,8 +24,9 @@ import org.techbd.model.csv.DemographicData;
 import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
-import org.techbd.service.converters.shinny.BaseConverter;
+import org.techbd.service.converters.shinny.CodeLookupService;
 import org.techbd.service.converters.shinny.ScreeningResponseObservationConverter;
+import org.techbd.udi.UdiPrimeJpaConfig;
 import org.techbd.util.FHIRUtil;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -32,11 +34,17 @@ import ca.uhn.fhir.parser.IParser;
 
 class ScreeningResponseObservationConverterTest {
 
-    @InjectMocks
-    private ScreeningResponseObservationConverter converter;
+    @Mock
+    UdiPrimeJpaConfig udiPrimeJpaConfig;
 
     @Mock
-    private BaseConverter baseConverter;
+    CodeLookupService codeLookupService;
+
+    @Mock
+    DSLContext dslContext;
+
+    @InjectMocks
+    private ScreeningResponseObservationConverter converter;
 
     @BeforeEach
     void setUp() throws Exception {

--- a/hub-prime/src/test/java/org/techbd/service/csv/SexualOrientationObservationConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/SexualOrientationObservationConverterTest.java
@@ -12,17 +12,21 @@ import org.assertj.core.api.SoftAssertions;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Observation;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
+import org.techbd.service.converters.shinny.CodeLookupService;
 import org.techbd.service.converters.shinny.SexualOrientationObservationConverter;
+import org.techbd.udi.UdiPrimeJpaConfig;
 import org.techbd.util.FHIRUtil;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -30,6 +34,16 @@ import ca.uhn.fhir.parser.IParser;
 
 @ExtendWith(MockitoExtension.class)
 class SexualOrientationObservationConverterTest {
+
+        @Mock
+        UdiPrimeJpaConfig udiPrimeJpaConfig;
+
+        @Mock
+        CodeLookupService codeLookupService;
+
+        @Mock
+        DSLContext dslContext;
+        
         @InjectMocks
         private SexualOrientationObservationConverter sexualOrientationObservationConverter;
 


### PR DESCRIPTION
- Injected mocks for UdiPrimeJpaConfig, CodeLookupService, and DSLContext
- Updated test files to use @Mock and @InjectMocks annotations
- Ensured test files are initialized with required mock dependencies
- Preserved test logic for verifying resource conversion and JSON output generation