### PR TITLE
feat: create psql file to fill the validation errors for already ingested csv files #1912

### DIFF
--- a/udi-prime/src/main/postgres/ingestion-center/denormalize_data_integrity_errors.psql
+++ b/udi-prime/src/main/postgres/ingestion-center/denormalize_data_integrity_errors.psql
@@ -1,0 +1,72 @@
+
+-- Purpose: Back fill the 'data_integrity' errors into sat_csv_fhir_processing_errors table
+
+-- data_integrity errors
+INSERT INTO techbd_udi_ingress.sat_csv_fhir_processing_errors (
+            sat_validation_and_fhir_conversion_errors_id, category, flat_file_hub_interaction_id, created_at, tenant_id, uri, 
+            zip_file_hub_interaction_id, group_id, section, field_name, value, error_type, error_subtype, error, description, 
+            row_number, field_number, zip_file_name, file_name, origin, user_agent, created_by, provenance, techbd_version_number)
+    WITH latest_interactions AS (
+        SELECT hub_interaction_id
+        FROM (
+            SELECT DISTINCT r.hub_interaction_id, r.created_at
+            FROM techbd_udi_ingress.sat_interaction_flat_file_csv_request r
+            WHERE r.hub_interaction_id NOT IN (
+                SELECT e.flat_file_hub_interaction_id
+                FROM techbd_udi_ingress.sat_csv_fhir_processing_errors e
+                WHERE e.flat_file_hub_interaction_id IS NOT NULL
+            )
+            AND r.nature = 'CSV Validation Result'
+        ) t
+        ORDER BY t.created_at DESC
+    )
+    SELECT gen_random_uuid()::text,
+            'data_integrity',
+            req.hub_interaction_id, --flat_file_hub_interaction_id
+            req.created_at,
+            tenant_id,
+            uri,
+            zip_file_hub_interaction_id,
+            group_id,
+            tasks.value ->> 'name' AS section,
+            coalesce(error_payload.value ->> 'fieldName',
+                    errors_summary.value ->> 'fieldName') AS field_name,
+            error_payload.value ->> 'cell' AS value,
+            coalesce(error_payload.value ->> 'title',
+                    errors_summary.value ->> 'type') AS error_type,
+            NULL,
+            coalesce(error_payload.value ->> 'message',
+                    errors_summary.value ->> 'message') AS error,
+            error_payload.value ->> 'description' AS description,
+            (error_payload.value ->> 'rowNumber')::integer AS row_number,
+            (error_payload.value ->> 'fieldNumber')::integer AS field_number,
+            NULL,
+            CASE
+                WHEN tasks.value ->> 'name' = 'qe_admin_data' THEN qe_admin_data_file_name
+                WHEN tasks.value ->> 'name' = 'demographic_data' THEN demographic_data_file_name
+                WHEN tasks.value ->> 'name' = 'screening_observation_data' THEN screening_observation_data_file_name
+                WHEN tasks.value ->> 'name' = 'screening_profile_data' THEN screening_profile_data_file_name
+                ELSE NULL
+            END AS file_name,
+            NULL,
+            user_agent, 
+            CURRENT_USER, 
+            'CSV', 
+            techbd_version_number 
+    FROM latest_interactions li
+    JOIN techbd_udi_ingress.sat_interaction_flat_file_csv_request req
+        ON req.hub_interaction_id = li.hub_interaction_id
+    CROSS JOIN LATERAL jsonb_array_elements(((validation_result_payload -> 'validationResults') -> 'report') -> 'tasks') tasks(value)
+    LEFT JOIN LATERAL jsonb_array_elements(tasks.value -> 'errors') error_payload(value) ON true
+    LEFT JOIN LATERAL jsonb_array_elements((validation_result_payload -> 'validationResults') -> 'errorsSummary') errors_summary(value) ON true
+    WHERE nature = 'CSV Validation Result'
+        AND (
+            ((((validation_result_payload -> 'validationResults') -> 'report') -> 'stats') ->> 'errors')::integer > 0
+            OR jsonb_array_length((validation_result_payload -> 'validationResults') -> 'errorsSummary') > 0
+            )
+        AND coalesce(error_payload.value ->> 'title', errors_summary.value ->> 'type') IS NOT NULL;
+
+
+
+
+--SELECT count(*) AS data_integrity_errors FROM techbd_udi_ingress.sat_csv_fhir_processing_errors WHERE category = 'data_integrity';

