### PR TITLE
fix: handle missing techByDesignDisposition when `X-TechBD-HealthCheck` header is blank #1707

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.techbd</groupId>
 		<artifactId>polyglot-prime</artifactId>
-		<version>0.650.0</version>
+		<version>0.651.0</version>
 		<relativePath>../pom.xml</relativePath> 
 	</parent>
 
@@ -375,7 +375,7 @@
 		<dependency>
 			<groupId>org.techbd</groupId>
 			<artifactId>nexus-core-lib</artifactId>
-			<version>0.650.0</version>
+			<version>0.651.0</version>
 		</dependency>
 	</dependencies>
 

--- a/nexus-core-lib/pom.xml
+++ b/nexus-core-lib/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.techbd</groupId>
         <artifactId>polyglot-prime</artifactId>
-        <version>0.650.0</version>
+        <version>0.651.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nexus-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
@@ -198,7 +198,7 @@ public class FHIRService {
                 final Map<String, Object> immediateResult = validate(requestParameters, payload, interactionId, provenance,
                         source);
                 final Map<String, Object> result = Map.of("OperationOutcome", immediateResult);
-				if (healthCheck == null || "false".equals(healthCheck)) {
+				if (!"true".equalsIgnoreCase(healthCheck != null ? healthCheck.trim() : null)) {
 					payloadWithDisposition = registerValidationResults(jooqCfg, requestParameters,
 							result, interactionId, groupInteractionId, masterInteractionId,
 							source, requestUriToBeOverriden);
@@ -208,7 +208,7 @@ public class FHIRService {
                     return result;
                 }
 
-                if ("true".equals(healthCheck)) {
+                if ("true".equalsIgnoreCase(healthCheck != null ? healthCheck.trim() : null)) {
                     return result;
                 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	  <modelVersion>4.0.0</modelVersion>
     <groupId>org.techbd</groupId>
     <artifactId>polyglot-prime</artifactId>
-    <version>0.650.0</version>
+    <version>0.651.0</version>
     <packaging>pom</packaging>
     <name>Polyglot Prime</name>
     <description>Parent Project for Polyglot Prime</description>


### PR DESCRIPTION

- Ensures techByDesignDisposition is correctly set even if the `X-TechBD-HealthCheck` header is present but empty.