### PR TITLE
feat: add Togglz-based DEBUG_LOG_REQUEST_HEADERS flag for request header logging #1761

### DIFF
--- a/nexus-ingestion-api/pom.xml
+++ b/nexus-ingestion-api/pom.xml
@@ -153,6 +153,16 @@
             <artifactId>hapi-structures-v28</artifactId>
             <version>${hapi.version}</version>
         </dependency>
+         <dependency> 
+            <groupId>org.togglz</groupId> 
+            <artifactId>togglz-console-spring-boot-starter</artifactId> 
+            <version>4.4.0</version> 
+        </dependency> 
+        <dependency> 
+            <groupId>org.togglz</groupId> 
+            <artifactId>togglz-spring-web</artifactId> 
+            <version>4.4.0</version> 
+        </dependency> 
     </dependencies>
 
     <build>

--- a/nexus-ingestion-api/pom.xml
+++ b/nexus-ingestion-api/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.techbd</groupId>
     <artifactId>nexus-ingestion-api</artifactId>
-    <version>0.1.17</version>
+    <version>0.1.18</version>
     <name>nexus-ingestion-api</name>
     <description>Nexus Ingestion API</description>
 

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
@@ -1,0 +1,46 @@
+package org.techbd.ingest.controller;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.techbd.ingest.feature.FeatureEnum;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+//@WebFilter(urlPatterns = "/*")
+public class InteractionsFilter extends OncePerRequestFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InteractionsFilter.class);
+   
+    @Override
+    protected void doFilterInternal(final HttpServletRequest origRequest, final HttpServletResponse origResponse,
+                                    final FilterChain chain) throws IOException, ServletException {
+               
+        LOG.info("Incoming Request");
+
+        if (FeatureEnum.isEnabled(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)) {
+            var headerNames = origRequest.getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                var headerName = headerNames.nextElement();
+                var headerValue = origRequest.getHeader(headerName);
+                LOG.info("{} - Header: {} = {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS, headerName, headerValue);
+            }
+        }
+
+        // ✅ Always call the next filter in the chain unless rejected
+        chain.doFilter(origRequest, origResponse);
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/CheckFeature.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/CheckFeature.java
@@ -1,0 +1,31 @@
+package org.techbd.ingest.feature;
+
+import org.springframework.stereotype.Controller;
+import org.togglz.core.manager.FeatureManager;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+
+@Controller
+public class CheckFeature {
+    private final FeatureManager featureManager;
+
+    public CheckFeature(FeatureManager featureManager) {
+        this.featureManager = featureManager;
+    }
+    @GetMapping("/feature")
+    @ResponseBody    
+    public String checkFeature() {
+        System.out.println("Feature is working");
+        if (!featureManager.isActive(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)){
+            System.out.println("Feature is not active");
+            return "Feature is not active";
+        }
+        else{
+            System.out.println("Feature is active");
+            return "Feature is active";
+        }
+
+    }
+    
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/FeatureEnum.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/FeatureEnum.java
@@ -1,0 +1,15 @@
+package org.techbd.ingest.feature;
+
+import org.togglz.core.Feature;
+import org.togglz.core.annotation.Label;
+import org.togglz.core.context.FeatureContext;
+
+public enum FeatureEnum implements Feature {
+
+    @Label("Enable Debug Logging for Request Headers")
+    DEBUG_LOG_REQUEST_HEADERS;
+
+    public static boolean isEnabled(Feature feature) {
+        return FeatureContext.getFeatureManager().isActive(feature);
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/TogglzConfiguration.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/TogglzConfiguration.java
@@ -1,0 +1,43 @@
+package org.techbd.ingest.feature;
+
+import org.springframework.context.annotation.Bean; 
+import org.springframework.context.annotation.Configuration; 
+import org.togglz.core.user.FeatureUser; 
+import org.togglz.core.user.UserProvider;   
+
+ 
+@Configuration
+public class TogglzConfiguration {
+ 
+    public TogglzConfiguration() {   
+    } 
+ 
+    @Bean 
+    public UserProvider userProvider() { 
+        return new UserProvider() { 
+            @Override 
+            public FeatureUser getCurrentUser() { 
+            //can customize this to get the user from the request
+
+                return new FeatureUser() { 
+ 
+                    @Override 
+                    public String getName() { 
+                        return "anonymous"; 
+                    } 
+ 
+                    @Override 
+                    public boolean isFeatureAdmin() { 
+                        return true; 
+                    } 
+ 
+                    @Override 
+                    public String getAttribute(String name) { 
+                        return null; 
+                    } 
+ 
+                }; 
+            } 
+        }; 
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/listener/MllpRoute.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/listener/MllpRoute.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.techbd.ingest.commons.Constants;
 import org.techbd.ingest.model.RequestContext;
 import org.techbd.ingest.service.router.IngestionRouter;
+import org.techbd.ingest.feature.FeatureEnum;
 import ca.uhn.hl7v2.AcknowledgmentCode;
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Message;
@@ -85,6 +86,10 @@ public class MllpRoute extends RouteBuilder {
         exchange.getIn().getHeaders().forEach((k, v) -> {
             if (v instanceof String) {
                 headers.put(k, (String) v);
+                // ✅ Conditional debug logging of headers
+                if (FeatureEnum.isEnabled(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)) {
+                    log.info("{} -Header: {} = {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS, k, v);
+                }
             }
         });
         String tenantId = headers.get(Constants.REQ_HEADER_TENANT_ID);

--- a/nexus-ingestion-api/src/main/resources/application.yml
+++ b/nexus-ingestion-api/src/main/resources/application.yml
@@ -12,4 +12,9 @@ org:
         bucket: ${AWS_S3_BUCKET_NAME:default-bucket}
 spring:
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:sandbox}      
+    active: ${SPRING_PROFILES_ACTIVE:sandbox}    
+togglz: 
+  enabled: true 
+  features: 
+    DEBUG_LOG_REQUEST_HEADERS: 
+      enabled: true  


### PR DESCRIPTION
- Introduced new feature flag `DEBUG_LOG_REQUEST_HEADERS` using Togglz.
- Created `InteractionsFilter` to log HTTP request headers based on the flag.
- Integrated the same flag into the MLLP ingestion flow for consistent logging across protocols.
- Allows runtime toggle of request header logging via Togglz console or config without redeployment.