### PR TITLE
fix: ensure original CCDA payload is displayed on validation failure of  CCDA Bundle Validate channel #1709

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-channel-files/nexus/CcdaBundleValidate.xml
+++ b/integration-artifacts/ccda/ccda-techbd-channel-files/nexus/CcdaBundleValidate.xml
@@ -1,17 +1,14 @@
 <channel version="4.5.3">
-  <id>4a538530-65ab-4b53-ab98-0eff0a1d075c</id>
+  <id>540b8010-424c-45c1-bca3-62f11e284491</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>CcdaBundleValidate</name>
-  <description>Version: 0.8.0</description>
-  <revision>9</revision>
+  <description>Version: 0.9.0</description>
+  <revision>15</revision>
   <sourceConnector version="4.5.3">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.5.3">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.5.3">
-  <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.5.3">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
@@ -33,6 +30,9 @@
           <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
           <truststoreUid/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.5.3">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="4.5.3">
         <host>0.0.0.0</host>
@@ -1781,6 +1781,10 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
             }
         };
 
+	// SUCCESS CASE - Save original payload and validation success
+        saveOriginalCcdaPayload(interactionId, tenantId, requestedPath, sourceXml, successResponse, FileName);  
+
+        
         // Replace spaces in specific patterns
         sourceXml = sourceXml.replace(/X-SDOH-FLO-1570000066-Patient unable to answer/g, &quot;X-SDOH-FLO-1570000066-Patient-unable-to-answer&quot;);
         sourceXml = sourceXml.replace(/X-SDOH-FLO-1570000066-Patient declined/g, &quot;X-SDOH-FLO-1570000066-Patient-declined&quot;);
@@ -1827,7 +1831,7 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
         validator.validate(xmlSource);
         
         // SUCCESS CASE - Save original payload and validation success
-        saveOriginalCcdaPayload(interactionId, tenantId, requestedPath, sourceXml, successResponse, FileName);
+       // saveOriginalCcdaPayload(interactionId, tenantId, requestedPath, sourceXml, successResponse, FileName);  
         saveValidationSuccess(interactionId, tenantId, requestedPath, sourceXml, successResponse, FileName);
         
         responseMap.put(&apos;status&apos;, &apos;200&apos;);     
@@ -1847,16 +1851,17 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
         var errorResponse = getJsonInvalidOperationOutcome(errorMsg, &quot;invalid&quot;);
 
         // Save original payload if we have it (this is the key fix)
-        if (sourceXml &amp;&amp; sourceXml.length &gt; 0) {
+        //if (sourceXml &amp;&amp; sourceXml.length &gt; 0) {
             try {
                 saveOriginalCcdaPayload(interactionId, tenantId, requestedPath, sourceXml, errorResponse, FileName);
+
                 logger.info(&quot;Successfully saved original CCDA payload for failed validation&quot;);
             } catch (saveError) {
                 logger.error(&quot;Failed to save original CCDA payload: &quot; + saveError.message);
             }
-        } else {
-            logger.warn(&quot;No source XML available to save for interactionId: &quot; + interactionId);
-        }
+//        } else {
+//            logger.warn(&quot;No source XML available to save for interactionId: &quot; + interactionId);
+//        }
 
         // Save validation failure
         try {
@@ -2310,7 +2315,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1758089694611</time>
+        <time>1758602140204</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -24,9 +24,9 @@
     {
       "type": "CCDA",
       "channel": "CcdaBundleValidate.xml",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "editedby": "jewelbonnie",
-      "date": "2025-09-17"
+      "date": "2025-09-23"
     },
     {
       "type": "FLAT FILE",


### PR DESCRIPTION
- ensure original CCDA payload is displayed on validation failure of  CCDA Bundle Validate channel
- update version.json for CCDA Bundle Validate channel