### PR TITLE
fix: standardize error messages for invalid character reasons in CSV processing #2294

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/service/CsvBundleProcessorService.java
+++ b/csv-service/src/main/java/org/techbd/csv/service/CsvBundleProcessorService.java
@@ -623,25 +623,25 @@ private List<Object> processScreening(final String groupKey,
                     } else if (reason.contains("not valid UTF-8 encoded")) {
                         return "wrong-encoding|File is not UTF-8 encoded";
                     }else if (reason.contains("Null bytes")) {
-                        return "invalid-content-null-bytes|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     }else if (reason.contains("Control characters")) {
-                        return "invalid-content-control|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("surrogate")) {
-                        return "invalid-content-surrogates|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Unicode non-characters")) {
-                        return "invalid-content-noncharacters|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Problematic whitespace")) {
-                        return "invalid-content-whitespace|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Invisible format characters")) {
-                        return "invalid-content-format|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Zero-width characters")) {
-                        return "invalid-content-zero-width|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     }else if (reason.contains("BOM character in middle")) {
-                        return "invalid-content-bom-middle|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Private use area characters")) {
-                        return "invalid-content-private-use|Invalid characters";
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.startsWith("File contains invalid characters")) {
-                        return "invalid-content-other|Invalid characters";} 
+                        return "Invalid characters|Invalid characters|" + reason;} 
                     else {
                         return "unknown|Unknown reason";
                     }

--- a/nexus-core-lib/src/main/java/org/techbd/service/csv/CsvBundleProcessorService.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/csv/CsvBundleProcessorService.java
@@ -586,25 +586,25 @@ private List<Object> processScreening(final String groupKey,
                     } else if (reason.contains("not valid UTF-8 encoded")) {
                         return "wrong-encoding|File is not UTF-8 encoded";
                     }else if (reason.contains("Null bytes")) {
-                        return "invalid-content-null-bytes|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     }else if (reason.contains("Control characters")) {
-                        return "invalid-content-control|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("surrogate")) {
-                        return "invalid-content-surrogates|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Unicode non-characters")) {
-                        return "invalid-content-noncharacters|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Problematic whitespace")) {
-                        return "invalid-content-whitespace|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Invisible format characters")) {
-                        return "invalid-content-format|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Zero-width characters")) {
-                        return "invalid-content-zero-width|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     }else if (reason.contains("BOM character in middle")) {
-                        return "invalid-content-bom-middle|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.contains("Private use area characters")) {
-                        return "invalid-content-private-use|Invalid characters|" + reason;
+                        return "Invalid characters|Invalid characters|" + reason;
                     } else if (reason.startsWith("File contains invalid characters")) {
-                        return "invalid-content-other|Invalid characters|" + reason;} 
+                        return "Invalid characters|Invalid characters|" + reason;} 
                     else {
                         return "unknown|Unknown reason";
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.897.0</revision>
+        <revision>0.898.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Updated the subType to use the common value "invalid character" for all content-level errors to maintain consistency across validations.