### PR TITLE
fix: update xslt file to remove duplicate entry of location resource for Epic CCDA files #1901

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -1994,7 +1994,7 @@
   
   <!-- Location Template from Encounters section -->
   <xsl:template name="EncountersLocationResource" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant/ccda:participantRole">
-  <xsl:if test="string($locationResourceId)">
+  <xsl:if test="not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location/ccda:healthCareFacility/ccda:location/ccda:name) and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -1994,7 +1994,7 @@
   
   <!-- Location Template from Encounters section -->
   <xsl:template name="EncountersLocationResource" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant/ccda:participantRole">
-  <xsl:if test="string($locationResourceId)">
+  <xsl:if test="not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location/ccda:healthCareFacility/ccda:location/ccda:name) and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {
@@ -2077,7 +2077,7 @@
     }
   </xsl:if>
   </xsl:template>
-  
+
   <xsl:template name="mapScreeningCodeDisplay">
     <xsl:param name="screeningCode"/>
     <xsl:choose>


### PR DESCRIPTION
Update xslt file to remove duplicate entry of location resource for Epic CCDA files