### PR TITLE
fix: update xslt files to fix issue with encounter status in Epic and Medent CCDA files #1901

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -126,9 +126,7 @@
                                 | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship/ccda:observation/ccda:entryRelationship
                                 | /ccda:ClinicalDocument/ccda:authorization/ccda:consent 
                                 | /ccda:ClinicalDocument/ccda:author
-                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter
                                 | /ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location/ccda:healthCareFacility/ccda:location
-                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant/ccda:participantRole
                                 "/>
             <!-- Call Grouper Observation template -->
             <xsl:call-template name="GrouperObservation"/>
@@ -641,116 +639,6 @@
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
                     "display": "<xsl:value-of select="ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>"
-                }
-            }
-        ]
-        </xsl:if>
-      }      
-      , "request" : {
-        "method" : "POST",
-        "url" : "<xsl:value-of select='$baseFhirUrl'/>/Encounter/<xsl:value-of select="$encounterResourceId"/>"
-      }
-    }
-  </xsl:template>
-
-  <!-- Encounter Template -->
-  <xsl:template name="ComponentEncounter" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter">
-    ,{
-      "fullUrl" : "<xsl:value-of select='$baseFhirUrl'/>/Encounter/<xsl:value-of select="$encounterResourceId"/>",
-      "resource": {
-        "resourceType": "Encounter",
-        "id": "<xsl:value-of select="$encounterResourceId"/>",
-        "meta" : {
-          "lastUpdated" : "<xsl:value-of select='$currentTimestamp'/>",
-          "profile" : ["<xsl:value-of select='$encounterMetaProfileUrlFull'/>"]
-        },
-        "status": "<xsl:call-template name='mapEncounterStatus'>
-                            <xsl:with-param name='statusCode' select='$encounterStatus'/>
-                        </xsl:call-template>",
-        <xsl:if test="string($encounterType)">
-          <xsl:variable name="encounterTypeDisplay">
-            <xsl:call-template name="getEncounterTypeDisplay">
-              <xsl:with-param name="encounterType" select="$encounterType"/>
-            </xsl:call-template>
-          </xsl:variable>
-
-          "type": [
-            {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "<xsl:value-of select="$encounterType"/>",
-                  "display": "<xsl:value-of select="$encounterTypeDisplay"/>"
-                }
-              ],
-              "text": "<xsl:value-of select="$encounterTypeDisplay"/>"
-            }
-          ],
-        </xsl:if>
-        "class": {
-          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          "code": "<xsl:value-of select="ccda:code/@code"/>",
-          "display": "<xsl:value-of select="ccda:code/@displayName"/>"
-        },
-        "subject" : {
-          "reference" : "Patient/<xsl:value-of select='$patientResourceId'/>",
-          "display" : "<xsl:value-of select="$patientResourceName"/>"
-        }
-        <xsl:choose>
-          <!-- Check if low or high exists -->
-          <xsl:when test="string(ccda:effectiveTime/ccda:low/@value) or string(ccda:effectiveTime/ccda:high/@value)">
-            , "period": {
-              "start": "<xsl:call-template name='formatDateTime'>
-                          <xsl:with-param name='dateTime' select='ccda:effectiveTime/ccda:low/@value'/>
-                      </xsl:call-template>",
-              "end": "<xsl:call-template name='formatDateTime'>
-                        <xsl:with-param name='dateTime' select='ccda:effectiveTime/ccda:high/@value'/>
-                    </xsl:call-template>"
-            }
-          </xsl:when>
-          <!-- Check if only value exists -->
-          <xsl:when test="string(ccda:effectiveTime/@value)">
-            , "period": {
-              "start": "<xsl:call-template name='formatDateTime'>
-                          <xsl:with-param name='dateTime' select='ccda:effectiveTime/@value'/>
-                      </xsl:call-template>"
-            }
-          </xsl:when>
-        </xsl:choose>
-        <xsl:if test="string(ccda:participant/@typeCode) and (string(ccda:participant/ccda:assignedEntity/ccda:assignedPerson/ccda:name/ccda:given[1]) or string(ccda:participant/ccda:assignedEntity/ccda:assignedPerson/ccda:name/ccda:family))">
-        , "participant": [
-                {
-                    <xsl:if test="string(ccda:participant/@typeCode)"> 
-                    "type": [
-                        {
-                            "coding": [
-                                {
-                                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                                    "code": "<xsl:value-of select="ccda:participant/@typeCode"/>",
-                                    "display": "<xsl:call-template name='mapParticipantType'>
-                                                  <xsl:with-param name='typeCode' select='ccda:participant/@typeCode'/>
-                                              </xsl:call-template>"
-                                }
-                            ]
-                        }
-                      ]
-                    </xsl:if>
-                    <xsl:if test="string(ccda:participant/ccda:assignedEntity/ccda:assignedPerson/ccda:name/ccda:given[1])  or string(ccda:participant/ccda:assignedEntity/ccda:assignedPerson/ccda:name/ccda:family)">
-                    , "individual": {
-                        "display": "<xsl:value-of select="concat(ccda:participant/ccda:assignedEntity/ccda:assignedPerson/ccda:name/ccda:given[1], ' ', ccda:participant/ccda:assignedEntity/ccda:assignedPerson/ccda:name/ccda:family)"/>"
-                    }
-                    </xsl:if>
-                }
-            ]
-        </xsl:if>
-        <xsl:if test="string($locationResourceId) or string(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)">
-        , "location": [
-            {
-                "location": {
-                    <xsl:if test="string($locationResourceId)"> 
-                      "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
-                    </xsl:if>
-                    "display": "<xsl:value-of select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>"
                 }
             }
         ]
