### PR TITLE
fix: update xslt files to remove warning errors from CCDA FHIR Bundles #2394

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.880.0</revision>
+        <revision>0.881.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -130,7 +130,7 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
+  <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name)"/>
 
   <xsl:template match="/">
   {
@@ -232,25 +232,14 @@
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>"
                         </xsl:if>
-                        <xsl:if test="
-                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
-                        ">
-                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:value-of select="normalize-space(.)"/>
-                                          <xsl:if test="position() != last()">, </xsl:if>
-                                      </xsl:for-each>
-                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
-                                      </xsl:if>"
+                        <xsl:variable name="formattedAddress">
+                            <xsl:call-template name="format-address">
+                                <xsl:with-param name="addr" select="../ccda:addr"/>
+                            </xsl:call-template>
+                        </xsl:variable>
+
+                        <xsl:if test="normalize-space($formattedAddress) != ''">
+                            , "text": "<xsl:value-of select="$formattedAddress"/>"
                         </xsl:if>
                         <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
                             , "line": [
@@ -260,20 +249,20 @@
                                 </xsl:for-each>
                             ]
                         </xsl:if>
-                        <xsl:if test="string(ccda:city)">
-                            , "city": "<xsl:value-of select="ccda:city"/>"
+                        <xsl:if test="normalize-space(ccda:city)">
+                            , "city": "<xsl:value-of select="normalize-space(ccda:city)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:county)">
-                            , "district": "<xsl:value-of select="ccda:county"/>"
+                        <xsl:if test="normalize-space(ccda:county)">
+                            , "district": "<xsl:value-of select="normalize-space(ccda:county)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:state)">
-                            , "state": "<xsl:value-of select="ccda:state"/>"
+                        <xsl:if test="normalize-space(ccda:state)">
+                            , "state": "<xsl:value-of select="normalize-space(ccda:state)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="ccda:postalCode"/>"
+                        <xsl:if test="normalize-space(ccda:postalCode)">
+                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:postalCode)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:country)">
-                            , "country": "<xsl:value-of select="ccda:country"/>"
+                        <xsl:if test="normalize-space(ccda:country)">
+                            , "country": "<xsl:value-of select="normalize-space(ccda:country)"/>"
                         </xsl:if>
                         <xsl:if test="ccda:useablePeriod">
                             ,"period": {
@@ -322,7 +311,7 @@
             ]
         </xsl:if>
         
-      <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode or ccda:patient/ccda:administrativeGenderCode/@code">
+      <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code or ccda:patient/ccda:administrativeGenderCode/@code">
       , "extension": [
         <!-- Declare OMB code sets -->
         <xsl:variable name="ombRaceCodes" select="'1002-5 2028-9 2054-5 2076-8 2106-3 UNK ASKU'" />
@@ -331,7 +320,8 @@
         <!-- RACE extension -->
         <xsl:if test="ccda:patient/ccda:raceCode">
           {
-            "extension": [
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            "extension": [              
               <xsl:for-each select="ccda:patient/ccda:raceCode">
                 <xsl:variable name="raceCode">
                   <xsl:choose>
@@ -389,14 +379,15 @@
                                   <xsl:if test='position() != last()'>, </xsl:if>
                                 </xsl:for-each>"
               }
-            ],
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-          },
+            ]            
+          }
         </xsl:if>
-
+      
         <!-- ETHNICITY extension -->
-        <xsl:if test="ccda:patient/ccda:ethnicGroupCode">
+        <xsl:if test="ccda:patient/ccda:ethnicGroupCode/@code">
+          <xsl:if test="ccda:patient/ccda:raceCode">,</xsl:if>
           {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
             "extension": [
               <xsl:for-each select="ccda:patient/ccda:ethnicGroupCode">
                 <xsl:variable name="ethCode">
@@ -454,15 +445,15 @@
                                   <xsl:if test='position() != last()'>, </xsl:if>
                                 </xsl:for-each>"
               }
-            ],
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+            ]            
           }
         </xsl:if>
 
         <!-- GenderCode extension -->
         <xsl:if test="string(ccda:patient/ccda:administrativeGenderCode/@code)">
