### PR TITLE
feat: upgrade HAPI FHIR to v8.2.2 #2320

### DIFF
--- a/core-lib/pom.xml
+++ b/core-lib/pom.xml
@@ -55,7 +55,7 @@
         <!-- <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -91,27 +91,27 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-base</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation-resources-r4</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-caching-caffeine</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency> -->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/csv-service/pom.xml
+++ b/csv-service/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
 			<groupId>com.github.bxforce</groupId>

--- a/fhir-validation-service/pom.xml
+++ b/fhir-validation-service/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -111,27 +111,27 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-base</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation-resources-r4</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-caching-caffeine</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/fhir-validation-service/src/main/java/org/techbd/fhir/service/engine/OrchestrationEngine.java
+++ b/fhir-validation-service/src/main/java/org/techbd/fhir/service/engine/OrchestrationEngine.java
@@ -301,7 +301,7 @@ public class OrchestrationEngine {
             this.engineConstructedAt = Instant.now();
             this.observability = new Observability(HapiValidationEngine.class.getName(),
                     "HAPI version %s (FHIR version %s)"
-                            .formatted("8.0.0", fhirContext.getVersion().getVersion().getFhirVersionString()),
+                            .formatted("8.2.2", fhirContext.getVersion().getVersion().getFhirVersionString()),
                     engineInitAt, engineConstructedAt);
             this.igPackages = builder.igPackages;
             this.igVersion = builder.igVersion;

--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -168,27 +168,27 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
-			<version>8.0.0</version>
+			<version>8.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
-			<version>8.0.0</version>
+			<version>8.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation-resources-r4</artifactId>
-			<version>8.0.0</version>
+			<version>8.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-validation</artifactId>
-			<version>8.0.0</version>
+			<version>8.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-caching-caffeine</artifactId>
-			<version>8.0.0</version>
+			<version>8.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
@@ -339,7 +339,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
-        	<version>8.0.0</version>
+        	<version>8.2.2</version>
         </dependency>
 		<dependency> 
             <groupId>io.micrometer</groupId> 

--- a/nexus-core-lib/pom.xml
+++ b/nexus-core-lib/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -91,27 +91,27 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-base</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation-resources-r4</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-caching-caffeine</artifactId>
-            <version>8.0.0</version>
+            <version>8.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/fhir/engine/OrchestrationEngine.java
@@ -301,7 +301,7 @@ public class OrchestrationEngine {
             this.engineConstructedAt = Instant.now();
             this.observability = new Observability(HapiValidationEngine.class.getName(),
                     "HAPI version %s (FHIR version %s)"
-                            .formatted("8.0.0", fhirContext.getVersion().getVersion().getFhirVersionString()),
+                            .formatted("8.2.2", fhirContext.getVersion().getVersion().getFhirVersionString()),
                     engineInitAt, engineConstructedAt);
             this.igPackages = builder.igPackages;
             this.igVersion = builder.igVersion;


### PR DESCRIPTION
- Updated all HAPI FHIR dependencies from v8.0.0  to v8.2.2
- Aligns with latest stable release for improved stability, performance, and validation fixes