### PR TITLE
fix(soap): properly handle WS-Addressing <wsa:Action> mustUnderstand header #1705

### DIFF
--- a/nexus-ingestion-api/.envrc.example
+++ b/nexus-ingestion-api/.envrc.example
@@ -10,3 +10,4 @@ export HOLD_S3_BUCKET_NAME=s3://local-hold-bucket
 export AWS_S3_METADATA_BUCKET_NAME=local-metadata-bucket
 export AWS_SQS_QUEUE_NAME=http://localhost:4566/000000000000/local-queue.fifo
 export HL7_MLLP_PORTS=2575,2576-2580
+export UNDERSTOOD_NAMESPACES="http://www.w3.org/2005/08/addressing"

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/AppConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/AppConfig.java
@@ -54,6 +54,7 @@ public class AppConfig {
             private String prefix;
             private String action;
             private String to;
+            private String understoodNamespaces;
         }
 
         @Data

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/WebServiceConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/WebServiceConfig.java
@@ -26,6 +26,7 @@ import org.springframework.xml.xsd.SimpleXsdSchema;
 import org.springframework.xml.xsd.XsdSchema;
 import org.techbd.ingest.interceptors.WsaHeaderInterceptor;
 import org.techbd.ingest.service.MessageProcessorService;
+import org.techbd.ingest.util.AppLogger;
 import org.techbd.ingest.util.SoapResponseUtil;
 
 import jakarta.xml.soap.MessageFactory;