--- a/udi-prime/src/main/postgres/ingestion-center/denormalize_errors.md
+++ b/udi-prime/src/main/postgres/ingestion-center/denormalize_errors.md
@@ -1,0 +1,31 @@
+# Denormalize the validation errors
+
+This repository contains the SQL scripts `denormalize_validation_errors.psql` and `denormalize_data_integrity_errors.psql` located in `udi-prime/src/main/postgres/ingestion-center/`.  
+
+The purpose of these scripts is to fill the `file not processed`, `incomplete groups` and `data_integrity` errors into `sat_csv_fhir_processing_errors` table for interactions that have already been ingested, in order to improve query performance.
+
+## Instructions
+
+### Prerequisites
+1. Ensure you have PostgreSQL installed.
+2. You must have access to the `psql` command-line tool.
+3. The target database must contain the `techbd_udi_ingress` schema and its associated tables.
+4. The `sat_csv_fhir_processing_errors` table should be there in the `techbd_udi_ingress` schema. 
+
+### Step 1: cd to the file location
+Navigate to the directory containing the script:
+```bash
+cd udi-prime/src/main/postgres/ingestion-center
+```
+
+### Step 2: Execute the SQL File (denormalize_validation_errors.psql) to insert `file not processed` and `incomplete groups` errors
+Run the SQL script to fill the error details into the table:
+```bash
+psql -h <hostname> -U <admin_user> -d <database_name> -f denormalize_validation_errors.psql
+```
+
+### Step 3: Execute the SQL File (denormalize_data_integrity_errors.psql) to insert `data_integrity` errors
+Run the SQL script to fill the error details into the table:
+```bash
+psql -h <hostname> -U <admin_user> -d <database_name> -f denormalize_data_integrity_errors.psql
+```

