### PR TITLE
feat: update xslt files to include both NPI ID and TIN in the identifier array of Organization resource #2338

### DIFF
--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
@@ -118,8 +118,34 @@
       select="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:statusCode/@code" />
 
   <!-- Encounter status from the normal encounters section -->
-  <xsl:variable name="normalEncounterStatus"
-      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code"/>
+  <!-- <xsl:variable name="normalEncounterStatus"
+      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code"/> -->
+  <xsl:variable name="normalEncounterStatus">
+    <xsl:choose>
+      <!-- Case 1: statusCode exists -->
+      <xsl:when test="
+        string-length(
+          normalize-space(
+            /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code
+          )
+        ) &gt; 0
+      ">
+        <xsl:value-of select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code"/>
+      </xsl:when>
+
+      <!-- Case 2: statusCode missing AND moodCode = EVN -->
+      <xsl:when test="
+        normalize-space(
+          /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/@moodCode
+        ) = 'EVN'
+      ">
+        completed
+      </xsl:when>
+
+      <!-- Case 3: Otherwise empty -->
+      <xsl:otherwise/>    
+    </xsl:choose>
+  </xsl:variable>
 
   <!-- Final encounterStatus -->
   <xsl:variable name="encounterStatus">
@@ -703,7 +729,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>"
                 }
             }
         ]