-        ,{
-            "url": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", 
+          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
+        {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
             "valueCode": "<xsl:call-template name='mapAdministrativeGenderCode'>
                               <xsl:with-param name='genderCode' select='ccda:patient/ccda:administrativeGenderCode/@code'/>
                           </xsl:call-template>"
@@ -567,7 +558,8 @@
       , "communication" : [{
         "language" : {
           "coding" : [{
-                "code" : "<xsl:value-of select="ccda:patient/ccda:languageCommunication/ccda:languageCode/@code"/>"
+                "code" : "<xsl:value-of select="ccda:patient/ccda:languageCommunication/ccda:languageCode/@code"/>",
+                "system" : "urn:ietf:bcp:47"
               }]
         }
         <xsl:if test="string(ccda:patient/ccda:languageCommunication/ccda:preferenceInd/@value)">
@@ -947,7 +939,7 @@
         </xsl:if>
         "name" : "<xsl:choose>
                     <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-                    <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
+                    <xsl:otherwise><xsl:value-of select="normalize-space(ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/></xsl:otherwise>
                   </xsl:choose>"
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
             , "telecom": [
@@ -988,26 +980,15 @@
                                 <xsl:when test="@use='OLD' or @use='BAD'">old</xsl:when>
                                 <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
                             </xsl:choose>"
-                        </xsl:if>
-                        <xsl:if test="
-                            ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
-                        ">
-                            , "text": "<xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:value-of select="normalize-space(.)"/>
-                                          <xsl:if test="position() != last()">, </xsl:if>
-                                      </xsl:for-each>
-                                      <xsl:if test="ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
-                                      </xsl:if>"
+                        </xsl:if>                        
+                        <xsl:variable name="formattedAddress">
+                            <xsl:call-template name="format-address">
+                                <xsl:with-param name="addr" select="../ccda:addr"/>
+                            </xsl:call-template>
+                        </xsl:variable>
+
+                        <xsl:if test="normalize-space($formattedAddress) != ''">
+                            , "text": "<xsl:value-of select="$formattedAddress"/>"
                         </xsl:if>
                         <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
                             , "line": [
@@ -1017,20 +998,23 @@
                                 </xsl:for-each>
                             ]
                         </xsl:if>
-                        <xsl:if test="string(ccda:city)">
-                            , "city": "<xsl:value-of select="ccda:city"/>"
-                        </xsl:if>
-                        <xsl:if test="string(ccda:county)">
-                            , "district": "<xsl:value-of select="ccda:county"/>"
-                        </xsl:if>
-                        <xsl:if test="string(ccda:state)">
-                            , "state": "<xsl:value-of select="ccda:state"/>"
-                        </xsl:if>
-                        <xsl:if test="string(ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="ccda:postalCode"/>"
-                        </xsl:if>
                         <xsl:if test="string(ccda:country)">
                             , "country": "<xsl:value-of select="ccda:country"/>"
+                        </xsl:if>
+                        <xsl:if test="normalize-space(ccda:city)">
+                            , "city": "<xsl:value-of select="normalize-space(ccda:city)"/>"
+                        </xsl:if>
+                        <xsl:if test="normalize-space(ccda:county)">
+                            , "district": "<xsl:value-of select="normalize-space(ccda:county)"/>"
+                        </xsl:if>
+                        <xsl:if test="normalize-space(ccda:state)">
+                            , "state": "<xsl:value-of select="normalize-space(ccda:state)"/>"
+                        </xsl:if>
+                        <xsl:if test="normalize-space(ccda:postalCode)">
+                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:postalCode)"/>"
+                        </xsl:if>
+                        <xsl:if test="normalize-space(ccda:country)">
+                            , "country": "<xsl:value-of select="normalize-space(ccda:country)"/>"
                         </xsl:if>
                         <xsl:if test="ccda:useablePeriod">
                             ,"period": {
@@ -1201,6 +1185,7 @@
                     "lastUpdated": "<xsl:value-of select='$currentTimestamp'/>",
                     "profile": ["<xsl:value-of select='$observationMetaProfileUrlFull'/>"]
                   },
+                  "language": "en",
                   "status": "<xsl:call-template name='mapObservationStatus'>
                                 <xsl:with-param name='statusCode' select='ccda:observation/ccda:statusCode/@code'/>
                             </xsl:call-template>",
@@ -1253,15 +1238,15 @@
                       {
                         "system": "http://loinc.org",
                         "code": "<xsl:value-of select='ccda:observation/ccda:code/@code'/>",
-                        "display": "<xsl:value-of select='ccda:observation/ccda:code/@displayName'/>"
+                        "display": "<xsl:value-of select='normalize-space(ccda:observation/ccda:code/@displayName)'/>"
                       }
                     ]
                     <xsl:choose>
                       <xsl:when test="ccda:observation/ccda:code/@originalText">
-                        , "text": "<xsl:value-of select='ccda:observation/ccda:code/@originalText'/>"
+                        , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:code/@originalText)'/>"
                       </xsl:when>
                       <xsl:when test="ccda:observation/ccda:code/@displayName">
-                        , "text": "<xsl:value-of select='ccda:observation/ccda:code/@displayName'/>"
+                        , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:code/@displayName)'/>"
                       </xsl:when>
                     </xsl:choose>
                   },
