### PR TITLE
feat: add support for SHIN-NY IG version via header in Validation APIs #1791

### DIFF
--- a/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/CsvController.java
+++ b/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/CsvController.java
@@ -78,7 +78,7 @@ public class CsvController {
     Map<String, Object> headerParameters = CoreFHIRUtil.buildHeaderParametersMap(tenantId, null,
         null,
         null, null, null, null,
-        null);   
+        null,null);   
     CoreFHIRUtil.buildRequestParametersMap(requestDetailsMap,null,
         null, null, null, null, request.getRequestURI());
     requestDetailsMap.put(Constants.MASTER_INTERACTION_ID, UUID.randomUUID().toString());
@@ -111,7 +111,7 @@ public class CsvController {
     Map<String, Object> headerParameters = CoreFHIRUtil.buildHeaderParametersMap(tenantId, null,
         null,
         null, validationSeverityLevel, null, null,
-        null);    
+        null,null);    
     CoreFHIRUtil.buildRequestParametersMap(requestDetailsMap,null,
         null, null, null, null, request.getRequestURI());
     requestDetailsMap.put(Constants.MASTER_INTERACTION_ID, UUID.randomUUID().toString());

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FhirController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FhirController.java
@@ -180,6 +180,7 @@ public class FhirController {
                         @Parameter(hidden = true, description = "Optional parameter to decide whether the session cookie (JSESSIONID) should be deleted.", required = false) @RequestParam(value = "delete-session-cookie", required = false) Boolean deleteSessionCookie,
                         @Parameter(hidden = true, description = "Optional parameter to specify source of the request.", required = false) @RequestParam(value = "source", required = false, defaultValue = "FHIR") String source,
                         @Parameter(description = "Optional header to set validation severity level (`information`, `warning`, `error`, `fatal`).", required = false) @RequestHeader(value = "X-TechBD-Validation-Severity-Level", required = false) String validationSeverityLevel,
+                        @Parameter(description = "Optional header to specify IG version.", required = false) @RequestHeader(value = "X-SHIN-NY-IG-Version", required = false) String requestedIgVersion ,                    
                         HttpServletRequest request, HttpServletResponse response) throws SQLException, IOException {
                 Span span = tracer.spanBuilder("FhirController.validateBundleAndForward").startSpan();
                 try {
@@ -205,7 +206,7 @@ public class FhirController {
                         Map<String, Object> headers = CoreFHIRUtil.buildHeaderParametersMap(tenantId, customDataLakeApi,
                                         dataLakeApiContentType,
                                         requestUriToBeOverridden, validationSeverityLevel, healthCheck, coRrelationId,
-                                        provenance);
+                                        provenance,requestedIgVersion);
                         Map <String,Object> requestDetailsMap = FHIRUtil.extractRequestDetails(request);
                         CoreFHIRUtil.buildRequestParametersMap(requestDetailsMap,deleteSessionCookie,
                                         mtlsStrategy, source, null, null,request.getRequestURI());
@@ -270,6 +271,7 @@ public class FhirController {
                         @Parameter(description = "Parameter to specify the Tenant ID. This is a <b>mandatory</b> parameter.", required = true) @RequestHeader(value = Configuration.Servlet.HeaderName.Request.TENANT_ID, required = true) String tenantId,
                         // "profile" is the same name that HL7 validator uses
                         @Parameter(hidden = true, description = "Optional parameter to decide whether the session cookie (JSESSIONID) should be deleted.", required = false) @RequestParam(value = "delete-session-cookie", required = false) Boolean deleteSessionCookie,
+                        @Parameter(description = "Optional header to specify IG version.", required = false) @RequestHeader(value = "X-SHIN-NY-IG-Version", required = false) String requestedIgVersion,
                         HttpServletRequest request, HttpServletResponse response) throws IOException {
                 Span span = tracer.spanBuilder("FhirController.validateBundle").startSpan();
                 try {
@@ -284,7 +286,7 @@ public class FhirController {
                         }
                         request = new CustomRequestWrapper(request, payload);
                         Map<String, Object> headers = CoreFHIRUtil.buildHeaderParametersMap(tenantId, null, null,
-                                        null, null, null, null, null);
+                                        null, null, null, null, null,requestedIgVersion );
                         Map <String,Object> requestDetailsMap = FHIRUtil.extractRequestDetails(request);            
                         CoreFHIRUtil.buildRequestParametersMap(requestDetailsMap,deleteSessionCookie,
                                         null, null,

--- a/nexus-core-lib/src/main/java/org/techbd/config/Constants.java
+++ b/nexus-core-lib/src/main/java/org/techbd/config/Constants.java
@@ -47,6 +47,7 @@ public interface Constants {
     public static final String REMOTE_ADDRESS = "remoteAddress";
     public static final String IMMEDIATE = "immediate";
     public static final String VALIDATION_SEVERITY_LEVEL = "X-TechBD-Validation-Severity-Level";
+    public static final String SHIN_NY_IG_VERSION = "X-SHIN-NY-IG-Version";
     public static final String FHIR_STRUCT_DEFN_PROFILE_URI = "X-TechBD-FHIR-Profile-URI";
     public static final String FHIR_VALIDATION_STRATEGY = "X-TechBD-FHIR-Validation-Strategy";
     public static final String DATALAKE_API_URL = "X-TechBD-DataLake-API-URL";

--- a/nexus-core-lib/src/main/java/org/techbd/service/csv/CsvBundleProcessorService.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/csv/CsvBundleProcessorService.java
@@ -393,7 +393,7 @@ private List<Object> processScreening(final String groupKey,
                                 (String) requestParameters.get(Constants.VALIDATION_SEVERITY_LEVEL), // Cast to String, // Pass severity level
                                 null,
                                 null,
-                                updatedProvenance);
+                                updatedProvenance, null);
                         org.techbd.util.fhir.CoreFHIRUtil.buildRequestParametersMap(requestParameters,
                             false, null, SourceType.CSV.name(),  groupInteractionId, masterInteractionId,(String) requestParameters.get(Constants.REQUEST_URI));
                         requestParameters.put(Constants.INTERACTION_ID, interactionId);

--- a/nexus-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
@@ -47,12 +47,12 @@ import org.techbd.config.CoreAppConfig.MTlsAwsSecrets;
 import org.techbd.config.CoreAppConfig.MTlsResources;
 import org.techbd.config.CoreAppConfig.PostStdinPayloadToNyecDataLakeExternal;
 import org.techbd.config.CoreAppConfig.WithApiKeyAuth;
+import org.techbd.config.CoreUdiPrimeJpaConfig;
 import org.techbd.config.Helpers;
 import org.techbd.config.Interactions;
 import org.techbd.config.Nature;
 import org.techbd.config.SourceType;
 import org.techbd.config.State;
-import org.techbd.config.CoreUdiPrimeJpaConfig;
 import org.techbd.exceptions.ErrorCode;
 import org.techbd.exceptions.JsonValidationException;
 import org.techbd.service.dataledger.CoreDataLedgerApiClient;
@@ -195,9 +195,9 @@ public class FHIRService {
                     dataLakeApiContentType = MediaType.APPLICATION_JSON_VALUE;
                 }
 
-                final Map<String, Object> immediateResult = validate(requestParameters, payload, interactionId, provenance,
+                                final Map<String, Object> immediateResult = validate(requestParameters, payload, interactionId, provenance,
                         source);
-                final Map<String, Object> result = Map.of("OperationOutcome", immediateResult);
+                                               final Map<String, Object> result = Map.of("OperationOutcome", immediateResult);
 				if (!"true".equalsIgnoreCase(healthCheck != null ? healthCheck.trim() : null)) {
 					payloadWithDisposition = registerValidationResults(jooqCfg, requestParameters,
 							result, interactionId, groupInteractionId, masterInteractionId,
@@ -502,6 +502,8 @@ public class FHIRService {
 			final var start = Instant.now();
 			LOG.info("FHIRService  - Validate -BEGIN for interactionId: {} ", interactionId);
 			final var igPackages = coreAppConfig.getIgPackages();
+            var requestedIgVersion = (String) requestParameters.get(Constants.SHIN_NY_IG_VERSION);
+            LOG.info("headerIgVersion : "+ requestedIgVersion);
 			final var sessionBuilder = engine.session()
 					.withSessionId(UUID.randomUUID().toString())
 					.onDevice(Device.createDefault())
@@ -510,6 +512,7 @@ public class FHIRService {
 					.withFhirProfileUrl(CoreFHIRUtil.getBundleProfileUrl())
 					.withTracer(tracer)
 					.withFhirIGPackages(igPackages)
+                    .withRequestedIgVersion(requestedIgVersion)
 					.addHapiValidationEngine(); // by default
 					// clearExisting is set to true so engines can be fully supplied through header
 					


### PR DESCRIPTION
This PR updates the TechBD validation APIs (/Bundle and /Bundle/$validate) to allow specifying a SHIN-NY IG version via the X-SHIN-NY-IG-Version header.

---

### 🔧 Changes included:

- Introduced `headerIgVersion` in OrchestrationEngine.validate() to track the requested IG version.
- Construct `shinNyPackagePath` dynamically depending on profile (test vs prod) and header value.
- Added CoreFHIRUtil.ensureEngineVersionMatches() to verify that the requested IG package exists and is valid.
- The validator uses the specified IG version to load the corresponding SHIN-NY IG for FHIR bundle validation.
- If the header is missing or invalid, the system defaults to the latest available SHIN-NY IG version.
- Logging updated for clarity on extracted profile URL, requested IG version, and resolved package path.
