### PR TITLE
feat: prettify JSON download content under configurable size limit #1752

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/config/FileDownloadProperties.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/config/FileDownloadProperties.java
@@ -1,0 +1,28 @@
+package org.techbd.service.http.hub.prime.ux.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "org.techbd.service.http.hub.prime")
+public class FileDownloadProperties {
+    /**
+     * Maximum allowed file content size in MB for JSON pretty-printing (default 1MB).
+     */
+    private int maxDownloadJsonPrettyPrintSizeMB = 1;
+
+    public int getMaxDownloadJsonPrettyPrintSizeMB() {
+        return maxDownloadJsonPrettyPrintSizeMB;
+    }
+
+    public void setMaxDownloadJsonPrettyPrintSizeMB(int maxDownloadJsonPrettyPrintSizeMB) {
+        this.maxDownloadJsonPrettyPrintSizeMB = maxDownloadJsonPrettyPrintSizeMB;
+    }
+
+    /**
+     * Returns the max JSON pretty-print size in bytes.
+     */
+    public int getMaxDownloadJsonPrettyPrintSizeBytes() {
+        return maxDownloadJsonPrettyPrintSizeMB * 1024 * 1024;
+    }
+}

--- a/hub-prime/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/hub-prime/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -613,5 +613,10 @@
     "name": "org.techbd.service.http.hub.prime.dataLedgerApiKeySecretName",
     "type": "java.lang.String",
     "description": "A description for 'org.techbd.service.http.hub.prime.dataLedgerApiKeySecretName'"
+  },
+  {
+    "name": "org.techbd.service.http.hub.prime.maxDownloadJsonPrettyPrintSizeMB",
+    "type": "java.lang.String",
+    "description": "Maximum JSON file size (in MB) eligible for pretty-printing during download. JSON downloads smaller than this limit will be formatted for readability. Larger files will be returned as-is to avoid performance overhead."
   }
 ]}

--- a/hub-prime/src/main/resources/application.yml
+++ b/hub-prime/src/main/resources/application.yml
@@ -97,6 +97,7 @@ org:
           prime:
             version: @project.version@
             fhirVersion: r4
+            maxDownloadJsonPrettyPrintSizeMB: 1 # 1MB default, configurable for file download JSON pretty-print
         interactions:
           defaultPersistStrategy: "{ \"nature\": \"fs\" }"
           persist:

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.683.0</revision>
+        <revision>0.684.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Added support to prettify downloaded file content if it is JSON and smaller than 1 MB (configurable via `application.yml`).
- Ensures large JSON files are skipped to avoid performance overhead.