### PR TITLE
fix: correct baseFHIRURL for SHIN-NY QA config in nexus-core-lib #2305

### DIFF
--- a/nexus-core-lib/src/main/resources/nexus-core-lib/application.yml
+++ b/nexus-core-lib/src/main/resources/nexus-core-lib/application.yml
@@ -54,7 +54,7 @@ org:
           us-core: ig-packages/fhir-v4/us-core/stu-7.0.0
           sdoh: ig-packages/fhir-v4/sdoh-clinicalcare/stu-2.2.0
           uv-sdc: ig-packages/fhir-v4/uv-sdc/stu-3.0.0
-    baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+    baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
     validation-severity-level: error  # Possible values: fatal, error, warning, information
     structureDefinitionsUrls:
       bundle: /StructureDefinition/SHINNYBundleProfile


### PR DESCRIPTION
- Updated `baseFHIRURL` in `application.yml` from `http://shinny.org/us/ny/hrsn` to `http://test.shinny.org/us/ny/hrsn`