### PR TITLE
fix: generate response based on soap protocol version of incoming request #1705

### DIFF
--- a/nexus-ingestion-api/pom.xml
+++ b/nexus-ingestion-api/pom.xml
@@ -190,6 +190,11 @@
             <artifactId>togglz-spring-web</artifactId> 
             <version>4.4.0</version> 
         </dependency> 
+        <dependency>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
+            <version>1.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.741.0</revision>
+        <revision>0.742.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Replaced explicit SOAP 1.1 / 1.2 protocol selection with `SOAPConstants.DYNAMIC_SOAP_PROTOCOL` for both MTOM multipart and regular SOAP request
- Generate response based on incoming request SOAP protocol