### PR TITLE
fix: correct SHIN-NY PROD baseFHIRURL configuration #2545

### DIFF
--- a/csv-service/src/main/resources/application.yml
+++ b/csv-service/src/main/resources/application.yml
@@ -56,7 +56,7 @@ org:
           us-core: ig-packages/fhir-v4/us-core/stu-7.0.0
           sdoh: ig-packages/fhir-v4/sdoh-clinicalcare/stu-2.2.0
           uv-sdc: ig-packages/fhir-v4/uv-sdc/stu-3.0.0
-    baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+    baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
     validation-severity-level: error  # Possible values: fatal, error, warning, information
     structureDefinitionsUrls:
       bundle: /StructureDefinition/SHINNYBundleProfile

--- a/fhir-validation-service/src/main/resources/application.yml
+++ b/fhir-validation-service/src/main/resources/application.yml
@@ -56,7 +56,7 @@ org:
           us-core: ig-packages/fhir-v4/us-core/stu-7.0.0
           sdoh: ig-packages/fhir-v4/sdoh-clinicalcare/stu-2.2.0
           uv-sdc: ig-packages/fhir-v4/uv-sdc/stu-3.0.0
-    baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+    baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
     validation-severity-level: error  # Possible values: fatal, error, warning, information
     structureDefinitionsUrls:
       bundle: /StructureDefinition/SHINNYBundleProfile

--- a/nexus-core-lib/src/main/resources/nexus-core-lib/application.yml
+++ b/nexus-core-lib/src/main/resources/nexus-core-lib/application.yml
@@ -37,7 +37,7 @@ org:
           us-core: ig-packages/fhir-v4/us-core/stu-7.0.0
           sdoh: ig-packages/fhir-v4/sdoh-clinicalcare/stu-2.2.0
           uv-sdc: ig-packages/fhir-v4/uv-sdc/stu-3.0.0
-    baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+    baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
     validation-severity-level: error  # Possible values: fatal, error, warning, information
     structureDefinitionsUrls:
       bundle: /StructureDefinition/SHINNYBundleProfile


### PR DESCRIPTION
- Updated baseFHIRURL from http://test.shinny.org/us/ny/hrsn to http://shinny.org/us/ny/hrsn
- Applied change across all relevant application.yml files for PROD