### PR TITLE
feat: add DataLake API URL header support to CSV service module; bump version to 0.959.0 #2055

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/controller/CsvController.java
+++ b/csv-service/src/main/java/org/techbd/csv/controller/CsvController.java
@@ -95,6 +95,7 @@ public class CsvController {
   public ResponseEntity<Object> handleCsvUploadAndConversion(
       @Parameter(description = "ZIP file containing CSV data. Must not be null.", required = true) @RequestPart("file") @Nonnull MultipartFile file,
       @Parameter(description = "Parameter to specify the Tenant ID. This is a <b>mandatory</b> parameter.", required = true) @RequestHeader(value = Configuration.Servlet.HeaderName.Request.TENANT_ID, required = true) String tenantId,
+      @Parameter(description = "Optional header to specify the Datalake API URL. If not specified, the default URL mentioned in the application configuration will be used.", required = false) @RequestHeader(value = Constants.DATALAKE_API_URL, required = false) String customDataLakeApi,
       @Parameter(description = "Optional header to specify the base FHIR URL. If provided, it will be used in the generated FHIR; otherwise, the default value will be used.", required = false) @RequestHeader(value = "X-TechBD-Base-FHIR-URL", required = false) String baseFHIRURL,
       @Parameter(hidden = true, description = "Parameter to specify origin of the request.", required = false) @RequestParam(value = "origin", required = false,defaultValue = "HTTP") String origin,
       @Parameter(hidden = true, description = "Parameter to specify sftp session id.", required = false) @RequestParam(value = "sftp-session-id", required = false) String sftpSessionId,

--- a/csv-service/src/main/java/org/techbd/csv/service/FhirValidationServiceClient.java
+++ b/csv-service/src/main/java/org/techbd/csv/service/FhirValidationServiceClient.java
@@ -263,6 +263,7 @@ public class FhirValidationServiceClient {
         addOptionalHeader(headers, "X-TechBD-Provenance", request.provenance);
         addOptionalHeader(headers, "X-TechBD-Health-Check", request.healthCheck);
         addOptionalHeader(headers, "X-TechBD-Custom-DataLake-API", request.customDataLakeApi);
+        addOptionalHeader(headers, "X-TechBD-DataLake-API-URL", request.customDataLakeApi);
         addOptionalHeader(headers, "X-TechBD-DataLake-API-Content-Type", request.dataLakeApiContentType);
         addOptionalHeader(headers, "X-TechBD-MTLS-Strategy", request.mtlsStrategy);
         addOptionalHeader(headers, "X-TechBD-Elaboration", request.elaboration);

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.958.0</revision>
+        <revision>0.959.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Enabled DataLake API URL override through request header in the CSV service module.

- Bumped version to 0.959.0.