@@ -818,10 +844,11 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <xsl:choose>
+            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <xsl:when test="$organizationNPI">
+              <!-- <xsl:when test="$organizationNPI"> -->
+              <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
                   "type": {
@@ -836,10 +863,14 @@
                   "system": "http://hl7.org/fhir/sid/us-npi",
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
-              </xsl:when>
+              </xsl:if>
+              <!-- </xsl:when> -->
+              
+              <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <xsl:when test="$organizationTIN">
+              <!-- <xsl:when test="$organizationTIN"> -->
+              <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
                   "type": {
@@ -854,8 +885,9 @@
                   "system": "http://www.irs.gov/",
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
-              </xsl:when>
-            </xsl:choose>
+              </xsl:if>
+              <!-- </xsl:when> -->
+            <!-- </xsl:choose> -->
           ],
         </xsl:if>
         "name" : "<xsl:choose>
@@ -964,11 +996,30 @@
   <!-- Sexual orientation Observation Template -->
   <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation">
     <xsl:if test="string(ccda:code/@code) = '76690-7'">
+
+      <xsl:variable name="resourceUUID">
+          <xsl:choose>
+            <xsl:when test="normalize-space(ccda:id/@extension)">
+              <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$sexualOrientationResourceId"/>
+            </xsl:otherwise>
+          </xsl:choose>
+      </xsl:variable>
+
+      <xsl:variable name="sexualOrientationResourceUUId">
+        <xsl:call-template name="generateFixedLengthResourceId">
+          <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+          <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
+        </xsl:call-template>
+      </xsl:variable>
+
       ,{
-        "fullUrl" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceId'/>",
+        "fullUrl" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceUUId'/>",
         "resource": {
           "resourceType": "Observation",
-          "id": "<xsl:value-of select='$sexualOrientationResourceId'/>",
+          "id": "<xsl:value-of select='$sexualOrientationResourceUUId'/>",
           "meta" : {
             "lastUpdated" : "<xsl:value-of select='$currentTimestamp'/>",
             "profile" : ["<xsl:value-of select='$observationSexualOrientationMetaProfileUrlFull'/>"]
@@ -1050,7 +1101,7 @@
         },
         "request" : {
           "method" : "POST",
-          "url" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceId'/>"
+          "url" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceUUId'/>"
         }
       }
     </xsl:if>
@@ -1088,10 +1139,23 @@
 
         <xsl:if test="string($categoryCode)">
 
+          <xsl:variable name="resourceUUID">
+            <xsl:choose>
+              <xsl:when test="normalize-space(ccda:id/@extension)">
+                <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="normalize-space(ccda:id/@root)"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+
           <xsl:variable name="observationResourceId">
             <xsl:call-template name="generateFixedLengthResourceId">
-              <xsl:with-param name="prefixString" select="$questionCode"/>
-              <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+              <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+              <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+              <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+              <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
             </xsl:call-template>
           </xsl:variable>
           ,{
@@ -1243,11 +1307,24 @@
                   <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                     "derivedFrom": [
                       <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                        <xsl:variable name="code" select="ccda:code/@code"/>
+                        <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
+                        <xsl:variable name="resourceUUID">
+                          <xsl:choose>
+                            <xsl:when test="normalize-space(ccda:id/@extension)">
+                              <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                              <xsl:value-of select="normalize-space(ccda:id/@root)"/>
+                            </xsl:otherwise>
+                          </xsl:choose>
+                        </xsl:variable>
+                
                         <xsl:variable name="observationResourceId">
                           <xsl:call-template name="generateFixedLengthResourceId">
-                            <xsl:with-param name="prefixString" select="$code"/>
-                            <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                            <!-- <xsl:with-param name="prefixString" select="$code"/>
+                            <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                            <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                            <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
                           </xsl:call-template>
                         </xsl:variable>
                         { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
@@ -1262,14 +1339,14 @@
                       "coding": [{
                         "system": "http://loinc.org",
                         "code": "<xsl:value-of select='ccda:value/@code'/>",
-                        "display": "<xsl:value-of select='ccda:value/@displayName'/>"
+                        "display": "<xsl:value-of select='normalize-space(ccda:value/@displayName)'/>"
                       }]
                       <xsl:choose>
                         <xsl:when test="ccda:value/@originalText">
-                          , "text": "<xsl:value-of select='ccda:value/@originalText'/>"
+                          , "text": "<xsl:value-of select='normalize-space(ccda:value/@originalText)'/>"
                         </xsl:when>
                         <xsl:when test="ccda:value/@displayName">
-                          , "text": "<xsl:value-of select='ccda:value/@displayName'/>"
+                          , "text": "<xsl:value-of select='normalize-space(ccda:value/@displayName)'/>"
                         </xsl:when>
                       </xsl:choose>
                     },
@@ -1754,9 +1831,11 @@
     <xsl:variable name="grouperObs" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation"/>
     <xsl:variable name="grouperScreening" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation[1]"/>
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
+
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
-            <xsl:with-param name="prefixString" select="$grouperScreeningCode"/>
+            <!-- <xsl:with-param name="prefixString" select="$grouperScreeningCode"/>-->
+            <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
             <xsl:with-param name="sha256ResourceId" select="$grouperObservationResourceSha256Id"/>
           </xsl:call-template>
         </xsl:variable>
@@ -1872,11 +1951,25 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
+
+                <xsl:variable name="resourceUUID">
+                  <xsl:choose>
+                    <xsl:when test="normalize-space(ccda:id/@extension)">
+                      <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:value-of select="normalize-space(ccda:id/@root)"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </xsl:variable>
+
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
                   </xsl:call-template>
                 </xsl:variable>
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.4 -->
+<!-- Version : 0.1.2 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -685,7 +685,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>"
                 }
             }
         ]
@@ -794,7 +794,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>"
                 }
             }
         ]
