### PR TITLE
fix: resolve logger dependency test failures in nexus-core-lib and Bumped version to 0.694.0

### DIFF
--- a/nexus-core-lib/src/test/java/org/techbd/converter/csv/BaseConverterTest.java
+++ b/nexus-core-lib/src/test/java/org/techbd/converter/csv/BaseConverterTest.java
@@ -78,10 +78,10 @@ class BaseConverterTest {
 
         BaseConverter.SYSTEM_LOOKUP = systemLookup;
 
-        String result = baseConverter.fetchSystem("example", "category", "interactionId", null);
+        String result = baseConverter.fetchSystem("example", "defaultSystem", "category", "interactionId");
         assertEquals("mappedSystem", result);
 
-        result = baseConverter.fetchSystem("unknown", "category", "interactionId", null);
+        result = baseConverter.fetchSystem("unknown", "unknown", "category", "interactionId");
         assertEquals("unknown", result);
     }
     

--- a/nexus-core-lib/src/test/java/org/techbd/converter/csv/PatientConverterTest.java
+++ b/nexus-core-lib/src/test/java/org/techbd/converter/csv/PatientConverterTest.java
@@ -30,7 +30,12 @@ import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
 import org.techbd.service.csv.CodeLookupService;
+import org.techbd.util.AppLogger;
+import org.techbd.util.TemplateLogger;
 import org.techbd.util.fhir.CoreFHIRUtil;
+import org.techbd.config.CoreUdiPrimeJpaConfig;
+
+import static org.mockito.Mockito.when;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -41,12 +46,23 @@ class PatientConverterTest {
      
         @Mock
         CodeLookupService codeLookupService;
+        
+        @Mock
+        CoreUdiPrimeJpaConfig coreUdiPrimeJpaConfig;
+        
+        @Mock
+        AppLogger appLogger;
+        
+        @Mock
+        TemplateLogger templateLogger;
 
-        @InjectMocks
         private PatientConverter patientConverter;
 
         @BeforeEach
         void setUp() throws Exception {
+                when(appLogger.getLogger(PatientConverter.class)).thenReturn(templateLogger);
+                patientConverter = new PatientConverter(codeLookupService, coreUdiPrimeJpaConfig, appLogger);
+                
                 Field profileMapField = CoreFHIRUtil.class.getDeclaredField("PROFILE_MAP");
                 profileMapField.setAccessible(true);
                 profileMapField.set(null, CsvTestHelper.getProfileMap());

--- a/nexus-core-lib/src/test/java/org/techbd/converter/csv/ProcedureConverterTest.java
+++ b/nexus-core-lib/src/test/java/org/techbd/converter/csv/ProcedureConverterTest.java
@@ -22,14 +22,19 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.techbd.config.CoreUdiPrimeJpaConfig;
 import org.techbd.model.csv.DemographicData;
 import org.techbd.converters.csv.ProcedureConverter;
 import org.techbd.model.csv.QeAdminData;
 import org.techbd.model.csv.ScreeningObservationData;
 import org.techbd.model.csv.ScreeningProfileData;
 import org.techbd.service.csv.CodeLookupService;
+import org.techbd.util.AppLogger;
+import org.techbd.util.TemplateLogger;
 import org.techbd.util.fhir.CoreFHIRUtil;
 import org.techbd.util.csv.CsvConstants;
+
+import static org.mockito.Mockito.when;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -38,6 +43,15 @@ class ProcedureConverterTest {
 
     @Mock
     CodeLookupService codeLookupService;
+    
+    @Mock
+    CoreUdiPrimeJpaConfig coreUdiPrimeJpaConfig;
+    
+    @Mock
+    AppLogger appLogger;
+    
+    @Mock
+    TemplateLogger templateLogger;
 
     @InjectMocks
     private ProcedureConverter procedureConverter;
@@ -57,6 +71,7 @@ class ProcedureConverterTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        when(appLogger.getLogger(ProcedureConverter.class)).thenReturn(templateLogger);
         idsGenerated = new HashMap<>();
         baseFHIRUrl = "http://shinny.org/us/ny/hrsn";
 

--- a/nexus-core-lib/src/test/java/org/techbd/service/ccda/CCDAServiceTest.java
+++ b/nexus-core-lib/src/test/java/org/techbd/service/ccda/CCDAServiceTest.java
@@ -18,6 +18,7 @@ import org.techbd.config.CoreAppConfig;
 import org.techbd.config.CoreUdiPrimeJpaConfig;
 import org.techbd.udi.auto.jooq.ingress.routines.RegisterInteractionCcdaRequest;
 import org.techbd.util.AppLogger;
+import org.techbd.util.TemplateLogger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -28,6 +29,7 @@ class CCDAServiceTest {
     private Configuration jooqConfig;
     private CCDAService ccdaService;
     private AppLogger appLogger;
+    private TemplateLogger templateLogger;
     private CoreAppConfig coreAppConfig;
 
     @BeforeEach
@@ -36,7 +38,9 @@ class CCDAServiceTest {
         dslContext = mock(DSLContext.class);
         jooqConfig = mock(Configuration.class);
         appLogger = mock(AppLogger.class);
+        templateLogger = mock(TemplateLogger.class);
         coreAppConfig = mock(CoreAppConfig.class);
+        when(appLogger.getLogger(CCDAService.class)).thenReturn(templateLogger);
         when(coreUdiPrimeJpaConfig.dsl()).thenReturn(dslContext);
         when(dslContext.configuration()).thenReturn(jooqConfig);
         ccdaService = new CCDAService(coreUdiPrimeJpaConfig, appLogger, coreAppConfig);
@@ -52,7 +56,7 @@ class CCDAServiceTest {
                              })) {
 
             boolean result = ccdaService.saveOriginalCcdaPayload("int123", "tenantA",
-                    "/test-uri", "{\"payload\":\"data\"}", Map.of("status", "ok"));
+                    "/test-uri", "{\"payload\":\"data\"}", Map.of("status", "ok"), "test-source");
 
             assertTrue(result);
         }
@@ -68,7 +72,7 @@ class CCDAServiceTest {
                              })) {
 
             boolean result = ccdaService.saveValidation(true, "int123", "tenantA",
-                    "/test-uri", "{\"payload\":\"data\"}", Map.of("status", "ok"));
+                    "/test-uri", "{\"payload\":\"data\"}", Map.of("status", "ok"), "test-source");
 
             assertTrue(result);
         }
