### PR TITLE
fix: correct header key for BASE_FHIR_URL #1406

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/config/Constants.java
+++ b/nexus-core-lib/src/main/java/org/techbd/config/Constants.java
@@ -53,7 +53,7 @@ public interface Constants {
     public static final String DATALAKE_API_CONTENT_TYPE = "DataLake-API-Content-Type";
     public static final String HEALTH_CHECK_HEADER = "X-TechBD-HealthCheck";
     public static final String START_TIME_ATTRIBUTE = "startTime";
-    public static final String BASE_FHIR_URL = "X-TechBD-BASE_FHIR_URL";
+    public static final String BASE_FHIR_URL = "X-TechBD-Base-FHIR-URL";
     public static final String METRIC_COOKIE = "METRIC_COOKIE";
     public static final String HEADER = "X-Observability-Metric-Interaction-Duration-Millisecs";
     public static final String DEFAULT_USER_NAME = "API_USER";


### PR DESCRIPTION
- Updated BASE_FHIR_URL value from "X-TechBD-BASE_FHIR_URL" to "X-TechBD-Base-FHIR-URL" to match the correct header format. This fixes a casing issue introduced in a previous commit.