### PR TITLE
fix: exclude the unused index (ccda_replay_details_bundle_id_key) due to unique key assosiation

### DIFF
--- a/udi-prime/src/main/postgres/ingestion-center/add_performance_indexes.psql
+++ b/udi-prime/src/main/postgres/ingestion-center/add_performance_indexes.psql
@@ -496,16 +496,8 @@ PERFORM pg_advisory_lock(hashtext('perfomance_index'));
                 AND indexname = 'ccda_replay_details_bundle_id_idx'
             ) THEN
               DROP INDEX techbd_udi_ingress.ccda_replay_details_bundle_id_idx; 
-        END IF;
+        END IF;        
         
-        IF EXISTS (
-            SELECT 1 FROM pg_indexes
-            WHERE schemaname = 'techbd_udi_ingress'
-                AND tablename = 'ccda_replay_details'
-                AND indexname = 'ccda_replay_details_bundle_id_key'
-            ) THEN
-              DROP INDEX techbd_udi_ingress.ccda_replay_details_bundle_id_key; 
-        END IF;
         RAISE NOTICE 'Cleanup complete: All unused indexes were handled successfully.';
             EXCEPTION
                 WHEN OTHERS THEN


### PR DESCRIPTION
- table - ccda_replay_details
- unique key name - ccda_replay_details_bundle_id_key
- index key name  - ccda_replay_details_bundle_id_key