@@ -1295,15 +1280,15 @@
                                     {
                                       "system": "http://loinc.org",
                                       "code": "<xsl:value-of select='ccda:observation/ccda:code/@code'/>",
-                                      "display": "<xsl:value-of select='ccda:observation/ccda:code/@displayName'/>"
+                                      "display": "<xsl:value-of select='normalize-space(ccda:observation/ccda:code/@displayName)'/>"
                                     }
                                   ]
                                   <xsl:choose>
                                     <xsl:when test="ccda:observation/ccda:code/@originalText">
-                                      , "text": "<xsl:value-of select='ccda:observation/ccda:code/@originalText'/>"
+                                      , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:code/@originalText)'/>"
                                     </xsl:when>
                                     <xsl:when test="ccda:observation/ccda:code/@displayName">
-                                      , "text": "<xsl:value-of select='ccda:observation/ccda:code/@displayName'/>"
+                                      , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:code/@displayName)'/>"
                                     </xsl:when>
                                   </xsl:choose>
                                 },
@@ -1969,8 +1954,8 @@
           "lastUpdated": "<xsl:value-of select='$currentTimestamp'/>",
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
-        <xsl:if test="ccda:name">
-          ,"name": "<xsl:value-of select="ccda:name"/>"
+        <xsl:if test="normalize-space(ccda:name)">
+          ,"name": "<xsl:value-of select="normalize-space(ccda:name)"/>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
@@ -1985,25 +1970,14 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>"
                         </xsl:if>
-                        <xsl:if test="
-                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
-                        ">
-                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:value-of select="normalize-space(.)"/>
-                                          <xsl:if test="position() != last()">, </xsl:if>
-                                      </xsl:for-each>
-                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
-                                      </xsl:if>"
+                        <xsl:variable name="formattedAddress">
+                            <xsl:call-template name="format-address">
+                                <xsl:with-param name="addr" select="ccda:addr"/>
+                            </xsl:call-template>
+                        </xsl:variable>
+
+                        <xsl:if test="normalize-space($formattedAddress) != ''">
+                            , "text": "<xsl:value-of select="$formattedAddress"/>"
                         </xsl:if>
                         <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
                             , "line": [
@@ -2013,20 +1987,20 @@
                                 </xsl:for-each>
                             ]
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:city)">
-                            , "city": "<xsl:value-of select="ccda:addr/ccda:city"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:city)">
+                            , "city": "<xsl:value-of select="normalize-space(ccda:addr/ccda:city)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:county)">
-                            , "district": "<xsl:value-of select="ccda:addr/ccda:county"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:county)">
+                            , "district": "<xsl:value-of select="normalize-space(ccda:addr/ccda:county)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:state)">
-                            , "state": "<xsl:value-of select="ccda:addr/ccda:state"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:state)">
+                            , "state": "<xsl:value-of select="normalize-space(ccda:addr/ccda:state)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="ccda:addr/ccda:postalCode"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:postalCode)">
+                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:addr/ccda:postalCode)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:country)">
-                            , "country": "<xsl:value-of select="ccda:addr/ccda:country"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:country)">
+                            , "country": "<xsl:value-of select="normalize-space(ccda:addr/ccda:country)"/>"
                         </xsl:if>
                         <xsl:if test="ccda:addr/ccda:useablePeriod">
                             ,"period": {
@@ -2066,8 +2040,8 @@
           "lastUpdated": "<xsl:value-of select='$currentTimestamp'/>",
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
-        <xsl:if test="ccda:playingEntity/ccda:name">
-          ,"name": "<xsl:value-of select="ccda:playingEntity/ccda:name"/>"
+        <xsl:if test="normalize-space(ccda:playingEntity/ccda:name)">
+          ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
@@ -2082,25 +2056,14 @@
                                 <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
                             </xsl:choose>"
                         </xsl:if>
-                        <xsl:if test="
-                            ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''] 
-                            or ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']
-                        ">
-                            , "text": "<xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:value-of select="normalize-space(.)"/>
-                                          <xsl:if test="position() != last()">, </xsl:if>
-                                      </xsl:for-each>
-                                      <xsl:if test="ccda:addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:city)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text>, </xsl:text><xsl:value-of select="normalize-space(ccda:state)"/>
-                                      </xsl:if>
-                                      <xsl:if test="ccda:addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']">
-                                          <xsl:text> </xsl:text><xsl:value-of select="normalize-space(ccda:postalCode)"/>
-                                      </xsl:if>"
+                        <xsl:variable name="formattedAddress">
+                            <xsl:call-template name="format-address">
+                                <xsl:with-param name="addr" select="ccda:addr"/>
+                            </xsl:call-template>
+                        </xsl:variable>
+
+                        <xsl:if test="normalize-space($formattedAddress) != ''">
+                            , "text": "<xsl:value-of select="$formattedAddress"/>"
                         </xsl:if>
                         <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
                             , "line": [
@@ -2110,20 +2073,20 @@
                                 </xsl:for-each>
                             ]
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:city)">
-                            , "city": "<xsl:value-of select="ccda:addr/ccda:city"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:city)">
+                            , "city": "<xsl:value-of select="normalize-space(ccda:addr/ccda:city)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:county)">
-                            , "district": "<xsl:value-of select="ccda:addr/ccda:county"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:county)">
+                            , "district": "<xsl:value-of select="normalize-space(ccda:addr/ccda:county)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:state)">
-                            , "state": "<xsl:value-of select="ccda:addr/ccda:state"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:state)">
+                            , "state": "<xsl:value-of select="normalize-space(ccda:addr/ccda:state)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="ccda:addr/ccda:postalCode"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:postalCode)">
+                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:addr/ccda:postalCode)"/>"
                         </xsl:if>
