### PR TITLE
chore: bump polyglot version to 0.681.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.680.0</revision>
+        <revision>0.681.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Incremented polyglot module version from 0.680.x to 0.681.0 to align with the latest release cycle and ensure consistency across dependent modules.