### PR TITLE
feat: update xslt files to create unique resource-id from facility-id and extension value for CCDA files #2470

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.912.0</revision>
+        <revision>0.913.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -1090,8 +1090,10 @@
 
           <xsl:variable name="observationResourceId">
             <xsl:call-template name="generateFixedLengthResourceId">
-              <xsl:with-param name="prefixString" select="$questionCode"/>
-              <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+              <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+              <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+              <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+              <xsl:with-param name="sha256ResourceId" select="ccda:id/@root"/>
             </xsl:call-template>
           </xsl:variable>
           ,{
@@ -1262,14 +1264,14 @@
                       "coding": [{
                         "system": "http://loinc.org",
                         "code": "<xsl:value-of select='ccda:value/@code'/>",
-                        "display": "<xsl:value-of select='ccda:value/@displayName'/>"
+                        "display": "<xsl:value-of select='normalize-space(ccda:value/@displayName)'/>"
                       }]
                       <xsl:choose>
                         <xsl:when test="ccda:value/@originalText">
-                          , "text": "<xsl:value-of select='ccda:value/@originalText'/>"
+                          , "text": "<xsl:value-of select='normalize-space(ccda:value/@originalText)'/>"
                         </xsl:when>
                         <xsl:when test="ccda:value/@displayName">
-                          , "text": "<xsl:value-of select='ccda:value/@displayName'/>"
+                          , "text": "<xsl:value-of select='normalize-space(ccda:value/@displayName)'/>"
                         </xsl:when>
                       </xsl:choose>
                     },
@@ -1872,11 +1874,13 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@root"/>
                   </xsl:call-template>
                 </xsl:variable>
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -1185,8 +1185,10 @@
 
               <xsl:variable name="observationResourceId">
                 <xsl:call-template name="generateFixedLengthResourceId">
-                  <xsl:with-param name="prefixString" select="$questionCode"/>
-                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                  <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                  <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                  <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
                 </xsl:call-template>
               </xsl:variable>
               ,{
@@ -1355,14 +1357,14 @@
                           "coding": [{
                             "system": "http://loinc.org",
                             "code": "<xsl:value-of select='ccda:observation/ccda:value/@code'/>",
-                            "display": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                            "display": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                           }]
                           <xsl:choose>
                             <xsl:when test="ccda:observation/ccda:value/@originalText">
-                              , "text": "<xsl:value-of select='ccda:observation/ccda:value/@originalText'/>"
+                              , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@originalText)'/>"
                             </xsl:when>
                             <xsl:when test="ccda:observation/ccda:value/@displayName">
-                              , "text": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                              , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                             </xsl:when>
                           </xsl:choose>
                         },
@@ -1959,11 +1961,13 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                   </xsl:call-template>
                 </xsl:variable>
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1068,8 +1068,10 @@
 
             <xsl:variable name="observationResourceId">
               <xsl:call-template name="generateFixedLengthResourceId">
-                <xsl:with-param name="prefixString" select="$questionCode"/>
-                <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
               </xsl:call-template>
             </xsl:variable>
             ,{
@@ -1236,14 +1238,14 @@
                             "coding": [{
                               "system": "http://loinc.org",
                               "code": "<xsl:value-of select='ccda:observation/ccda:value/@code'/>",
-                              "display": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                              "display": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                             }]
                             <xsl:choose>
                               <xsl:when test="ccda:observation/ccda:value/@originalText">
-                                , "text": "<xsl:value-of select='ccda:observation/ccda:value/@originalText'/>"
+                                , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@originalText)'/>"
                               </xsl:when>
                               <xsl:when test="ccda:observation/ccda:value/@displayName">
-                                , "text": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                                , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                               </xsl:when>
                             </xsl:choose>
                           },
@@ -1955,11 +1957,13 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                   </xsl:call-template>
                 </xsl:variable>
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>

--- a/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
@@ -44,7 +44,7 @@
             <xsl:copy-of select="hl7:legalAuthenticator"/>
             <xsl:copy-of select="hl7:documentationOf"/>
 
-            <!-- Medent - always have consent details in Procedures section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value (Yes/No)  -->
+            <!-- Medent - always have consent details in Procedures section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value.code (LA33-6 = Yes/ LA33-8 = No)   -->
             <xsl:variable name="consent" select="
                 hl7:component/hl7:structuredBody/hl7:component
                 /hl7:section[hl7:code[@code='47519-4']]
@@ -54,7 +54,18 @@
             <xsl:if test="$consent">
                 <xsl:variable name="consentDisplay">
                     <xsl:choose>
-                        <xsl:when test="$consent/hl7:value/@displayName = 'Yes'">permit</xsl:when>
+                        <!-- <xsl:when test="$consent/hl7:value/@displayName = 'Yes'">permit</xsl:when> -->
+                        <xsl:when test="
+                            normalize-space($consent/hl7:value/@code) = 'LA33-6'
+                            or
+                            translate(
+                                normalize-space($consent/hl7:value/@displayName),
+                                'abcdefghijklmnopqrstuvwxyz',
+                                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                            ) = 'YES'
+                            ">
+                            permit
+                        </xsl:when>
                         <xsl:otherwise>deny</xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>


### PR DESCRIPTION
Updated xslt files to create unique resource-id from facility-id and extension value for CCDA files.
- Updated Epic and Medent xslt files to create resource-id from facility-id and extension value
- Updated AthenaHealth xslt file to create resource-id from facility-id and root value
- Updated all the xslt files to remove the space in the answer text and display for Observation resources
- Updated Medent xslt file to include the case insentive check and LOIC code for the Permit consent