### PR TITLE
fix: externalize flat file paths using env vars #1406

### DIFF
--- a/nexus-core-lib/src/main/resources/nexus-core-lib/application.yml
+++ b/nexus-core-lib/src/main/resources/nexus-core-lib/application.yml
@@ -2,12 +2,12 @@ org:
   techbd:
     csv:
       validation:
-        pythonScriptPath: support/specifications/flat-file/validate-nyher-fhir-ig-equivalent.py
+        pythonScriptPath: ${PYTHON_SCRIPT_PATH}support/specifications/flat-file/validate-nyher-fhir-ig-equivalent.py
         pythonExecutable: python3
-        packagePath: support/specifications/flat-file/datapackage-nyher-fhir-ig-equivalent.json
+        packagePath: ${PYTHON_SCRIPT_PATH}support/specifications/flat-file/datapackage-nyher-fhir-ig-equivalent.json
         inboundPath: /app/techbyDesign/flatFile/inbound
         outputPath: /app/techbyDesign/flatFile/outbound
-        ingressHomePath: /app/techbyDesign/flatFile/ingress   
+        ingressHomePath: /app/techbyDesign/flatFile/ingress
     udi:
       prime:
         jdbc:


### PR DESCRIPTION
Replaced hardcoded script and data package paths with ${PYTHON_SCRIPT_PATH}.