### PR TITLE
feat: update Consent and Encounter Status logic for AthenaHealth #1949

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.914.0</revision>
+        <revision>0.915.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -118,8 +118,34 @@
       select="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:statusCode/@code" />
 
   <!-- Encounter status from the normal encounters section -->
-  <xsl:variable name="normalEncounterStatus"
-      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code"/>
+  <!-- <xsl:variable name="normalEncounterStatus"
+      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code"/> -->
+  <xsl:variable name="normalEncounterStatus">
+    <xsl:choose>
+      <!-- Case 1: statusCode exists -->
+      <xsl:when test="
+        string-length(
+          normalize-space(
+            /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code
+          )
+        ) &gt; 0
+      ">
+        <xsl:value-of select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code"/>
+      </xsl:when>
+
+      <!-- Case 2: statusCode missing AND moodCode = EVN -->
+      <xsl:when test="
+        normalize-space(
+          /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/@moodCode
+        ) = 'EVN'
+      ">
+        completed
+      </xsl:when>
+
+      <!-- Case 3: Otherwise empty -->
+      <xsl:otherwise/>    
+    </xsl:choose>
+  </xsl:variable>
 
   <!-- Final encounterStatus -->
   <xsl:variable name="encounterStatus">

--- a/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
@@ -47,13 +47,36 @@
             <xsl:copy-of select="hl7:legalAuthenticator"/>
             <xsl:copy-of select="hl7:documentationOf"/>
 
-            <!-- Consent (same style as Epic for easy diff) -->
+            <!-- Consent details are in Social History section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value (Yes/No)  -->
+            <xsl:variable name="consent" select="
+                hl7:component/hl7:structuredBody/hl7:component
+                /hl7:section[hl7:code[@code='29762-2']]
+                /hl7:entry/hl7:observation/hl7:entryRelationship
+                /hl7:observation[hl7:code/@code = '105511-0']
+            "/>   
             <xsl:choose>
+                <xsl:when test="$consent">
+                    <xsl:variable name="consentDisplay">
+                        <xsl:choose>
+                            <!-- <xsl:when test="$consent/hl7:value/@displayName = 'Permit' or $consent/hl7:value/@code = 'LA33-6'">permit</xsl:when> -->
+                            <xsl:when test="$consent/hl7:value/@code = 'LA33-6'">permit</xsl:when>
+                            <xsl:otherwise>deny</xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <authorization>
+                        <consent>
+                            <id root="2.16.840.1.113883.3.227.2845.10.41.1.1"/>
+                            <code code="105511-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <xsl:attribute name="displayName"><xsl:value-of select="$consentDisplay"/></xsl:attribute>
+                            </code>
+                            <xsl:copy-of select="$consent/hl7:statusCode"/>
+                        </consent>
+                    </authorization>
+                </xsl:when>
                 <xsl:when test="hl7:authorization/hl7:consent[hl7:code[@code='59284-0']]">
                     <xsl:copy-of select="hl7:authorization"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <!-- keep Epic-style explicit deny node so diffs clearly show consent differences -->
                     <authorization>
                         <consent>
                             <id root="2.16.840.1.113883.3.933"/>


### PR DESCRIPTION
Updated Consent and Encounter Status logic for AthenaHealth.
- Updated Encounter Status from section.entry.encounter.moodCode
- Updated Consent from section[code.code='29762-2'].entry.observation.entryRelationship.observation[code.code = '105511-0']