### PR TITLE
chore: remove logging for health check endpoints #2091

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/SecurityConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // Publicly permitted endpoints
 
-                        .requestMatchers(HttpMethod.GET, "/actuator/health/mllp").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/actuator/health/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/").permitAll()
                         .requestMatchers(HttpMethod.HEAD, "/").permitAll()
                         .requestMatchers(HttpMethod.POST, "/ingest").permitAll()

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
@@ -57,7 +57,6 @@ public class DataIngestionController extends AbstractMessageSourceProvider {
     @RequestMapping(value = "/", method = RequestMethod.GET)
     public ResponseEntity<Void> healthCheck() {
         try {
-            LOG.info("Health check requested via HEAD /ingest");
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             LOG.error("Health check failed", e);

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
@@ -26,16 +26,19 @@ public class InteractionsFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(final HttpServletRequest origRequest, final HttpServletResponse origResponse,
                                     final FilterChain chain) throws IOException, ServletException {
-        String interactionId = UUID.randomUUID().toString();
-        origRequest.setAttribute("interactionId", interactionId);
-        LOG.info("Incoming Request - interactionId={}", interactionId);
+        if (FeatureEnum.isEnabled(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)
+                && !origRequest.getRequestURI().equals("/")
+                && !origRequest.getRequestURI().startsWith("/actuator/health")) {
+            String interactionId = UUID.randomUUID().toString();
+            origRequest.setAttribute("interactionId", interactionId);
+            LOG.info("Incoming Request - interactionId={}", interactionId);
 
-        if (FeatureEnum.isEnabled(FeatureEnum.DEBUG_LOG_REQUEST_HEADERS)) {
             var headerNames = origRequest.getHeaderNames();
             while (headerNames.hasMoreElements()) {
                 var headerName = headerNames.nextElement();
                 var headerValue = origRequest.getHeader(headerName);
-                LOG.info("{} - Header: {} = {} for interaction id: {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS, headerName, headerValue, interactionId);
+                LOG.info("{} - Header: {} = {} for interaction id: {}", FeatureEnum.DEBUG_LOG_REQUEST_HEADERS,
+                        headerName, headerValue, interactionId);
             }
         }
         chain.doFilter(origRequest, origResponse);

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.740.0</revision>
+        <revision>0.741.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Remove health check logs
- Allow /actuator/health endpoint
- Do not create interaction ID for health check requests