@@ -910,10 +910,11 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <xsl:choose>
+            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <xsl:when test="$organizationNPI">
+              <!-- <xsl:when test="$organizationNPI"> -->
+              <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
                   "type": {
@@ -928,10 +929,14 @@
                   "system": "http://hl7.org/fhir/sid/us-npi",
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
-              </xsl:when>
+              </xsl:if>
+              <!-- </xsl:when> -->
+              
+              <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <xsl:when test="$organizationTIN">
+              <!-- <xsl:when test="$organizationTIN"> -->
+              <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
                   "type": {
@@ -946,8 +951,9 @@
                   "system": "http://www.irs.gov/",
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
-              </xsl:when>
-            </xsl:choose>
+              </xsl:if>
+              <!-- </xsl:when> -->
+            <!-- </xsl:choose> -->
           ],
         </xsl:if>
         "name" : "<xsl:choose>
@@ -1059,11 +1065,30 @@
   <!-- Sexual orientation Observation Template -->
   <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation">
     <xsl:if test="string(ccda:code/@code) = '76690-7'">
+
+      <xsl:variable name="resourceUUID">
+          <xsl:choose>
+            <xsl:when test="normalize-space(ccda:id/@extension)">
+              <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$sexualOrientationResourceId"/>
+            </xsl:otherwise>
+          </xsl:choose>
+      </xsl:variable>
+
+      <xsl:variable name="sexualOrientationResourceUUId">
+        <xsl:call-template name="generateFixedLengthResourceId">
+          <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+          <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
+        </xsl:call-template>
+      </xsl:variable>
+
       ,{
-        "fullUrl" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceId'/>",
+        "fullUrl" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceUUId'/>",
         "resource": {
           "resourceType": "Observation",
-          "id": "<xsl:value-of select='$sexualOrientationResourceId'/>",
+          "id": "<xsl:value-of select='$sexualOrientationResourceUUId'/>",
           "meta" : {
             "lastUpdated" : "<xsl:value-of select='$currentTimestamp'/>",
             "profile" : ["<xsl:value-of select='$observationSexualOrientationMetaProfileUrlFull'/>"]
@@ -1145,7 +1170,7 @@
         },
         "request" : {
           "method" : "POST",
-          "url" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceId'/>"
+          "url" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceUUId'/>"
         }
       }
     </xsl:if>
@@ -1185,8 +1210,10 @@
 
               <xsl:variable name="observationResourceId">
                 <xsl:call-template name="generateFixedLengthResourceId">
-                  <xsl:with-param name="prefixString" select="$questionCode"/>
-                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                  <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                  <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                  <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
                 </xsl:call-template>
               </xsl:variable>
               ,{
@@ -1338,11 +1365,13 @@
                         <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                           "derivedFrom": [
                             <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                              <xsl:variable name="code" select="ccda:code/@code"/>
+                              <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
                               <xsl:variable name="observationResourceId">
                                 <xsl:call-template name="generateFixedLengthResourceId">
-                                  <xsl:with-param name="prefixString" select="$code"/>
-                                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                                  <!-- <xsl:with-param name="prefixString" select="$code"/>
+                                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                                  <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                                  <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                                 </xsl:call-template>
                               </xsl:variable>
                               { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
@@ -1355,14 +1384,14 @@
                           "coding": [{
                             "system": "http://loinc.org",
                             "code": "<xsl:value-of select='ccda:observation/ccda:value/@code'/>",
-                            "display": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                            "display": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                           }]
                           <xsl:choose>
                             <xsl:when test="ccda:observation/ccda:value/@originalText">
-                              , "text": "<xsl:value-of select='ccda:observation/ccda:value/@originalText'/>"
+                              , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@originalText)'/>"
                             </xsl:when>
                             <xsl:when test="ccda:observation/ccda:value/@displayName">
-                              , "text": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                              , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                             </xsl:when>
                           </xsl:choose>
                         },
@@ -1839,11 +1868,12 @@
 <!-- Grouper Observation Template -->
   <xsl:template name="GrouperObservation">
     <xsl:variable name="grouperObs" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship/ccda:observation/ccda:entryRelationship"/>
-    <xsl:variable name="grouperScreening" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation"/>
+    <xsl:variable name="grouperScreening" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation[1]"/>
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
-            <xsl:with-param name="prefixString" select="$grouperScreeningCode"/>
+            <!-- <xsl:with-param name="prefixString" select="$grouperScreeningCode"/>-->
+            <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
             <xsl:with-param name="sha256ResourceId" select="$grouperObservationResourceSha256Id"/>
           </xsl:call-template>
         </xsl:variable>
@@ -1959,11 +1989,13 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                   </xsl:call-template>
                 </xsl:variable>
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
@@ -675,7 +675,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>"
                 }
             }
         ]
