### PR TITLE
feat: map facility and encounter type from headers #1355

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/SwaggerConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SwaggerConfig.java
@@ -169,6 +169,20 @@ public class SwaggerConfig {
                                             .required(true)
                                             .in("header")
                                             .schema(new StringSchema()))
+                                       .addParametersItem(new Parameter()
+                                            .name("X-TechBD-Facility-ID")
+                                            .description(
+                                                    "Mandatory header for MRN Facility code")
+                                            .required(true)
+                                            .in("header")
+                                            .schema(new StringSchema()))
+                                       .addParametersItem(new Parameter()
+                                            .name("X-TechBD-Encounter-Type")
+                                            .description(
+                                                    "Mandatory header for Encounter Type Code")
+                                            .required(true)
+                                            .in("header")
+                                            .schema(new StringSchema()))
                                         .addParametersItem(new Parameter()
                                             .name("X-TechBD-OrgNPI")
                                             .description(


### PR DESCRIPTION
- Update Swagger/OpenAPI to include both headers as required parameters for `/ccda/Bundle`