@@ -39,16 +40,18 @@ public class WebServiceConfig extends WsConfigurationSupport {
     private final SoapResponseUtil soapResponseUtil;
     private final MessageProcessorService messageProcessorService;
     private final AppConfig appConfig;
+    private final AppLogger LOG;
 
-    public WebServiceConfig(SoapResponseUtil soapResponseUtil, MessageProcessorService messageProcessorService, AppConfig appConfig) {
+    public WebServiceConfig(SoapResponseUtil soapResponseUtil, MessageProcessorService messageProcessorService, AppConfig appConfig, AppLogger appLogger) {
         this.soapResponseUtil = soapResponseUtil;
         this.messageProcessorService = messageProcessorService;
         this.appConfig = appConfig;
+        this.LOG = appLogger;
     }
 
     @Override
     protected void addInterceptors(List<EndpointInterceptor> interceptors) {
-        interceptors.add(new WsaHeaderInterceptor(soapResponseUtil, messageProcessorService, appConfig));
+        interceptors.add(new WsaHeaderInterceptor(soapResponseUtil, messageProcessorService, appConfig,LOG));
     }
 
     @Bean

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
@@ -2,62 +2,119 @@ package org.techbd.ingest.interceptors;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.server.EndpointInterceptor;
+import org.springframework.ws.soap.SoapHeaderElement;
 import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.server.SoapEndpointInterceptor;
 import org.springframework.ws.transport.context.TransportContextHolder;
 import org.springframework.ws.transport.http.HttpServletConnection;
 import org.techbd.ingest.commons.Constants;
 import org.techbd.ingest.config.AppConfig;
 import org.techbd.ingest.model.RequestContext;
 import org.techbd.ingest.service.MessageProcessorService;
+import org.techbd.ingest.util.AppLogger;
 import org.techbd.ingest.util.Hl7Util;
 import org.techbd.ingest.util.SoapResponseUtil;
-
+import org.techbd.ingest.util.TemplateLogger;
 import jakarta.servlet.http.HttpServletRequest;
 
-public class WsaHeaderInterceptor implements EndpointInterceptor {
+public class WsaHeaderInterceptor implements EndpointInterceptor, SoapEndpointInterceptor {
 
     private final SoapResponseUtil soapResponseUtil;
     private final MessageProcessorService messageProcessorService;
     private final AppConfig appConfig;
-    
-    public WsaHeaderInterceptor(SoapResponseUtil soapResponseUtil, MessageProcessorService messageProcessorService, AppConfig appConfig) {
+    private final TemplateLogger LOG;
+
+    public WsaHeaderInterceptor(SoapResponseUtil soapResponseUtil,
+                                MessageProcessorService messageProcessorService,
+                                AppConfig appConfig,
+                                AppLogger appLogger) {
         this.soapResponseUtil = soapResponseUtil;
         this.messageProcessorService = messageProcessorService;
         this.appConfig = appConfig;
+        this.LOG = appLogger.getLogger(WsaHeaderInterceptor.class);
     }
+
     @Override
     public boolean handleRequest(MessageContext messageContext, Object endpoint) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         messageContext.getRequest().writeTo(out);
         String soapXml = out.toString(StandardCharsets.UTF_8);
         messageContext.setProperty(Constants.RAW_SOAP_ATTRIBUTE, soapXml);
+
+        String interactionId = (String) messageContext.getProperty(Constants.INTERACTION_ID);
+        LOG.info("handleRequest: Captured SOAP request. interactionId={}, payload={}", interactionId, soapXml);
+
         return true;
     }
 
     @Override
     public boolean handleResponse(MessageContext messageContext, Object endpoint) throws Exception {
-         var transportContext = TransportContextHolder.getTransportContext();
+        var transportContext = TransportContextHolder.getTransportContext();
         var connection = (HttpServletConnection) transportContext.getConnection();
         HttpServletRequest httpRequest = connection.getHttpServletRequest();
         String interactionId = (String) httpRequest.getAttribute(Constants.INTERACTION_ID);
+
         SoapMessage message = soapResponseUtil.buildSoapResponse(interactionId, messageContext);
         RequestContext context = (RequestContext) httpRequest.getAttribute(Constants.REQUEST_CONTEXT);
         String rawSoapMessage = (String) messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE);
-        messageProcessorService.processMessage(context, rawSoapMessage,Hl7Util.soapMessageToString(message, interactionId));
+
+        messageContext.setProperty(Constants.INTERACTION_ID, interactionId);
+        LOG.info("handleResponse: Processing SOAP response. interactionId={}", interactionId);
+
+        messageProcessorService.processMessage(context, rawSoapMessage,
+                Hl7Util.soapMessageToString(message, interactionId));
+
         return true;
     }
 
     @Override
     public boolean handleFault(MessageContext messageContext, Object endpoint) throws Exception {
-        // Optionally modify fault responses
-        return true;
+        String interactionId = (String) messageContext.getProperty(Constants.INTERACTION_ID);
+
+        try {
+            SoapMessage faultMessage = (SoapMessage) messageContext.getResponse();
+            if (faultMessage != null) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                faultMessage.writeTo(out);
+                String faultXml = out.toString(StandardCharsets.UTF_8);
+                LOG.error("handleFault: SOAP Fault encountered. interactionId={}, fault={}", interactionId, faultXml);
+            }
+        } catch (Exception e) {
+            LOG.error("handleFault: Exception while processing SOAP fault. interactionId={}, error={}", 
+                      interactionId, e.getMessage(), e);
+        }
+
+        return true; // continue interceptor chain
     }
 
     @Override
     public void afterCompletion(MessageContext messageContext, Object endpoint, Exception ex) throws Exception {
-        // Optional cleanup
+        String interactionId = (String) messageContext.getProperty(Constants.INTERACTION_ID);
+        String status = (ex == null) ? "SUCCESS" : "FAILURE";
+
+        if (ex != null) {
+            LOG.error(
+                    "afterCompletion: SOAP interaction completed with ERROR. interactionId={}, errorMessage={}, stackTrace={}",
+                    interactionId, ex.getMessage(), ex);
+        } else {
+            LOG.info("afterCompletion: SOAP interaction completed. interactionId={}, status={}", interactionId, status);
+        }
+    }
+
+    @Override
+    public boolean understands(SoapHeaderElement header) {
+        String namespaces = appConfig.getSoap().getWsa().getUnderstoodNamespaces();
+        if (namespaces == null || namespaces.isEmpty()) {
+            return false;
+        }
+        Set<String> namespaceSet = Arrays.stream(namespaces.split(","))
+                                         .map(String::trim)
+                                         .collect(Collectors.toSet());
+        return namespaceSet.contains(header.getName().getNamespaceURI());
     }
 }

--- a/nexus-ingestion-api/src/main/resources/application.yml
+++ b/nexus-ingestion-api/src/main/resources/application.yml
@@ -26,6 +26,7 @@ org:
         prefix: "wsa"
         action: "urn:hl7-org:v3:MCCI_IN000002UV01"
         to: "http://www.w3.org/2005/08/addressing/anonymous"
+        understood-namespaces: ${UNDERSTOOD_NAMESPACES:http://www.w3.org/2005/08/addressing}
       techbd:
         namespace: "urn:techbd:custom"
         prefix: "techbd"    

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <revision>0.744.0</revision>
+        <revision>0.745.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- The <wsa:Action> element (namespace: http://www.w3.org/2005/08/addressing) is required and marked mustUnderstand="true" in SOAP messages for IHE ITI-41 (ProvideAndRegisterDocumentSet-b) transactions.
- Previously, the service returned a MustUnderstand fault because this header was not recognized.
- Updated WsaHeaderInterceptor to support multiple understood namespaces via a configurable list.
- WS-Addressing headers are now correctly processed, preventing   unnecessary MustUnderstand faults.
- The list of understood namespaces can be configured via the environment variable:
  `export UNDERSTOOD_NAMESPACES=http://www.w3.org/2005/08/addressing