### PR TITLE
fix: update xslt files to fix issue in CCDA FHIR Bundles because of the nullFlavor in streetAddressLine element of address tag #1367

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.1 -->
+<!-- Version : 0.1.2 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -203,19 +203,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -949,19 +960,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -1934,19 +1956,30 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:streetAddressLine) or string(ccda:addr/ccda:city) or string(ccda:addr/ccda:state) or string(ccda:addr/ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:addr/ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:state)">, <xsl:value-of select="ccda:addr/ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -2020,19 +2053,30 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:streetAddressLine) or string(ccda:addr/ccda:city) or string(ccda:addr/ccda:state) or string(ccda:addr/ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:addr/ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:state)">, <xsl:value-of select="ccda:addr/ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -2077,7 +2121,7 @@
     }
   </xsl:if>
   </xsl:template>
-  
+
   <xsl:template name="mapScreeningCodeDisplay">
     <xsl:param name="screeningCode"/>
     <xsl:choose>

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.1 -->
+<!-- Version : 0.1.2 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -193,19 +193,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -829,19 +840,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -1659,19 +1681,30 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:streetAddressLine) or string(ccda:addr/ccda:city) or string(ccda:addr/ccda:state) or string(ccda:addr/ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:addr/ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:state)">, <xsl:value-of select="ccda:addr/ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.1 -->
+<!-- Version : 0.1.2 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -203,19 +203,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -949,19 +960,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -1934,19 +1956,30 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:streetAddressLine) or string(ccda:addr/ccda:city) or string(ccda:addr/ccda:state) or string(ccda:addr/ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:addr/ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:state)">, <xsl:value-of select="ccda:addr/ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -2020,19 +2053,30 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:streetAddressLine) or string(ccda:addr/ccda:city) or string(ccda:addr/ccda:state) or string(ccda:addr/ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:addr/ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:state)">, <xsl:value-of select="ccda:addr/ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.1 -->
+<!-- Version : 0.1.2 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -193,19 +193,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -829,19 +840,30 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:streetAddressLine) or string(ccda:city) or string(ccda:state) or string(ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:state)">, <xsl:value-of select="ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]
@@ -1659,19 +1681,30 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>",
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:streetAddressLine) or string(ccda:addr/ccda:city) or string(ccda:addr/ccda:state) or string(ccda:addr/ccda:postalCode)">
-                            "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                  <xsl:value-of select="."/>
-                                  <xsl:if test="position() != last()">, </xsl:if>
-                              </xsl:for-each>
-                              <xsl:if test="string(ccda:addr/ccda:city)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:city"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:state)">, <xsl:value-of select="ccda:addr/ccda:state"/></xsl:if>
-                              <xsl:if test="string(ccda:addr/ccda:postalCode)"> <xsl:text> </xsl:text><xsl:value-of select="ccda:addr/ccda:postalCode"/></xsl:if>" ,
+                        <xsl:if test="
+                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
+                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
+                        ">
+                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:value-of select="normalize-space(.)"/>
+                                          <xsl:if test="position() != last()">, </xsl:if>
+                                      </xsl:for-each>
+                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
+                                      </xsl:if>
+                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
+                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
+                                      </xsl:if>"
                         </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
+                        <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                            , "line": [
+                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+                                    "<xsl:value-of select="normalize-space(.)"/>"
                                     <xsl:if test="position() != last()">, </xsl:if>
                                 </xsl:for-each>
                             ]


### PR DESCRIPTION
- Updated the following xslt files to fix issue in CCDA FHIR Bundles because of the nullFlavor in streetAddressLine element of address tag in Patient, Organization and Location resources.
1. cda-fhir-bundle-epic.xslt
2. cda-fhir-bundle-medent.xslt
 - Updated the files in develop and integration artifacts folder.