### PR TITLE
fix: enhance state code handling in converters; added fetchCodeFromDisplay method for improved state resolution #1996

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/BaseConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/BaseConverter.java
@@ -77,6 +77,29 @@ public abstract class BaseConverter implements IConverter {
         return innerMap.getOrDefault(code, valueFromCsv);
     }
 
+    public String fetchCodeFromDisplay(String display, String category, String interactionId) {
+        if (DISPLAY_LOOKUP == null) {
+            final var dslContext = coreUdiPrimeJpaConfig.dsl();
+            BaseConverter.DISPLAY_LOOKUP = codeLookupService.fetchDisplay(dslContext, interactionId);
+        }
+
+        if (display == null || category == null) {
+            return null;
+        }
+        Map<String, String> innerMap = DISPLAY_LOOKUP.get(category);
+        if (innerMap == null) {
+            return null;
+        }
+
+        // Reverse lookup: find code for a given display
+        return innerMap.entrySet().stream()
+                .filter(e -> e.getValue().equalsIgnoreCase(display))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(null);
+    }
+
+
     public String getOmbRaceCategory(String ombCategoryCode, String interactionId) {
         return getCategoryType("ombRaceCategory", ombCategoryCode, interactionId);
     }

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/OrganizationConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/OrganizationConverter.java
@@ -166,14 +166,25 @@ public class OrganizationConverter extends BaseConverter {
             if (StringUtils.isNotEmpty(qrAdminData.getFacilityCity())) {
                 fullAddressText += ", " + qrAdminData.getFacilityCity();
             }
+            
             if (StringUtils.isNotEmpty(qrAdminData.getFacilityState())) {
-                if(qrAdminData.getFacilityState().equalsIgnoreCase("New York")) {
-                    address.setState("NY");
-                    fullAddressText += ", " + address.getState();
+                String originalValue = qrAdminData.getFacilityState();
+                String code = fetchCode(originalValue, CsvConstants.STATE, interactionId);
+
+                if (!code.equalsIgnoreCase(originalValue)) {
+                    address.setState(code);
                 } else {
-                    fullAddressText += ", " + fetchCode(qrAdminData.getFacilityState(), CsvConstants.STATE, interactionId);
+                    String codeFromDisplay = fetchCodeFromDisplay(originalValue, CsvConstants.STATE, interactionId);
+                    if (codeFromDisplay != null) {
+                        address.setState(codeFromDisplay);
+                    } else {
+                        address.setState(originalValue);
+                    }
                 }
+
+                fullAddressText += ", " + address.getState();
             }
+
             if (StringUtils.isNotEmpty(qrAdminData.getFacilityZip())) {
                 fullAddressText += " " + qrAdminData.getFacilityZip();
             }

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/PatientConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/PatientConverter.java
@@ -406,11 +406,21 @@ public class PatientConverter extends BaseConverter {
             .filter(StringUtils::isNotEmpty)
             .ifPresent(address::addLine);
             address.setCity(data.getCity());
-            if(data.getState().equalsIgnoreCase("New York")) {
-                address.setState("NY");
+
+            String originalValue = data.getState();
+            String code = fetchCode(originalValue, CsvConstants.STATE, interactionId);
+
+            if (!code.equalsIgnoreCase(originalValue)) {
+                address.setState(code);
             } else {
-                address.setState(fetchCode(data.getState(), CsvConstants.STATE, interactionId));
+                String codeFromDisplay = fetchCodeFromDisplay(originalValue, CsvConstants.STATE, interactionId);
+                if (codeFromDisplay != null) {
+                    address.setState(codeFromDisplay);
+                } else {
+                    address.setState(originalValue);
+                }
             }
+
             Optional.ofNullable(data.getCounty())
                     .filter(StringUtils::isNotEmpty)
                     .ifPresent(address::setDistrict);

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.705.0</revision>
+        <revision>0.706.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Removed hardcoded "New York" → "NY" mapping logic.  
- Updated state resolution to follow a three-step lookup:
  1. Attempt to resolve state using `fetchCode` (case-insensitive).  
  2. If result equals the original value (not found in DB), attempt a new `fetchCodeFromDisplay` method.  
  3. If no mapping exists, fall back to the original input.  

- Introduced `fetchCodeFromDisplay` method to resolve a code from a display value using DISPLAY_LOOKUP.  
- Ensured all lookups are case-insensitive to avoid issues with input variations.  
- This removes hardcoded state mappings and makes the logic fully data-driven via DB lookups.