### PR TITLE
feat: update fhir count in zip file request table #1912

### DIFF
--- a/udi-prime/src/main/postgres/ingestion-center/update_fhir_and_file_counts_in_zip_interaction_table.md
+++ b/udi-prime/src/main/postgres/ingestion-center/update_fhir_and_file_counts_in_zip_interaction_table.md
@@ -1,0 +1,25 @@
+# Update file and FHIR counts into sat_interaction_zip_file_request table
+
+This repository contains the SQL script `update_fhir_count.psql` located in `udi-prime/src/main/postgres/ingestion-center/`.  
+
+The purpose of this script is to fill the `number_of_fhir_bundles_generated_from_zip_file` column into `sat_interaction_zip_file_request` table for showing the `FHIR count` in `CSV via HTTPs` page.
+
+## Instructions
+
+### Prerequisites
+1. Ensure you have PostgreSQL installed.
+2. You must have access to the `psql` command-line tool.
+3. The target database must contain the `techbd_udi_ingress` schema and its associated tables.
+4. The `sat_interaction_zip_file_request` table should be there in the `techbd_udi_ingress` schema. 
+
+### Step 1: cd to the file location
+Navigate to the directory containing the script:
+```bash
+cd udi-prime/src/main/postgres/ingestion-center
+```
+
+### Step 2: Execute the SQL File (update_fhir_count.psql) to fill the `number_of_fhir_bundles_generated_from_zip_file` column
+Run the SQL script to fill the error details into the table:
+```bash
+psql -h <hostname> -U <admin_user> -d <database_name> -f update_fhir_count.psql
+```

--- a/udi-prime/src/main/postgres/ingestion-center/update_fhir_count.psql
+++ b/udi-prime/src/main/postgres/ingestion-center/update_fhir_count.psql
@@ -1,0 +1,23 @@
+
+-- Purpose: Back fill the 'number_of_fhir_bundles_generated_from_zip_file' value into `sat_interaction_zip_file_request` table
+
+-- File Not Processed Errors
+WITH fhir_bundle_counts AS (
+    SELECT 
+        source_hub_interaction_id AS hub_interaction_id,
+        COUNT(DISTINCT hub_interaction_id) AS fhir_bundle_count
+    FROM techbd_udi_ingress.sat_interaction_fhir_request
+    WHERE source_type = 'CSV' AND nature = 'Original FHIR Payload'
+    GROUP BY source_hub_interaction_id
+)
+UPDATE techbd_udi_ingress.sat_interaction_zip_file_request zip
+SET number_of_fhir_bundles_generated_from_zip_file = COALESCE(fhir_bundle_counts.fhir_bundle_count, 0)
+FROM fhir_bundle_counts
+WHERE zip.hub_interaction_id = fhir_bundle_counts.hub_interaction_id
+  AND zip.number_of_fhir_bundles_generated_from_zip_file IS NULL OR zip.number_of_fhir_bundles_generated_from_zip_file = 0;
+
+-- SELECT count(*) FROM techbd_udi_ingress.sat_interaction_zip_file_request WHERE number_of_fhir_bundles_generated_from_zip_file IS NOT NULL;
+
+UPDATE techbd_udi_ingress.sat_interaction_zip_file_request 
+SET number_of_fhir_bundles_generated_from_zip_file = 0
+WHERE number_of_fhir_bundles_generated_from_zip_file IS NULL;


### PR DESCRIPTION
- added update_fhir_count.psql file to fill the `number_of_fhir_bundles_generated_from_zip_file` column into `sat_interaction_zip_file_request` table for showing the `FHIR count` in `CSV via HTTPs` page.
- added update_fhir_and_file_counts_in_zip_interaction_table.md file for the instructions to execute the psql files.