-                        <xsl:if test="string(ccda:addr/ccda:country)">
-                            , "country": "<xsl:value-of select="ccda:addr/ccda:country"/>"
+                        <xsl:if test="normalize-space(ccda:addr/ccda:country)">
+                            , "country": "<xsl:value-of select="normalize-space(ccda:addr/ccda:country)"/>"
                         </xsl:if>
                         <xsl:if test="ccda:addr/ccda:useablePeriod">
                             ,"period": {
@@ -2174,6 +2137,48 @@
         <xsl:text>http://loinc.org</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <!-- Template to format an address -->
+  <xsl:template name="format-address">
+      <xsl:param name="addr"/>
+
+      <!-- Extract components -->
+      <xsl:variable name="street">
+          <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+              <xsl:value-of select="normalize-space(.)"/>
+              <xsl:if test="position() != last()">, </xsl:if>
+          </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:variable name="city"  select="normalize-space($addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''])"/>
+      <xsl:variable name="state" select="normalize-space($addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''])"/>
+      <xsl:variable name="zip"   select="normalize-space($addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != ''])"/>
+
+      <!-- Build the final string -->
+      <xsl:variable name="fullAddress">
+          <xsl:if test="string-length(normalize-space($street)) &gt; 0">
+              <xsl:value-of select="$street"/>
+          </xsl:if>
+
+          <xsl:if test="$city != ''">
+              <xsl:if test="normalize-space($street) != ''">, </xsl:if>
+              <xsl:value-of select="$city"/>
+          </xsl:if>
+
+          <xsl:if test="$state != ''">
+              <xsl:if test="$city != '' or normalize-space($street) != ''">, </xsl:if>
+              <xsl:value-of select="$state"/>
+          </xsl:if>
+
+          <xsl:if test="$zip != ''">
+              <xsl:text> </xsl:text>
+              <xsl:value-of select="$zip"/>
+          </xsl:if>
+      </xsl:variable>
+
+      <!-- Output trimmed -->
+      <xsl:value-of select="normalize-space($fullAddress)"/>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Update xslt files (for Epic, Medent and AthenaHealth) to remove warning errors from CCDA FHIR Bundles
1. Updated the following elements to remove the whitespace from the start or finish. 
	- 'address' in Patient, Location and Organization resources 
	- 'display' in Observation resource
	- 'name' in Location and Organization resources
2. Added the new element 'language' in Observation resource and defaulted to 'en'. Need to get the xpath to the location.
3. 'system' is added as 'urn:ietf:bcp:47' in Patient.communication.language which is provided in the SHINNY IG examples.
4. Removed displaying 'ethnicity' in Patient.extension for files with 'ethnicGroupCode' as nullFlavour (<ethnicGroupCode nullFlavor="UNK" />).
5. The 'url' for administrative Gender extension changed from 'http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender' to 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'.
