### PR TITLE
chore: add AWS SDK v2 SQS dependency (v2.17.87) #1406

### DIFF
--- a/nexus-core-lib/pom.xml
+++ b/nexus-core-lib/pom.xml
@@ -32,36 +32,11 @@
             <artifactId>secretsmanager</artifactId>
             <version>2.17.87</version>
         </dependency>
-        <!-- <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-core</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>regions</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>auth</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sqs</artifactId>
-            <version>${aws.sdk.version}</version>
+            <version>2.17.87</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>utils</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency> -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
- Introduced `software.amazon.awssdk:sqs:2.17.87` to support SQS integration
- Cleaned up previously unused or commented AWS SDK JARs