### PR TITLE
fix: extract base profile URL from StructureDefinition path #1791

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
@@ -501,11 +501,18 @@ public class OrchestrationEngine {
                                 "us-core", "ig-packages/fhir-v4/us-core/stu-7.0.0",
                                 "sdoh", "ig-packages/fhir-v4/sdoh-clinicalcare/stu-2.2.0",
                                 "uv-sdc", "ig-packages/fhir-v4/uv-sdc/stu-3.0.0");
-
+                        
+                        String profileBaseUrl = profileUrl;
+                        if (profileUrl != null) {
+                            int idx = profileUrl.indexOf("/StructureDefinition/");
+                            if (idx != -1) {
+                                profileBaseUrl = profileUrl.substring(0, idx);
+                            }
+                        }                                
                         bundleValidator = FhirBundleValidator.builder()
                                 .fhirContext(FhirContext.forR4())
-                                .fhirValidator(initializeFhirValidator(shinNyPackagePath, basePackages, profileUrl))
-                                .baseFHIRUrl(profileUrl)
+                                .fhirValidator(initializeFhirValidator(shinNyPackagePath, basePackages, profileBaseUrl))
+                                .baseFHIRUrl(profileBaseUrl)
                                 .packagePath(shinNyPackagePath)
                                 .igVersion(headerIgVersion)
                                 .build();

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.677.0</revision>
+        <revision>0.678.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Added logic to derive `profileBaseUrl` from `profileUrl` by trimming
  the `/StructureDefinition/...` suffix.