### PR TITLE
refactor: move interactionId generation from controller to filter for better traceability

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
@@ -79,15 +79,17 @@ public class DataIngestionController {
             @RequestParam("file") @Nonnull MultipartFile file,
             @RequestHeader Map<String, String> headers,
             HttpServletRequest request) throws Exception {
-        String interactionId = UUID.randomUUID().toString();
+        
+        // Get interactionId from filter
+        String interactionId = (String) request.getAttribute("interactionId");
         LOG.info("DataIngestionController:: Received ingest request. interactionId={}", interactionId);
 
-         // ✅ Conditional debug logging of headers using Togglz
-         if (FeatureEnum.isEnabled(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)) {
-            headers.forEach((k, v) -> {
-                log.info("{} -Header for the InteractionId {} :  {} = {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS,interactionId , k, v);
-            });
-        }
+        //  // ✅ Conditional debug logging of headers using Togglz
+        //  if (FeatureEnum.isEnabled(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)) {
+        //     headers.forEach((k, v) -> {
+        //         log.info("{} -Header for the InteractionId {} :  {} = {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS,interactionId , k, v);
+        //     });
+        // }
 
         if (file == null || file.isEmpty()) {
             LOG.warn("Uploaded file is empty. interactionId={}", interactionId);

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
@@ -3,6 +3,7 @@ package org.techbd.ingest.controller;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,14 +30,19 @@ public class InteractionsFilter extends OncePerRequestFilter {
     protected void doFilterInternal(final HttpServletRequest origRequest, final HttpServletResponse origResponse,
                                     final FilterChain chain) throws IOException, ServletException {
                
-        LOG.info("Incoming Request");
+        // Generate interactionId early
+        String interactionId = UUID.randomUUID().toString();
+
+        // Store in request attribute
+        origRequest.setAttribute("interactionId", interactionId);
+        LOG.info("Incoming Request - interactionId={}", interactionId);
 
         if (FeatureEnum.isEnabled(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)) {
             var headerNames = origRequest.getHeaderNames();
             while (headerNames.hasMoreElements()) {
                 var headerName = headerNames.nextElement();
                 var headerValue = origRequest.getHeader(headerName);
-                LOG.info("{} - Header: {} = {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS, headerName, headerValue);
+                LOG.info("{} - Header: {} = {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS, interactionId, headerName, headerValue);
             }
         }
 


### PR DESCRIPTION


- Move interactionId generation from DataIngestionController to InteractionsFilter
- Store interactionId in request attributes for downstream access