@@ -790,10 +790,11 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <xsl:choose>
+            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <xsl:when test="$organizationNPI">
+              <!-- <xsl:when test="$organizationNPI"> -->
+              <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
                   "type": {
@@ -808,10 +809,14 @@
                   "system": "http://hl7.org/fhir/sid/us-npi",
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
-              </xsl:when>
+              </xsl:if>
+              <!-- </xsl:when> -->
+              
+              <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <xsl:when test="$organizationTIN">
+              <!-- <xsl:when test="$organizationTIN"> -->
+              <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
                   "type": {
@@ -826,8 +831,9 @@
                   "system": "http://www.irs.gov/",
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
-              </xsl:when>
-            </xsl:choose>
+              </xsl:if>
+              <!-- </xsl:when> -->
+            <!-- </xsl:choose> -->
           ],
         </xsl:if>
         "name" : "<xsl:choose>
@@ -936,11 +942,30 @@
   <!-- Sexual orientation Observation Template -->
   <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation">
     <xsl:if test="string(ccda:code/@code) = '76690-7'">
+      
+      <xsl:variable name="resourceUUID">
+        <xsl:choose>
+          <xsl:when test="normalize-space(ccda:id/@extension)">
+            <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="normalize-space($sexualOrientationResourceId)"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:variable name="sexualOrientationResourceUUId">
+        <xsl:call-template name="generateFixedLengthResourceId">
+          <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+          <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
+        </xsl:call-template>
+      </xsl:variable>
+
       ,{
-        "fullUrl" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceId'/>",
+        "fullUrl" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceUUId'/>",
         "resource": {
           "resourceType": "Observation",
-          "id": "<xsl:value-of select='$sexualOrientationResourceId'/>",
+          "id": "<xsl:value-of select='$sexualOrientationResourceUUId'/>",
           "meta" : {
             "lastUpdated" : "<xsl:value-of select='$currentTimestamp'/>",
             "profile" : ["<xsl:value-of select='$observationSexualOrientationMetaProfileUrlFull'/>"]
@@ -1020,7 +1045,7 @@
         },
         "request" : {
           "method" : "POST",
-          "url" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceId'/>"
+          "url" : "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$sexualOrientationResourceUUId'/>"
         }
       }
     </xsl:if>
@@ -1065,11 +1090,23 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
+            <xsl:variable name="observationPrefix">
+                <xsl:choose>                  
+                  <xsl:when test="ccda:observation/ccda:code/@code = '95614-4'"> <!-- Total Safety Score -->
+                    <xsl:value-of select="concat($facilityID, '-', ccda:observation/ccda:value/@value)"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="concat($facilityID, '-')"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:variable>
 
             <xsl:variable name="observationResourceId">
               <xsl:call-template name="generateFixedLengthResourceId">
-                <xsl:with-param name="prefixString" select="$questionCode"/>
-                <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
+                <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
               </xsl:call-template>
             </xsl:variable>
             ,{
@@ -1219,11 +1256,13 @@
                           <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                             "derivedFrom": [
                               <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                                <xsl:variable name="code" select="ccda:code/@code"/>
+                                <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
                                 <xsl:variable name="observationResourceId">
                                   <xsl:call-template name="generateFixedLengthResourceId">
-                                    <xsl:with-param name="prefixString" select="$code"/>
-                                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                                    <!-- <xsl:with-param name="prefixString" select="$code"/>
+                                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                                   </xsl:call-template>
                                 </xsl:variable>
                                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
@@ -1236,14 +1275,14 @@
                             "coding": [{
                               "system": "http://loinc.org",
                               "code": "<xsl:value-of select='ccda:observation/ccda:value/@code'/>",
-                              "display": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                              "display": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                             }]
                             <xsl:choose>
                               <xsl:when test="ccda:observation/ccda:value/@originalText">
-                                , "text": "<xsl:value-of select='ccda:observation/ccda:value/@originalText'/>"
+                                , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@originalText)'/>"
                               </xsl:when>
                               <xsl:when test="ccda:observation/ccda:value/@displayName">
-                                , "text": "<xsl:value-of select='ccda:observation/ccda:value/@displayName'/>"
+                                , "text": "<xsl:value-of select='normalize-space(ccda:observation/ccda:value/@displayName)'/>"
                               </xsl:when>
                             </xsl:choose>
                           },
@@ -1836,10 +1875,11 @@
     </xsl:variable>
 
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
-      <xsl:for-each select="$grouperObs[ccda:code/@code = $screeningCode]"> <!--'96777-8'-->
+      <xsl:for-each select="$grouperObs[ccda:code/@code = $screeningCode]"> <!--'96777-8'-->       
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
-            <xsl:with-param name="prefixString" select="concat(generate-id(ccda:code/@code), position())"/>
+            <!-- <xsl:with-param name="prefixString" select="concat(generate-id(ccda:code/@code), position())"/>-->
+            <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
             <xsl:with-param name="sha256ResourceId" select="$grouperObservationResourceSha256Id"/>
           </xsl:call-template>
         </xsl:variable>
@@ -1955,11 +1995,24 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
+                <xsl:variable name="observationPrefix">
+                  <xsl:choose>                  
+                    <xsl:when test="ccda:code/@code = '95614-4'"> <!-- Total Safety Score -->
+                      <xsl:value-of select="concat($facilityID, '-', ccda:value/@value)"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:value-of select="concat($facilityID, '-')"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </xsl:variable>
+
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/>
+                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
+                    <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
+                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                   </xsl:call-template>
                 </xsl:variable>
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -729,7 +729,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>"
                 }
             }
         ]
