### PR TITLE
feat: add SimpleMultipartFile class to wrap raw bytes as MultipartFile #1524

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/service/csv/SimpleMultipartFile.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/csv/SimpleMultipartFile.java
@@ -1,0 +1,61 @@
+package org.techbd.service.csv;
+
+import org.springframework.web.multipart.MultipartFile;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class SimpleMultipartFile implements MultipartFile {
+
+    private final String originalFilename;
+    private final String contentType;
+    private final byte[] content;
+
+    public SimpleMultipartFile(String originalFilename, String contentType, byte[] content) {
+        this.originalFilename = originalFilename;
+        this.contentType = contentType;
+        this.content = content;
+    }
+
+    @Override
+    public String getName() {
+        return originalFilename;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return content == null || content.length == 0;
+    }
+
+    @Override
+    public long getSize() {
+        return content.length;
+    }
+
+    @Override
+    public byte[] getBytes() throws IOException {
+        return content;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new ByteArrayInputStream(content);
+    }
+
+    @Override
+    public void transferTo(java.io.File dest) throws IOException {
+        try (var stream = new java.io.FileOutputStream(dest)) {
+            stream.write(content);
+        }
+    }
+}


### PR DESCRIPTION
- This utility class implements Spring's MultipartFile interface and is used in Mirth channels to wrap ZIP file bytes extracted from multipart/form-data HTTP requests. Enables seamless integration with CSV validation services.