### PR TITLE
revert: use Bundle-based validation instead of payload string (#1825)

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
@@ -464,11 +464,11 @@ public class OrchestrationEngine {
                     fhirContext.setParserErrorHandler(lenientErrorHandler);
 
                     LOG.debug("BUNDLE PAYLOAD parse -BEGIN for interactionId:{}", interactionId);
-                    //final var bundle = fhirContext.newJsonParser().parseResource(Bundle.class, payload);
+                    final var bundle = fhirContext.newJsonParser().parseResource(Bundle.class, payload);
                     LOG.debug("BUNDLE PAYLOAD parse -END for interactionid:{} ", interactionId);
                     // final var validatorOptions = new ValidationOptions().addProfile(profileUrl);
                     // final var hapiVR = bundleValidator.getFhirValidator().validateWithResult(bundle,validatorOptions);
-                     final var hapiVR = bundleValidator.getFhirValidator().validateWithResult(payload);
+                     final var hapiVR = bundleValidator.getFhirValidator().validateWithResult(bundle);
                     final var completedAt = Instant.now();
                     LOG.info("VALIDATOR -END completed at :{} ms for interactionId:{} with ig version :{}",
                             Duration.between(initiatedAt, completedAt).toMillis(), interactionId, igVersion);


### PR DESCRIPTION
- Reverted validation logic to parse payload into a Bundle:  `fhirContext.newJsonParser().parseResource(Bundle.class, payload)`
- Updated validator call to use `validateWithResult(bundle)` instead of `validateWithResult(payload)`
- Temporarily restores original behavior while investigating stricter JSON structure validation