@@ -1430,18 +1318,19 @@
     </xsl:choose>
 </xsl:template>
 
-<xsl:template name="mapEncounterStatus">
+<xsl:template name="mapEncounterStatus"> 
     <xsl:param name="statusCode"/>
+    <xsl:variable name="cleanCode" select="normalize-space(string($statusCode))"/>
     <xsl:choose>
-        <xsl:when test="$statusCode = 'completed' or 
-                        $statusCode = 'normal'">finished</xsl:when>
-        <xsl:when test="$statusCode = 'active'">in-progress</xsl:when>
-        <xsl:when test="$statusCode = 'cancelled' or 
-                        $statusCode = 'aborted'">cancelled</xsl:when>
-        <xsl:when test="$statusCode = 'suspended'">on-hold</xsl:when>
-        <xsl:when test="$statusCode = 'nullified' or 
-                        $statusCode = 'corrected'">entered-in-error</xsl:when>
-        <xsl:when test="$statusCode = 'new'">planned</xsl:when>
+        <xsl:when test="$cleanCode = 'completed' or 
+                        $cleanCode = 'normal'">finished</xsl:when>
+        <xsl:when test="$cleanCode = 'active'">in-progress</xsl:when>
+        <xsl:when test="$cleanCode = 'cancelled' or 
+                        $cleanCode = 'aborted'">cancelled</xsl:when>
+        <xsl:when test="$cleanCode = 'suspended'">on-hold</xsl:when>
+        <xsl:when test="$cleanCode = 'nullified' or 
+                        $cleanCode = 'corrected'">entered-in-error</xsl:when>
+        <xsl:when test="$cleanCode = 'new'">planned</xsl:when>
         <xsl:otherwise>unknown</xsl:otherwise>
     </xsl:choose>
 </xsl:template>
