### PR TITLE
test: remove unused @Mock annotation and DSLContext import from test files #1467

### DIFF
--- a/hub-prime/src/test/java/org/techbd/service/csv/EncounterConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/EncounterConverterTest.java
@@ -12,7 +12,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Encounter;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,15 +42,12 @@ class EncounterConverterTest {
     @Mock
     CodeLookupService codeLookupService;
 
-    @Mock
-    DSLContext dslContext;
-
     @InjectMocks
     private EncounterConverter encounterConverter;
     
     @BeforeEach
     void setUp() throws Exception {
-            encounterConverter = new EncounterConverter(udiPrimeJpaConfig, codeLookupService);
+           encounterConverter = new EncounterConverter(udiPrimeJpaConfig, codeLookupService);
 
             Field profileMapField = FHIRUtil.class.getDeclaredField("PROFILE_MAP");
             profileMapField.setAccessible(true);

--- a/hub-prime/src/test/java/org/techbd/service/csv/OrganizationConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/OrganizationConverterTest.java
@@ -15,7 +15,6 @@ import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Organization;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,9 +44,6 @@ class OrganizationConverterTest {
 
     @Mock
     CodeLookupService codeLookupService;
-
-    @Mock
-    DSLContext dslContext;
 
     @InjectMocks
     private OrganizationConverter organizationConverter;

--- a/hub-prime/src/test/java/org/techbd/service/csv/PatientConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/PatientConverterTest.java
@@ -16,7 +16,6 @@ import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,9 +45,6 @@ class PatientConverterTest {
 
         @Mock
         CodeLookupService codeLookupService;
-
-        @Mock
-        DSLContext dslContext;
 
         @InjectMocks
         private PatientConverter patientConverter;

--- a/hub-prime/src/test/java/org/techbd/service/csv/ProcedureConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/ProcedureConverterTest.java
@@ -17,7 +17,6 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Procedure;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -43,9 +42,6 @@ class ProcedureConverterTest {
 
     @Mock
     CodeLookupService codeLookupService;
-
-    @Mock
-    DSLContext dslContext;
 
     @InjectMocks
     private ProcedureConverter procedureConverter;

--- a/hub-prime/src/test/java/org/techbd/service/csv/ScreeningResponseObservationConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/ScreeningResponseObservationConverterTest.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Observation;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -39,9 +38,6 @@ class ScreeningResponseObservationConverterTest {
 
     @Mock
     CodeLookupService codeLookupService;
-
-    @Mock
-    DSLContext dslContext;
 
     @InjectMocks
     private ScreeningResponseObservationConverter converter;

--- a/hub-prime/src/test/java/org/techbd/service/csv/SexualOrientationObservationConverterTest.java
+++ b/hub-prime/src/test/java/org/techbd/service/csv/SexualOrientationObservationConverterTest.java
@@ -12,7 +12,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Observation;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -40,10 +39,7 @@ class SexualOrientationObservationConverterTest {
 
         @Mock
         CodeLookupService codeLookupService;
-
-        @Mock
-        DSLContext dslContext;
-        
+     
         @InjectMocks
         private SexualOrientationObservationConverter sexualOrientationObservationConverter;
 


### PR DESCRIPTION
- Removed `@Mock` annotation for DSLContext
- Cleaned up unused `org.mockito.Mock` import