### PR TITLE
fix: resolve XsdSchema bean ambiguity for PIX and PNR WSDL definitions #1705, #1706

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/WebServiceConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/WebServiceConfig.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -65,7 +66,7 @@ public class WebServiceConfig extends WsConfigurationSupport {
     }
 
     @Bean(name = "pix")
-    public DefaultWsdl11Definition pixWsdl(XsdSchema hl7Schema) {
+    public DefaultWsdl11Definition pixWsdl(@Qualifier("hl7Schema") XsdSchema hl7Schema) {
         var wsdlDefinition = new DefaultWsdl11Definition();
         wsdlDefinition.setPortTypeName("PIXPort");
         wsdlDefinition.setLocationUri("/ws");
@@ -75,7 +76,7 @@ public class WebServiceConfig extends WsConfigurationSupport {
     }
 
     @Bean(name = "pnr")
-    public DefaultWsdl11Definition pnrWsdl(XsdSchema pnrSchema) {
+    public DefaultWsdl11Definition pnrWsdl(@Qualifier("pnrSchema") XsdSchema pnrSchema) {
         var wsdlDefinition = new DefaultWsdl11Definition();
         wsdlDefinition.setPortTypeName("PNRPort");
         wsdlDefinition.setLocationUri("/ws");


### PR DESCRIPTION
- Added @Qualifier annotations to pixWsdl() and pnrWsdl() methods to explicitly define which XsdSchema bean should be injected. This fixes Spring Boot startup failures caused by multiple XsdSchema beans (hl7Schema, pnrSchema) that were preventing application context initialization.


#1705, #1706