### PR TITLE
fix: improve handling of demographic codes in converters #1690

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
@@ -255,24 +255,27 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                         if (organizationId != null) {
                             observation.addPerformer(new Reference("Organization/" + organizationId));
                         }
-                        String[] codes = StringUtils.defaultString(data.getPotentialNeedIndicated()).split(";");
+                        String rawValue = StringUtils.trimToEmpty(data.getPotentialNeedIndicated());
+                        if (!"NULL".equalsIgnoreCase(rawValue)) {
+                                String[] codes = StringUtils.defaultString(rawValue).split(";");
                                 CodeableConcept interpretation = new CodeableConcept();
 
                                 for (String rawCode : codes) {
-                                rawCode = rawCode.trim();
-                                if (StringUtils.isNotEmpty(rawCode)) {
+                                        rawCode = rawCode.trim();
+                                        if (StringUtils.isNotEmpty(rawCode) && !"NULL".equalsIgnoreCase(rawCode)) {
                                         String potentialNeedIndicated = fetchCode(rawCode, CsvConstants.POTENTIAL_NEED_INDICATED, interactionId);
                                         String display = fetchDisplay(potentialNeedIndicated, "Positive", CsvConstants.POTENTIAL_NEED_INDICATED, interactionId);
 
                                         interpretation.addCoding(
-                                        new Coding("http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", potentialNeedIndicated, display)
+                                                new Coding("http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", potentialNeedIndicated, display)
                                         );
-                                }
+                                        }
                                 }
 
                                 if (!interpretation.getCoding().isEmpty()) {
-                                observation.addInterpretation(interpretation);
+                                        observation.addInterpretation(interpretation);
                                 }
+                        }
                         //TO-DO
                         questionAndAnswerCode.put(data.getQuestionCode(), data.getAnswerCode());
 

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/SexualOrientationObservationConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/SexualOrientationObservationConverter.java
@@ -78,17 +78,27 @@ public class SexualOrientationObservationConverter extends BaseConverter {
             code.addCoding(new Coding("http://loinc.org", // TODO : remove static reference
                     "76690-7", "Sexual orientation")); // TODO : remove static reference
             observation.setCode(code);
+
             CodeableConcept value = new CodeableConcept();
-            String sexualOrientationCode = fetchCode(demographicData.getSexualOrientationCode(), CsvConstants.SEXUAL_ORIENTATION_CODE, interactionId);
-            value.addCoding(new Coding(fetchSystem(sexualOrientationCode, demographicData.getSexualOrientationCodeSystem(), CsvConstants.SEXUAL_ORIENTATION_CODE, interactionId),
-                    sexualOrientationCode,
-                    fetchDisplay(sexualOrientationCode, demographicData.getSexualOrientationCodeDescription(), CsvConstants.SEXUAL_ORIENTATION_CODE, interactionId)));
+            String originalCode = demographicData.getSexualOrientationCode();
+            String mappedCode = originalCode;
+
+            if ("ASKU".equalsIgnoreCase(originalCode)) {
+                mappedCode = "asked-unknown";
+            } else if ("UNK".equalsIgnoreCase(originalCode)) {
+                mappedCode = "unknown";
+            } else {
+                mappedCode = fetchCode(originalCode, CsvConstants.SEXUAL_ORIENTATION_CODE, interactionId);
+            }
+
+            value.addCoding(new Coding(
+                    fetchSystem(originalCode, demographicData.getSexualOrientationCodeSystem(), CsvConstants.SEXUAL_ORIENTATION_CODE, interactionId),
+                    mappedCode,
+                    fetchDisplay(originalCode, demographicData.getSexualOrientationCodeDescription(), CsvConstants.SEXUAL_ORIENTATION_CODE, interactionId)
+            ));
+
             observation.setValue(value);
-            // observation.setId("Observation"+CsvConversionUtil.sha256(demographicData.getPatientMrIdValue()));
-            // observation.setEffective(new DateTimeType(demographicData.getSexualOrientationLastUpdated())); //Not Used
-            // Narrative text = new Narrative();
-            // text.setStatus(Narrative.NarrativeStatus.fromCode("generated")); //TODO : remove static reference
-            // observation.setText(text);
+            
             BundleEntryComponent entry = new BundleEntryComponent();
             entry.setFullUrl(fullUrl);
             entry.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)


### PR DESCRIPTION
- Handled 'ASKU' & 'OTH' in SexAtBirthCode.
- Handled 'ASKU' & 'UNK' in Ethnicity.
- Handled 'ASKU' & 'asked-declined' in GenderIdentityCode.
- Handled 'ASKU' & 'UNK' in SexualOrientationCode.
- Handled 'NULL' in PotentialNeedIndicated.