### PR TITLE
feat: update health check to use GET method instead of HEAD #1761

### DIFF
--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.techbd</groupId>
 		<artifactId>polyglot-prime</artifactId>
-		<version>0.649.0</version>
+		<version>0.650.0</version>
 		<relativePath>../pom.xml</relativePath> 
 	</parent>
 
@@ -375,7 +375,7 @@
 		<dependency>
 			<groupId>org.techbd</groupId>
 			<artifactId>nexus-core-lib</artifactId>
-			<version>0.649.0</version>
+			<version>0.650.0</version>
 		</dependency>
 	</dependencies>
 

--- a/nexus-core-lib/pom.xml
+++ b/nexus-core-lib/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.techbd</groupId>
         <artifactId>polyglot-prime</artifactId>
-        <version>0.649.0</version>
+        <version>0.650.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nexus-ingestion-api/README.md
+++ b/nexus-ingestion-api/README.md
@@ -30,6 +30,28 @@
     s3://<bucket-name>/metadata/<YYYY>/<MM>/<DD>/<timestamp>/<interactionId>/metadata.json
     ```
 
+- **Sample S3 Metadata**
+  ```json
+  {
+  "key": "data/<YYYY>/<MM>/<DD>/<timestamp>-<interactionId>-<fileName>.zip",
+  "json_metadata": {
+    "headers": "<Map of request headers including IP and Port headers like x-real-ip, x-forwarded-for, x-server-ip, x-server-port>",
+    "interactionId": "<UUID>",
+    "fileName": "<file-name>.zip",
+    "queryParams": null,
+    "sourceSystem": "<source-system>",
+    "s3ObjectPath": "s3://<s3-bucket-name>/data/<YYYY>/<MM>/<DD>/<timestamp>-<interactionId>-<fileName>.zip",
+    "protocol": "<protocol-version>",
+    "uploadDate": "<YYYY-MM-DD>",
+    "fileSize": "<file-size-in-bytes>",
+    "requestUrl": "/ingest",
+    "localAddress": "<local-address>",
+    "tenantId": "<tenant-id-or-unknown>",
+    "fullRequestUrl": "http://<hostname>/ingest",
+    "remoteAddress": "<remote-address>",
+    "timestamp": "<epoch-timestamp-in-ms>"
+  }
+  ```
 - **Structured Messaging to Amazon SQS**  
   A message is pushed to **Amazon SQS** with a deterministic `messageGroupId` to ensure **FIFO** ordering and grouping.
 
@@ -88,9 +110,9 @@
   - Health check:
 
   ```bash
-  curl --head http://<hostname>/
+  curl http://<hostname>/
   ```
-
+  
 - **MLLP (Minimal Lower Layer Protocol)**
   - The application listens on ports defined via the `HL7_MLLP_PORTS` environment variable:
 
@@ -112,7 +134,19 @@
   ```bash
   curl http://<hostname>/actuator/health/mllp
   ```
-
+     - Example Response for health check***
+      ```
+      {
+        "status": "UP",
+        "details": {
+          "MLLP Ports": {
+            "Port 2575": "UP",
+            "Port 2576": "UP",
+            "Port 2577": "UP"
+          }
+        }
+      }
+      ```
 - **SOAP Endpoints**
   - SOAP routes support **PIX** and **PNR** requests.
   - Standard SOAP acknowledgements are returned.
@@ -131,7 +165,7 @@
         enabled: true
   ```
 
-  Logs can be viewed in **CloudWatch** using either the `interactionId` or by searching `DEBUG_LOG_REQUEST_HEADERS`.
+  If  `DEBUG_LOG_REQUEST_HEADERS` is enabled headers available in request can be viewed in **CloudWatch** using either the `interactionId` or by searching `DEBUG_LOG_REQUEST_HEADERS`.
 
 - **📲 Togglz REST API Endpoints**
 

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/SecurityConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         // Publicly permitted endpoints
 
                         .requestMatchers(HttpMethod.GET, "/actuator/health/mllp").permitAll()
-                        .requestMatchers(HttpMethod.HEAD, "/").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/").permitAll()
                         .requestMatchers(HttpMethod.POST, "/ingest").permitAll()
                         .requestMatchers("/ws").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/features/*").permitAll()

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
@@ -54,7 +54,7 @@ public class DataIngestionController {
      *
      * @return A response entity indicating service health status.
      */
-    @RequestMapping(value = "/", method = RequestMethod.HEAD)
+    @RequestMapping(value = "/", method = RequestMethod.GET)
     public ResponseEntity<Void> healthCheck() {
         try {
             LOG.info("Health check requested via HEAD /ingest");

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	  <modelVersion>4.0.0</modelVersion>
     <groupId>org.techbd</groupId>
     <artifactId>polyglot-prime</artifactId>
-    <version>0.649.0</version>
+    <version>0.650.0</version>
     <packaging>pom</packaging>
     <name>Polyglot Prime</name>
     <description>Parent Project for Polyglot Prime</description>


### PR DESCRIPTION
docs(readme): document IngestionAPI features and update health check method

- Documented key features of IngestionAPI:
  - Multi-protocol support (HTTP, MLLP)
  - Health check endpoints:
    - HTTP(S): `curl https://<hostname>/`
    - MLLP:    `curl http://<hostname>/actuator/health/mllp`
  - SQS FIFO with messageGroupId for ordered delivery
  - Feature flag toggling using Togglz:
    - DEBUG_LOG_REQUEST_HEADERS for request header logging
      - Enable:  curl -s -X POST http://<hostname>/api/features/DEBUG_LOG_REQUEST_HEADERS/enable
      - Disable: curl -s -X POST http://<hostname>/api/features/DEBUG_LOG_REQUEST_HEADERS/disable
- feat: switched HTTP health check from HEAD to GET method 