### PR TITLE
feat: update xslt file to change the consent code for HL7 #2281

### DIFF
--- a/integration-artifacts/hl7v2/hl7-techbd-schema-files/hl7v2-fhir-bundle.xslt
+++ b/integration-artifacts/hl7v2/hl7-techbd-schema-files/hl7v2-fhir-bundle.xslt
@@ -1204,12 +1204,12 @@
 
 <!-- Consent Template -->
   <xsl:template name="ConsentFromOBX">
-  <xsl:variable name="consentOBX" select="//OBX[normalize-space(OBX.3/OBX.3.2) = 'AHC-HRSN Patient Consent'][1]"/>
+  <xsl:variable name="consentOBX" select="//OBX[normalize-space(OBX.3/OBX.3.1) = '105511-0'][1]"/>
   
    <!-- Define boolean: is consent given -->
   <xsl:variable name="isConsentGiven"
-                select="contains(normalize-space($consentOBX/OBX.5/OBX.5.1), 'Patient Consents') or 
-                        contains(normalize-space($consentOBX/OBX.5/OBX.5.1), 'Yes')"/>
+                select="contains(normalize-space($consentOBX/OBX.5/OBX.5.2), 'Patient Consents') or 
+                        contains(normalize-space($consentOBX/OBX.5/OBX.5.2), 'Yes')"/>
 						
   {
     "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Consent/<xsl:value-of select='$consentResourceId'/>",

--- a/support/specifications/develop/hl7/hl7v2-fhir-bundle.xslt
+++ b/support/specifications/develop/hl7/hl7v2-fhir-bundle.xslt
@@ -1204,12 +1204,12 @@
 
 <!-- Consent Template -->
   <xsl:template name="ConsentFromOBX">
-  <xsl:variable name="consentOBX" select="//OBX[normalize-space(OBX.3/OBX.3.2) = 'AHC-HRSN Patient Consent'][1]"/>
+  <xsl:variable name="consentOBX" select="//OBX[normalize-space(OBX.3/OBX.3.1) = '105511-0'][1]"/>
   
    <!-- Define boolean: is consent given -->
   <xsl:variable name="isConsentGiven"
-                select="contains(normalize-space($consentOBX/OBX.5/OBX.5.1), 'Patient Consents') or 
-                        contains(normalize-space($consentOBX/OBX.5/OBX.5.1), 'Yes')"/>
+                select="contains(normalize-space($consentOBX/OBX.5/OBX.5.2), 'Patient Consents') or 
+                        contains(normalize-space($consentOBX/OBX.5/OBX.5.2), 'Yes')"/>
 						
   {
     "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Consent/<xsl:value-of select='$consentResourceId'/>",


### PR DESCRIPTION
Updated xslt file so that if OBX.3.1 is the LOINC code '105511-0' and OBX.5.2 is 'Patient Consents' or 'Yes', then that OBX is considered as 'Permit', otherwise, 'Deny'.