### PR TITLE
feat: update screening code mapping and enhance observation handling in XSLT files #1608

### DIFF
--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -1749,10 +1749,21 @@
             "code": {
               "coding": [
                 {
-                  "system": "http://loinc.org",
+                  "system": "<xsl:call-template name="mapScreeningCodeSystem">
+                                <xsl:with-param name="screeningCode" select="$grouperScreeningCode"/>
+                              </xsl:call-template>",
                   "code": "<xsl:value-of select='$grouperScreeningCode'/>",
-                  "display": "Social Determinants of Health screening report Document"
+                  "display": "<xsl:call-template name="mapScreeningCodeDisplay">
+                                <xsl:with-param name="screeningCode" select="$grouperScreeningCode"/>
+                              </xsl:call-template>"
                 }
+                <xsl:if test="starts-with($grouperScreeningCode, 'NYS')">
+                  ,{
+                    "code": "100698-0",
+                    "system": "http://loinc.org",
+                    "display": "Social Determinants of Health screening report Document"
+                  }
+                </xsl:if>
               ]
             },
             "subject": {
@@ -1803,29 +1814,22 @@
               }
             ],
             "hasMember": [
-              <xsl:for-each select="$grouperObs">
-                <xsl:variable name="questionCode" select="ccda:observation/ccda:code/@code"/>
-                <!--The observation resource will be generated only for the question codes present in the list specified in 'mapObservationCategoryCodes'-->                
-                <xsl:variable name="categoryCode">
-                        <xsl:call-template name="mapObservationCategoryCodes">
-                          <xsl:with-param name="questionCode" select="$questionCode"/>
-                        </xsl:call-template>
-                      </xsl:variable>
-
-                <xsl:if test="string($categoryCode) and (
-                          (string(ccda:observation/ccda:value/ccda:translation/@code) = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer' 
-                          or string(ccda:observation/ccda:value/ccda:translation/@code) = 'X-SDOH-FLO-1570000066-Patient-declined' ) 
-                                or (
-                                  string(ccda:observation/ccda:value/@code) != 'UNK' 
-                                  and string-length(ccda:observation/ccda:value/@code) > 0 
-                                  and string(ccda:observation/ccda:code/@code) != 'UNK' 
-                                  and string-length(ccda:observation/ccda:code/@code) > 0
-                                  and string-length(ccda:observation/ccda:value/@nullFlavor) = 0
-                                  and string-length(ccda:observation/ccda:code/@nullFlavor) = 0
-                                  and (ccda:observation/ccda:code/@codeSystemName = 'LOINC' or ccda:observation/ccda:code/@codeSystemName = 'SNOMED' or ccda:observation/ccda:code/@codeSystemName = 'SNOMED CT')
-                                )
-                          )
-                    ">                      
+              <xsl:variable name="allowedCodes" select="'|71802-3|96778-6|96779-4|88122-7|88123-5|93030-5|96780-2|96782-8|95618-5|95617-7|95616-9|95615-1|95614-4|'" />
+              <xsl:for-each select="$grouperObs/ccda:observation[
+                                        (string(ccda:value/ccda:translation/@code) = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer'
+                                        or string(ccda:value/ccda:translation/@code) = 'X-SDOH-FLO-1570000066-Patient-declined')
+                                        or (
+                                          string(ccda:value/@code) != 'UNK'
+                                          and string-length(ccda:value/@code) > 0
+                                          and string(ccda:code/@code) != 'UNK'
+                                          and string-length(ccda:code/@code) > 0
+                                          and string-length(ccda:value/@nullFlavor) = 0
+                                          and string-length(ccda:code/@nullFlavor) = 0
+                                          and (ccda:code/@codeSystemName = 'LOINC' or ccda:code/@codeSystemName = 'SNOMED' or ccda:code/@codeSystemName = 'SNOMED CT')
+                                        )
+                                        and contains($allowedCodes, concat('|', ccda:code/@code, '|'))
+                                      ]">
+                  <xsl:variable name="questionCode" select="ccda:code/@code"/>
                         <xsl:variable name="observationResourceId">
                           <xsl:call-template name="generateFixedLengthResourceId">
                             <xsl:with-param name="prefixString" select="$questionCode"/>
@@ -1833,8 +1837,7 @@
                           </xsl:call-template>
                         </xsl:variable>
                         <xsl:if test="position() > 1">,</xsl:if>
-                        { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }
-                </xsl:if>
+                        { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>"}
               </xsl:for-each>
             ]
           },
@@ -1843,7 +1846,32 @@
             "url": "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$grouperObservationResourceId'/>"
           }
         }
-      <!-- </xsl:for-each> -->
     </xsl:if>
   </xsl:template>
+
+  <xsl:template name="mapScreeningCodeDisplay">
+    <xsl:param name="screeningCode"/>
+    <xsl:choose>
+      <xsl:when test="$screeningCode = 'NYSAHCHRSN'">NYS Accountable Health Communities (AHC) Health-Related Social Needs Screening (HRSN) tool [Alternate]</xsl:when>
+      <xsl:when test="$screeningCode = 'NYS-AHC-HRSN'">INYS Accountable Health Communities (AHC) Health-Related Social Needs Screening (HRSN) tool</xsl:when>
+      <xsl:when test="$screeningCode = '96777-8'">Accountable health communities (AHC) health-related social needs screening (HRSN) tool</xsl:when>
+      <xsl:when test="$screeningCode = '97023-6'">Accountable health communities (AHC) health-related social needs (HRSN) supplemental questions</xsl:when> 
+      <xsl:when test="$screeningCode = '100698-0'">Social Determinants of Health screening report Document</xsl:when>    
+      <xsl:otherwise>
+        <xsl:text/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="mapScreeningCodeSystem">
+    <xsl:param name="screeningCode"/>
+    <xsl:choose>
+      <xsl:when test="$screeningCode = 'NYSAHCHRSN' or $screeningCode = 'NYS-AHC-HRSN'">http://test.shinny.org/us/ny/hrsn/CodeSystem/NYS-HRSN-Questionnaire</xsl:when>
+      <xsl:when test="$screeningCode = '96777-8' or $screeningCode = '97023-6' or $screeningCode = '100698-0'">http://loinc.org</xsl:when>
+      <xsl:otherwise>
+        <xsl:text>http://loinc.org</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-epic.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-epic.xslt
@@ -45,7 +45,7 @@
                     <authorization>
                         <consent>
                             <id root="2.16.840.1.113883.3.933"/>                            
-                            <code code="OPT-OUT" codeSystem="2.16.840.1.113883.5.8" displayName="deny"/>
+                            <code code="59284-0" codeSystem="2.16.840.1.113883.6.1" displayName="deny"/>
                             <statusCode code="completed"/>
                         </consent>
                     </authorization>


### PR DESCRIPTION
Updated grouper resource with the following for both Epic and Medent files:
- give the system and display according to the code
- if any of the NYS code then add the code "100698-0"
- fixed issue with extra comma is coming in 'hasMember' element