--- a/udi-prime/src/main/postgres/ingestion-center/denormalize_validation_errors.psql
+++ b/udi-prime/src/main/postgres/ingestion-center/denormalize_validation_errors.psql
@@ -1,0 +1,107 @@
+
+-- Purpose: Back fill the 'file not processed' and 'incomplete groups' validation errors into sat_csv_fhir_processing_errors table
+
+-- File Not Processed Errors
+INSERT INTO techbd_udi_ingress.sat_csv_fhir_processing_errors (
+            sat_validation_and_fhir_conversion_errors_id, category, flat_file_hub_interaction_id, created_at, tenant_id, uri, 
+            zip_file_hub_interaction_id, group_id, section, field_name, value, error_type, error_subtype, error, description, 
+            row_number, field_number, zip_file_name, file_name, origin, user_agent, created_by, provenance, techbd_version_number)
+    WITH latest_interactions AS (
+        SELECT hub_interaction_id        
+        FROM techbd_udi_ingress.sat_interaction_zip_file_request
+        WHERE hub_interaction_id NOT IN (
+            SELECT zip_file_hub_interaction_id
+            FROM techbd_udi_ingress.sat_csv_fhir_processing_errors
+        )
+        ORDER BY created_at DESC 
+    )
+    SELECT 
+        gen_random_uuid()::text AS id,
+        'file_not_processed' AS category,
+        NULL::uuid AS flat_file_hub_interaction_id,
+        req.created_at,
+        req.tenant_id,
+        req.uri,
+        req.hub_interaction_id AS zip_file_hub_interaction_id,
+        req.group_id,
+        NULL AS extra1,
+        NULL AS extra2,
+        NULL AS extra3,
+        issue.value ->> 'type'        AS error_type,
+        issue.value ->> 'subType'     AS error_subtype,
+        issue.value ->> 'reason'      AS error,
+        issue.value ->> 'description' AS description,
+        NULL AS extra4,
+        NULL AS extra5,
+        req.csv_zip_file_name,
+        file_name.value               AS file_name,
+        req.origin,
+        req.user_agent,
+        CURRENT_USER                  AS created_by,
+        'CSV'                         AS source_type,
+        req.techbd_version_number
+    FROM latest_interactions li
+    JOIN techbd_udi_ingress.sat_interaction_zip_file_request req
+        ON req.hub_interaction_id = li.hub_interaction_id
+    CROSS JOIN LATERAL jsonb_array_elements(COALESCE(req.general_errors, '[]'::jsonb)) AS general_error(value)
+    CROSS JOIN LATERAL jsonb_array_elements(general_error.value -> 'validationResults' -> 'errors') AS issue(value)
+    CROSS JOIN LATERAL jsonb_array_elements_text(issue.value -> 'files') AS file_name(value);
+
+
+		
+-- incomplete_groups errors
+INSERT INTO techbd_udi_ingress.sat_csv_fhir_processing_errors (
+            sat_validation_and_fhir_conversion_errors_id, category, flat_file_hub_interaction_id, created_at, tenant_id, uri, 
+            zip_file_hub_interaction_id, group_id, section, field_name, value, error_type, error_subtype, error, description, 
+            row_number, field_number, zip_file_name, file_name, origin, user_agent, created_by, provenance, techbd_version_number)
+    WITH latest_interactions AS (
+        SELECT hub_interaction_id        
+        FROM techbd_udi_ingress.sat_interaction_flat_file_csv_request
+        WHERE hub_interaction_id NOT IN (
+            SELECT flat_file_hub_interaction_id
+            FROM techbd_udi_ingress.sat_csv_fhir_processing_errors
+        )
+        AND (nature = 'CSV Validation Result' OR nature = 'Converted to FHIR')
+        ORDER BY created_at DESC
+    )
+    SELECT  
+        gen_random_uuid()::text,
+        'incomplete_groups',
+        req.hub_interaction_id, -- flat_file_hub_interaction_id
+        req.created_at,
+        req.tenant_id,
+        req.uri,
+        req.zip_file_hub_interaction_id,
+        req.group_id,
+        NULL,
+        NULL,
+        NULL,
+        error_payload.value ->> 'type'        AS error_type,
+        NULL                                  AS error_subtype,
+        error_payload.value ->> 'message'     AS error,
+        error_payload.value ->> 'description' AS description,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL, 
+        req.user_agent, 
+        CURRENT_USER, 
+        'CSV', 
+        req.techbd_version_number
+    FROM latest_interactions li
+    JOIN techbd_udi_ingress.sat_interaction_flat_file_csv_request req
+        ON req.hub_interaction_id = li.hub_interaction_id
+    CROSS JOIN LATERAL jsonb_array_elements(
+        (req.validation_result_payload -> 'validationResults') -> 'errors'
+    ) AS error_payload(value)
+    WHERE (req.nature = 'CSV Validation Result' OR req.nature = 'Converted to FHIR')
+        AND jsonb_array_length(
+            COALESCE((req.validation_result_payload -> 'validationResults') -> 'errors', '[]'::jsonb)
+            ) > 0;
+
+
+
+
+--SELECT count(*) AS file_not_processed_errors FROM techbd_udi_ingress.sat_csv_fhir_processing_errors WHERE category = 'file_not_processed';
+--SELECT count(*) AS incomplete_groups_errors FROM techbd_udi_ingress.sat_csv_fhir_processing_errors WHERE category = 'incomplete_groups';


### PR DESCRIPTION
- added denormalize_validation_errors.psql file to fill the 'file not processed' and 'incomplete groups' errors into `sat_csv_fhir_processing_errors` table.
- added denormalize_data_integrity_errors.psql file to fill the data_integrity errors into `sat_csv_fhir_processing_errors` table.
- added denormalize_errors.md file for the instructions to execute the psql files.