@@ -844,10 +844,11 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <xsl:choose>
+            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <xsl:when test="$organizationNPI">
+              <!-- <xsl:when test="$organizationNPI"> -->
+              <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
                   "type": {
@@ -862,10 +863,14 @@
                   "system": "http://hl7.org/fhir/sid/us-npi",
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
-              </xsl:when>
+              </xsl:if>
+              <!-- </xsl:when> -->
+              
+              <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <xsl:when test="$organizationTIN">
+              <!-- <xsl:when test="$organizationTIN"> -->
+              <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
                   "type": {
@@ -880,8 +885,9 @@
                   "system": "http://www.irs.gov/",
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
-              </xsl:when>
-            </xsl:choose>
+              </xsl:if>
+              <!-- </xsl:when> -->
+            <!-- </xsl:choose> -->
           ],
         </xsl:if>
         "name" : "<xsl:choose>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -685,7 +685,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>"
                 }
             }
         ]
@@ -794,7 +794,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>"
                 }
             }
         ]
@@ -910,10 +910,11 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <xsl:choose>
+            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <xsl:when test="$organizationNPI">
+              <!-- <xsl:when test="$organizationNPI"> -->
+              <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
                   "type": {
@@ -928,10 +929,14 @@
                   "system": "http://hl7.org/fhir/sid/us-npi",
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
-              </xsl:when>
+              </xsl:if>
+              <!-- </xsl:when> -->
+              
+              <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <xsl:when test="$organizationTIN">
+              <!-- <xsl:when test="$organizationTIN"> -->
+              <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
                   "type": {
@@ -946,8 +951,9 @@
                   "system": "http://www.irs.gov/",
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
-              </xsl:when>
-            </xsl:choose>
+              </xsl:if>
+              <!-- </xsl:when> -->
+            <!-- </xsl:choose> -->
           ],
         </xsl:if>
         "name" : "<xsl:choose>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -675,7 +675,7 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>"
+                    "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>"
                 }
             }
         ]
@@ -790,10 +790,11 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <xsl:choose>
+            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <xsl:when test="$organizationNPI">
+              <!-- <xsl:when test="$organizationNPI"> -->
+              <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
                   "type": {
@@ -808,10 +809,14 @@
                   "system": "http://hl7.org/fhir/sid/us-npi",
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
-              </xsl:when>
+              </xsl:if>
+              <!-- </xsl:when> -->
+              
+              <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <xsl:when test="$organizationTIN">
+              <!-- <xsl:when test="$organizationTIN"> -->
+              <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
                   "type": {
@@ -826,8 +831,9 @@
                   "system": "http://www.irs.gov/",
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
-              </xsl:when>
-            </xsl:choose>
+              </xsl:if>
+              <!-- </xsl:when> -->
+            <!-- </xsl:choose> -->
           ],
         </xsl:if>
         "name" : "<xsl:choose>


### PR DESCRIPTION
Updated xslt files to include both NPI ID and TIN in the identifier array of Organization resource.
- updated for Epic, Medent and AthenaHealth CCDA files.