### PR TITLE
feat: increase payload size limits and bump version to 0.683.0 #1894

### DIFF
--- a/nexus-ingestion-api/src/main/resources/application.yml
+++ b/nexus-ingestion-api/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 server:
   port: ${SERVER_PORT:8080}
-  max-http-request-size: ${MAX_HTTP_REQUEST_SIZE:10MB}
+  max-http-request-size: ${MAX_HTTP_REQUEST_SIZE:50MB}
   tomcat:
-    max-swallow-size: ${MAX_SWALLOW_SIZE:10MB}
-    max-http-form-post-size: ${MAX_HTTP_FORM_POST_SIZE:10MB}
+    max-swallow-size: ${MAX_SWALLOW_SIZE:50MB}
+    max-http-form-post-size: ${MAX_HTTP_FORM_POST_SIZE:50MB}
 org:
   techbd:
     aws:
@@ -30,8 +30,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: ${MULTIPART_FILE_SIZE:10MB}
-      max-request-size: ${MULTIPART_REQUEST_SIZE:10MB}
+      max-file-size: ${MULTIPART_FILE_SIZE:50MB}
+      max-request-size: ${MULTIPART_REQUEST_SIZE:50MB}
       file-size-threshold: 2MB
       resolve-lazily: true
 management:

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.682.0</revision>
+        <revision>0.683.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Update nexus-ingestion-api application.yml payload size limits from 10MB to 50MB:
  * max-http-request-size: 10MB → 50MB
  * max-swallow-size: 10MB → 50MB
  * max-http-form-post-size: 10MB → 50MB
  * max-file-size: 10MB → 50MB
  * max-request-size: 10MB → 50MB
- Bump parent POM version from 0.682.0 to 0.683.0
#1894