### PR TITLE
fix: standardize server port to 8080 in nexus-ingestion-api #1894

### DIFF
--- a/nexus-ingestion-api/src/main/resources/application.yml
+++ b/nexus-ingestion-api/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${SERVER_PORT:9999}
+  port: ${SERVER_PORT:8080}
   max-http-request-size: ${MAX_HTTP_REQUEST_SIZE:10MB}
   tomcat:
     max-swallow-size: ${MAX_SWALLOW_SIZE:10MB}


### PR DESCRIPTION
- Changed default server port from 9999 to 8080 in application.yml
- Aligns with standard Spring Boot default port configuration