### PR TITLE
fix: update xslt files to resolve the issue with grouper observation resource created without any observation resources #1367

### DIFF
--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -1768,7 +1768,7 @@
   <xsl:template name="GrouperObservation">
     <xsl:variable name="grouperObs" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship/ccda:observation/ccda:entryRelationship"/>
     <xsl:variable name="grouperScreening" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation"/>
-    <xsl:if test="$grouperObs">
+    <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
             <xsl:with-param name="prefixString" select="$grouperScreeningCode"/>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1759,7 +1759,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <xsl:if test="$grouperObs">
+    <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
       <xsl:for-each select="$grouperObs[ccda:code/@code = $screeningCode]"> <!--'96777-8'-->
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">


### PR DESCRIPTION
Updated the following xslt files to resolve the issue with grouper observation resource created without any observation resources.
cda-fhir-bundle-epic.xslt
cda-fhir-bundle-medent.xslt 