@@ -84,7 +88,7 @@ class CCDAServiceTest {
                              })) {
 
             boolean result = ccdaService.saveFhirConversionResult(true, "int123", "tenantA",
-                    "/test-uri", Map.of("fhir", "bundle"));
+                    "/test-uri", Map.of("fhir", "bundle"), "test-source");
 
             assertTrue(result);
         }
@@ -100,7 +104,7 @@ class CCDAServiceTest {
                              })) {
 
             boolean result = ccdaService.saveCcdaValidation(true, "int123", "tenantA",
-                    "/test-uri", "{\"payload\":\"data\"}", Map.of("status", "ok"));
+                    "/test-uri", "{\"payload\":\"data\"}", Map.of("status", "ok"), "test-source");
 
             assertTrue(result);
         }
@@ -113,7 +117,7 @@ class CCDAServiceTest {
 
         CCDAService errorService = new CCDAService(faultyConfig, appLogger,coreAppConfig);
 
-        boolean result = errorService.saveOriginalCcdaPayload("int123", "tenantA", "/uri", "{}", Map.of());
+        boolean result = errorService.saveOriginalCcdaPayload("int123", "tenantA", "/uri", "{}", Map.of(), "test-source");
 
         assertFalse(result);
     }

--- a/nexus-core-lib/src/test/java/org/techbd/service/dataledger/DataLedgerApiClientTest.java
+++ b/nexus-core-lib/src/test/java/org/techbd/service/dataledger/DataLedgerApiClientTest.java
@@ -26,6 +26,7 @@ import org.techbd.service.dataledger.CoreDataLedgerApiClient.Action;
 import org.techbd.service.dataledger.CoreDataLedgerApiClient.Actor;
 import org.techbd.service.dataledger.CoreDataLedgerApiClient.DataLedgerPayload;
 import org.techbd.util.AppLogger;
+import org.techbd.util.TemplateLogger;
 
 class DataLedgerApiClientTest {
 
@@ -39,12 +40,15 @@ class DataLedgerApiClientTest {
     private static HttpClient httpClient;
     private CoreDataLedgerApiClient coreDataLedgerApiClient;
     private static AppLogger appLogger;
+    private static TemplateLogger templateLogger;
 
     @BeforeAll
     static void init() {
         mockedHttpClient = mockStatic(HttpClient.class);
         httpClient = mock(HttpClient.class);
         appLogger = mock(AppLogger.class);
+        templateLogger = mock(TemplateLogger.class);
+        when(appLogger.getLogger(CoreDataLedgerApiClient.class)).thenReturn(templateLogger);
         mockedHttpClient.when(HttpClient::newHttpClient).thenReturn(httpClient);
     }
 

--- a/nexus-core-lib/src/test/java/org/techbd/service/fhir/BaseIgValidationTest.java
+++ b/nexus-core-lib/src/test/java/org/techbd/service/fhir/BaseIgValidationTest.java
@@ -12,7 +12,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.techbd.config.CoreAppConfig;
 import org.techbd.config.CoreAppConfig.FhirV4Config;
 import org.techbd.service.fhir.engine.OrchestrationEngine;
+import org.techbd.service.fhir.validation.PostPopulateSupport;
+import org.techbd.service.fhir.validation.PrePopulateSupport;
 import org.techbd.util.AppLogger;
+import org.techbd.util.TemplateLogger;
 import org.techbd.util.fhir.CoreFHIRUtil;
 
 import io.opentelemetry.api.trace.Span;
@@ -31,6 +34,8 @@ public abstract class BaseIgValidationTest {
     protected static Span span;
     
     private static AppLogger appLogger;
+    
+    private static TemplateLogger templateLogger;
 
     protected static OrchestrationEngine.HapiValidationEngine spyHapiEngine;
 
@@ -41,6 +46,10 @@ public abstract class BaseIgValidationTest {
         spanBuilder = mock(SpanBuilder.class);
         span = mock(Span.class);
         appLogger = mock(AppLogger.class);
+        templateLogger = mock(TemplateLogger.class);
+        when(appLogger.getLogger(OrchestrationEngine.class)).thenReturn(templateLogger);
+        when(appLogger.getLogger(PrePopulateSupport.class)).thenReturn(templateLogger);
+        when(appLogger.getLogger(PostPopulateSupport.class)).thenReturn(templateLogger);
         when(tracer.spanBuilder(anyString())).thenReturn(spanBuilder);
         when(spanBuilder.startSpan()).thenReturn(span);
         when(appConfig.getIgPackages()).thenReturn(getIgPackages());

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.693.0</revision>
+        <revision>0.694.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Fixed 24 test failures caused by null AppLogger/TemplateLogger dependencies.

Added proper mocks for AppLogger and TemplateLogger in all affected test classes:
- SexualOrientationObservationConverterTest
- ScreeningResponseObservationConverterTest
- ProcedureConverterTest
- OrganizationConverterTest
- EncounterConverterTest
- CCDAServiceTest
- DataLedgerApiClientTest
- BaseIgValidationTest