### PR TITLE
refactor(fhir-validation-service): return disposition payload for $validate requests #2055

### DIFF
--- a/fhir-validation-service/src/main/java/org/techbd/fhir/service/FHIRService.java
+++ b/fhir-validation-service/src/main/java/org/techbd/fhir/service/FHIRService.java
@@ -206,7 +206,7 @@ public class FHIRService {
 				}
                 if (StringUtils.isNotEmpty(requestUri)
                         && (requestUri.equals("/Bundle/$validate") || requestUri.equals("/Bundle/$validate/"))) {
-                    return result;
+                    return payloadWithDisposition;
                 }
 
                 if ("true".equalsIgnoreCase(healthCheck != null ? healthCheck.trim() : null)) {


### PR DESCRIPTION
change  return value in processBundle method (in FHIRService.java) to return payloadWithDisposition instead of result for /Bundle/$validate and /Bundle/$validate/ requests. This ensures that validation responses include any disposition data captured during FHIR bundle processing.