@@ -1922,92 +1811,6 @@
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": 
-                    {
-                        <xsl:if test="string(ccda:addr/@use)">
-                            "use": "<xsl:choose>
-                                <xsl:when test="ccda:addr/@use='HP' or ccda:addr/@use='H'">home</xsl:when>
-                                <xsl:when test="ccda:addr/@use='WP'">work</xsl:when>
-                                <xsl:when test="ccda:addr/@use='TMP'">temp</xsl:when>
-                                <xsl:when test="ccda:addr/@use='OLD' or ccda:addr/@use='BAD'">old</xsl:when>
-                                <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
-                            </xsl:choose>",
-                        </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:streetAddressLine) or string(ccda:addr/ccda:city) or string(ccda:addr/ccda:state) or string(ccda:addr/ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:addr/ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:state)">, <xsl:value-of select="ccda:addr/ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:postalCode"/></xsl:if>" ,
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:city)">
-                            , "city": "<xsl:value-of select="ccda:addr/ccda:city"/>"
-                        </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:county)">
-                            , "district": "<xsl:value-of select="ccda:addr/ccda:county"/>"
-                        </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:state)">
-                            , "state": "<xsl:value-of select="ccda:addr/ccda:state"/>"
-                        </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="ccda:addr/ccda:postalCode"/>"
-                        </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:country)">
-                            , "country": "<xsl:value-of select="ccda:addr/ccda:country"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    } 
-        </xsl:if>
-      },
-      "request" : {
-        "method" : "POST",
-        "url" : "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select="$locationResourceId"/>"
-      }
-    }
-  </xsl:if>
-  </xsl:template>
-
-  <!-- Location Template from Encounters section -->
-  <xsl:template name="EncountersLocationResource" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant/ccda:participantRole">
-  <xsl:if test="string($locationResourceId)">
-    ,{
-      "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
-      "resource": {
-        "resourceType": "Location",
-        "id": "<xsl:value-of select='$locationResourceId'/>",
-        "meta": {
-          "lastUpdated": "<xsl:value-of select='$currentTimestamp'/>",
-          "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
-        }
-        <xsl:if test="ccda:playingEntity/ccda:name">
-          ,"name": "<xsl:value-of select="ccda:playingEntity/ccda:name"/>"
-        </xsl:if>
-
-        <xsl:if test="ccda:addr[not(@nullFlavor)]">
             , "address":
                     {
                         <xsl:if test="string(ccda:addr/@use)">
@@ -2076,7 +1879,7 @@
     }
   </xsl:if>
   </xsl:template>
-
+  
   <xsl:template name="mapScreeningCodeDisplay">
     <xsl:param name="screeningCode"/>
     <xsl:choose>

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
@@ -1324,18 +1324,19 @@
     </xsl:choose>
 </xsl:template>
 
-<xsl:template name="mapEncounterStatus">
+<xsl:template name="mapEncounterStatus"> 
     <xsl:param name="statusCode"/>
+    <xsl:variable name="cleanCode" select="normalize-space(string($statusCode))"/>
     <xsl:choose>
-        <xsl:when test="$statusCode = 'completed' or 
-                        $statusCode = 'normal'">finished</xsl:when>
-        <xsl:when test="$statusCode = 'active'">in-progress</xsl:when>
-        <xsl:when test="$statusCode = 'cancelled' or 
-                        $statusCode = 'aborted'">cancelled</xsl:when>
-        <xsl:when test="$statusCode = 'suspended'">on-hold</xsl:when>
-        <xsl:when test="$statusCode = 'nullified' or 
-                        $statusCode = 'corrected'">entered-in-error</xsl:when>
-        <xsl:when test="$statusCode = 'new'">planned</xsl:when>
+        <xsl:when test="$cleanCode = 'completed' or 
+                        $cleanCode = 'normal'">finished</xsl:when>
+        <xsl:when test="$cleanCode = 'active'">in-progress</xsl:when>
+        <xsl:when test="$cleanCode = 'cancelled' or 
+                        $cleanCode = 'aborted'">cancelled</xsl:when>
+        <xsl:when test="$cleanCode = 'suspended'">on-hold</xsl:when>
+        <xsl:when test="$cleanCode = 'nullified' or 
+                        $cleanCode = 'corrected'">entered-in-error</xsl:when>
+        <xsl:when test="$cleanCode = 'new'">planned</xsl:when>
         <xsl:otherwise>unknown</xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter-epic.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter-epic.xslt
@@ -65,7 +65,6 @@
             <component>
                 <structuredBody>
                     <!-- Encounter -->
-                    <xsl:if test="not(hl7:componentOf/hl7:encompassingEncounter)">
                         <xsl:variable name="encounterEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='46240-8']]/hl7:entry[hl7:encounter]"/>
                         <xsl:if test="$encounterEntry">
                             <component>
@@ -76,8 +75,7 @@
                                 </section>
                             </component>
                         </xsl:if>
-                    </xsl:if>
-
+                    
                     <!-- Observations -->
                     <xsl:variable name="observations" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='29762-2']]/hl7:entry[
                         hl7:observation/hl7:entryRelationship/hl7:observation/hl7:entryRelationship/hl7:observation[

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1324,18 +1324,19 @@
     </xsl:choose>
 </xsl:template>
 
-<xsl:template name="mapEncounterStatus">
+<xsl:template name="mapEncounterStatus"> 
     <xsl:param name="statusCode"/>
+    <xsl:variable name="cleanCode" select="normalize-space(string($statusCode))"/>
     <xsl:choose>
-        <xsl:when test="$statusCode = 'completed' or 
-                        $statusCode = 'normal'">finished</xsl:when>
-        <xsl:when test="$statusCode = 'active'">in-progress</xsl:when>
-        <xsl:when test="$statusCode = 'cancelled' or 
-                        $statusCode = 'aborted'">cancelled</xsl:when>
-        <xsl:when test="$statusCode = 'suspended'">on-hold</xsl:when>
-        <xsl:when test="$statusCode = 'nullified' or 
-                        $statusCode = 'corrected'">entered-in-error</xsl:when>
-        <xsl:when test="$statusCode = 'new'">planned</xsl:when>
+        <xsl:when test="$cleanCode = 'completed' or 
+                        $cleanCode = 'normal'">finished</xsl:when>
+        <xsl:when test="$cleanCode = 'active'">in-progress</xsl:when>
+        <xsl:when test="$cleanCode = 'cancelled' or 
+                        $cleanCode = 'aborted'">cancelled</xsl:when>
+        <xsl:when test="$cleanCode = 'suspended'">on-hold</xsl:when>
+        <xsl:when test="$cleanCode = 'nullified' or 
+                        $cleanCode = 'corrected'">entered-in-error</xsl:when>
+        <xsl:when test="$cleanCode = 'new'">planned</xsl:when>
         <xsl:otherwise>unknown</xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/support/specifications/develop/ccda/cda-phi-filter-epic.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-epic.xslt
@@ -66,7 +66,6 @@
             <component>
                 <structuredBody>
                     <!-- Encounter -->
-                    <xsl:if test="not(hl7:componentOf/hl7:encompassingEncounter)">
                         <xsl:variable name="encounterEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='46240-8']]/hl7:entry[hl7:encounter]"/>
                         <xsl:if test="$encounterEntry">
                             <component>
@@ -77,8 +76,7 @@
                                 </section>
                             </component>
                         </xsl:if>
-                    </xsl:if>
-
+                    
                     <!-- Observations -->
                     <xsl:variable name="observations" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='29762-2']]/hl7:entry[
                         hl7:observation/hl7:entryRelationship/hl7:observation/hl7:entryRelationship/hl7:observation[


### PR DESCRIPTION
1. Updated xslt files to remove code for generating encounter resource from encounter section in Epic CCDA files to fix issue with encounter status.
2. Updated cda-phi-filter-epic.xslt file to add the encounter section along with encompasinf Encounter section, to take status from encounter section.
3. Updated xslt files to update the function for mapping the encounter status for FHIR codes (mapEncounterStatus) to exclude unwanted space.