### PR TITLE
feat: update XSLT files to change the location of Encounter status for Guthrie CCDA files #2338

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.900.0</revision>
+        <revision>0.901.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -98,14 +98,17 @@
   <!-- Remove unwanted space,if any -->
   <xsl:variable name="encounterEffectiveTimeValue" select="normalize-space($encounterEffTimeValue)"/>
 
- <!-- <xsl:variable name="encounterStatus" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:statusCode/@code"/> -->
   <!-- Check whether the CCDA from Guthrie and get Encounter Status in a separate logic -->
   <!-- Determine if this is a Guthrie CCDA -->
   <xsl:variable name="IsGuthrieCCDA"
       select="contains(/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name, 'Guthrie')" />
 
-  <!-- Encounter status from the Guthrie path -->
-  <xsl:variable name="guthrieEncounterStatus"
+  <!-- Encounter status from the encounters section only for Guthrie-->
+  <xsl:variable name="guthrieEncounterStatusFromAct"
+      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:entryRelationship[1]/ccda:act/ccda:statusCode/@code"/>
+
+  <!-- Encounter status from the default path for Guthrie-->
+  <xsl:variable name="guthrieEncounterStatusDefault"
       select="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:statusCode/@code" />
 
   <!-- Encounter status from the normal encounters section -->
@@ -115,12 +118,17 @@
   <!-- Final encounterStatus -->
   <xsl:variable name="encounterStatus">
       <xsl:choose>
-          <!-- Case 1: Guthrie AND Guthrie encounter status exists -->
-          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatus) &gt; 0">
-              <xsl:value-of select="$guthrieEncounterStatus"/>
+          <!-- Case 1: Guthrie AND Guthrie encounter status exists from entryRelationship.act-->
+          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatusFromAct) &gt; 0">
+              <xsl:value-of select="$guthrieEncounterStatusFromAct"/>
           </xsl:when>
 
-          <!-- Case 2: Otherwise use normal encounter status -->
+          <!-- Case 2: Guthrie AND Guthrie encounter status exists from encompassingEncounter-->
+          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatusDefault) &gt; 0">
+              <xsl:value-of select="$guthrieEncounterStatusDefault"/>
+          </xsl:when>
+
+          <!-- Case 3: Otherwise use normal encounter status -->
           <xsl:otherwise>
               <xsl:value-of select="$normalEncounterStatus"/>
           </xsl:otherwise>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -98,15 +98,17 @@
   <!-- Remove unwanted space,if any -->
   <xsl:variable name="encounterEffectiveTimeValue" select="normalize-space($encounterEffTimeValue)"/>
 
- <!-- <xsl:variable name="encounterStatus" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:statusCode/@code"/> -->
-
   <!-- Check whether the CCDA from Guthrie and get Encounter Status in a separate logic -->
   <!-- Determine if this is a Guthrie CCDA -->
   <xsl:variable name="IsGuthrieCCDA"
       select="contains(/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name, 'Guthrie')" />
 
-  <!-- Encounter status from the Guthrie path -->
-  <xsl:variable name="guthrieEncounterStatus"
+  <!-- Encounter status from the encounters section only for Guthrie-->
+  <xsl:variable name="guthrieEncounterStatusFromAct"
+      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:entryRelationship[1]/ccda:act/ccda:statusCode/@code"/>
+
+  <!-- Encounter status from the default path for Guthrie-->
+  <xsl:variable name="guthrieEncounterStatusDefault"
       select="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:statusCode/@code" />
 
   <!-- Encounter status from the normal encounters section -->
@@ -116,12 +118,17 @@
   <!-- Final encounterStatus -->
   <xsl:variable name="encounterStatus">
       <xsl:choose>
-          <!-- Case 1: Guthrie AND Guthrie encounter status exists -->
-          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatus) &gt; 0">
-              <xsl:value-of select="$guthrieEncounterStatus"/>
+          <!-- Case 1: Guthrie AND Guthrie encounter status exists from entryRelationship.act-->
+          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatusFromAct) &gt; 0">
+              <xsl:value-of select="$guthrieEncounterStatusFromAct"/>
           </xsl:when>
 
