### PR TITLE
chore: downgrade AWS SDK from 2.17.87 to 2.15.28 for BridgeLink compatibility #1406

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -319,7 +319,7 @@
 		<dependency>
     		<groupId>software.amazon.awssdk</groupId>
     		<artifactId>secretsmanager</artifactId>
-    		<version>2.17.87</version>
+    		<version>2.15.28</version>
 		</dependency>
 		<dependency>
   			<groupId>io.github.linuxforhealth</groupId>

--- a/nexus-core-lib/pom.xml
+++ b/nexus-core-lib/pom.xml
@@ -17,7 +17,7 @@
     <name>Java Mirth Changes</name>
     <description>Standalone JAR for Mirth</description>
     <properties>
-        <aws.sdk.version>2.28.0</aws.sdk.version>
+        <aws.sdk.version>2.15.28</aws.sdk.version>
 	</properties>
     <dependencies>
         <dependency>
@@ -30,38 +30,8 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>secretsmanager</artifactId>
-            <version>2.17.87</version>
+            <version>2.15.28</version>
         </dependency>
-        <!-- <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-core</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>regions</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>auth</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sqs</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>utils</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency> -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/nexus-ingestion-api/pom.xml
+++ b/nexus-ingestion-api/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <aws.sdk.version>2.28.0</aws.sdk.version>
+        <aws.sdk.version>2.15.28</aws.sdk.version>
 	</properties>
 
     


### PR DESCRIPTION
- Updated AWS SDK dependencies in pom.xml to version 2.15.28
- Ensures compatibility with BridgeLink 4.5.3 (server-lib/client-lib)
- Verified existing Java functionality remains stable after downgrade