### PR TITLE
fix: ensure correct IG version is set in OperationOutcome during parallel validations #1832

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
@@ -546,6 +546,7 @@ public class OrchestrationEngine {
                     final var completedAt = Instant.now();
                     LOG.info("VALIDATOR -END completed at :{} ms for interactionId:{} with ig version :{}",
                             Duration.between(initiatedAt, completedAt).toMillis(), interactionId, igVersion);
+                    this.igVersion = bundleValidator.getIgVersion();  
                     return new OrchestrationEngine.ValidationResult() {
                         @Override
                         @JsonSerialize(using = JsonTextSerializer.class)


### PR DESCRIPTION
- Reassigned `this.igVersion` after `validateAsRawPayload(...)` to prevent stale or incorrect values
- Fixes issue where multiple IG bundle validations in parallel caused wrong version to appear in OperationOutcome