-          <!-- Case 2: Otherwise use normal encounter status -->
+          <!-- Case 2: Guthrie AND Guthrie encounter status exists from encompassingEncounter-->
+          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatusDefault) &gt; 0">
+              <xsl:value-of select="$guthrieEncounterStatusDefault"/>
+          </xsl:when>
+
+          <!-- Case 3: Otherwise use normal encounter status -->
           <xsl:otherwise>
               <xsl:value-of select="$normalEncounterStatus"/>
           </xsl:otherwise>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -88,14 +88,17 @@
   <!-- Remove unwanted space,if any -->
   <xsl:variable name="encounterEffectiveTimeValue" select="normalize-space($encounterEffTimeValue)"/>
   
-  <!-- <xsl:variable name="encounterStatus" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:entryRelationship/ccda:act/ccda:entryRelationship/ccda:observation/ccda:statusCode/@code"/> -->
   <!-- Check whether the CCDA from Guthrie and get Encounter Status in a separate logic -->
   <!-- Determine if this is a Guthrie CCDA -->
   <xsl:variable name="IsGuthrieCCDA"
       select="contains(/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name, 'Guthrie')" />
 
-  <!-- Encounter status from the Guthrie path -->
-  <xsl:variable name="guthrieEncounterStatus"
+  <!-- Encounter status from the encounters section only for Guthrie-->
+  <xsl:variable name="guthrieEncounterStatusFromAct"
+      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:entryRelationship[1]/ccda:act/ccda:statusCode/@code"/>
+
+  <!-- Encounter status from the default path for Guthrie-->
+  <xsl:variable name="guthrieEncounterStatusDefault"
       select="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:statusCode/@code" />
 
   <!-- Encounter status from the normal encounters section -->
@@ -105,12 +108,17 @@
   <!-- Final encounterStatus -->
   <xsl:variable name="encounterStatus">
       <xsl:choose>
-          <!-- Case 1: Guthrie AND Guthrie encounter status exists -->
-          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatus) &gt; 0">
-              <xsl:value-of select="$guthrieEncounterStatus"/>
+          <!-- Case 1: Guthrie AND Guthrie encounter status exists from entryRelationship.act-->
+          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatusFromAct) &gt; 0">
+              <xsl:value-of select="$guthrieEncounterStatusFromAct"/>
           </xsl:when>
 
-          <!-- Case 2: Otherwise use normal encounter status -->
+          <!-- Case 2: Guthrie AND Guthrie encounter status exists from encompassingEncounter-->
+          <xsl:when test="$IsGuthrieCCDA and string-length($guthrieEncounterStatusDefault) &gt; 0">
+              <xsl:value-of select="$guthrieEncounterStatusDefault"/>
+          </xsl:when>
+
+          <!-- Case 3: Otherwise use normal encounter status -->
           <xsl:otherwise>
               <xsl:value-of select="$normalEncounterStatus"/>
           </xsl:otherwise>


### PR DESCRIPTION
Updated the XSLT files to change the location of Encounter status for Guthrie CCDA files which is determined using the following priority:
**1. Primary Location**
ClinicalDocument.component.structuredBody.component.section[code.code='46240-8'].entry[1].encounter[1].entryRelationship[1].act.statusCode.code

**2. Secondary Location**
ClinicalDocument.componentOf.encompassingEncounter.statusCode.code

**3. QE-Specific Logic (Fallback)**
_For Epic / AthenaHealth:_
ClinicalDocument.component.structuredBody.component.section[code.code='46240-8'].entry[1].encounter.statusCode.code
_For Medent:_
ClinicalDocument.component.structuredBody.component.section[code.code='46240-8'].entry[1].encounter.entryRelationship.act.entryRelationship.observation.statusCode.code

**Selection Logic:**
If a value is present in Primary Location, it will be used.
If Primary Location is empty, we will use Secondary Location.
If both Primary and Secondary Locations are empty, we will apply QE-Specific Logic based on the QE type.
If none of the three locations contain a value, the Encounter Status will default to "unknown".