### PR TITLE
feat: update xslt files to change the logic of resource id generation of Observation resources for Epic, Medent and AthenaHealth CCDA files #2470

### DIFF
--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.4 -->
+<!-- Version : 0.1.2 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -1139,13 +1139,46 @@
 
         <xsl:if test="string($categoryCode)">
 
-          <xsl:variable name="resourceUUID">
+          <!-- <xsl:variable name="resourceUUID">
             <xsl:choose>
               <xsl:when test="normalize-space(ccda:id/@extension)">
                 <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:value-of select="normalize-space(ccda:id/@root)"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable> -->
+          <xsl:variable name="encounterEffectiveTime">
+              <xsl:choose>
+                  <xsl:when test="ccda:effectiveTime/@value">
+                      <xsl:call-template name="formatDateTime">
+                          <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                      </xsl:call-template>
+                  </xsl:when>
+                  <xsl:when test="$encounterEffectiveTimeValue">
+                      <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                      <xsl:value-of select="$currentTimestamp"/>
+                  </xsl:otherwise>
+              </xsl:choose>
+          </xsl:variable>
+
+          <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+          <xsl:variable name="observationIdSource">
+            <xsl:choose>
+              <!-- Use extension if present and not empty -->
+              <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
+              </xsl:when>
+
+              <!-- Fallback: questionCode + encounterEffectiveTime -->
+              <xsl:otherwise>
+                <xsl:value-of
+                  select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
               </xsl:otherwise>
             </xsl:choose>
           </xsl:variable>
@@ -1155,7 +1188,8 @@
               <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
               <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
               <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-              <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
+              <!-- <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/> -->
+              <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
             </xsl:call-template>
           </xsl:variable>
           ,{
@@ -1307,8 +1341,7 @@
                   <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                     "derivedFrom": [
                       <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                        <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
-                        <xsl:variable name="resourceUUID">
+                        <!-- <xsl:variable name="resourceUUID">
                           <xsl:choose>
                             <xsl:when test="normalize-space(ccda:id/@extension)">
                               <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
@@ -1317,17 +1350,49 @@
                               <xsl:value-of select="normalize-space(ccda:id/@root)"/>
                             </xsl:otherwise>
                           </xsl:choose>
+                        </xsl:variable> -->
+                        <xsl:variable name="encounterEffectiveTimeDF">
+                            <xsl:choose>
+                                <xsl:when test="ccda:effectiveTime/@value">
+                                    <xsl:call-template name="formatDateTime">
+                                        <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                                    </xsl:call-template>
+                                </xsl:when>
+                                <xsl:when test="$encounterEffectiveTimeValue">
+                                    <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="$currentTimestamp"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
                         </xsl:variable>
-                
-                        <xsl:variable name="observationResourceId">
+
+                        <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                        <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
+
+                        <xsl:variable name="observationIdSourceDF">
+                          <xsl:choose>
+                            <!-- Use extension if present and not empty -->
+                            <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                              <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                              <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
+                            </xsl:when>
+
+                            <!-- Fallback: questionCode + encounterEffectiveTime -->
+                            <xsl:otherwise>
+                              <xsl:value-of
+                                select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                            </xsl:otherwise>
+                          </xsl:choose>
+                        </xsl:variable>
+
+                        <xsl:variable name="observationResourceIdDF">
                           <xsl:call-template name="generateFixedLengthResourceId">
-                            <!-- <xsl:with-param name="prefixString" select="$code"/>
-                            <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                             <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                            <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
+                            <xsl:with-param name="sha256ResourceId" select="$observationIdSourceDF"/>
                           </xsl:call-template>
-                        </xsl:variable>
-                        { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
+                        </xsl:variable>                
+                        { "reference": "Observation/<xsl:value-of select='$observationResourceIdDF'/>" }<xsl:if test="position() != last()">,</xsl:if>
                       </xsl:for-each>
                     ],
                   </xsl:if>
@@ -1364,7 +1429,7 @@
               </xsl:if>
 
               <!-- effectiveDateTime block -->
-              <xsl:if test="ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
+              <!-- <xsl:if test="ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
                 , "effectiveDateTime": "<xsl:choose>
                                           <xsl:when test="ccda:effectiveTime/@value">
                                               <xsl:call-template name="formatDateTime">
@@ -1378,7 +1443,8 @@
                                               <xsl:value-of select="$currentTimestamp"/>
                                           </xsl:otherwise>
                                         </xsl:choose>"
-              </xsl:if>
+              </xsl:if> -->
+              , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
 
               <xsl:if test="string($organizationResourceId)">
               , "performer": [{
@@ -1749,52 +1815,105 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- middle name extension -->
         <xsl:if test="string($selectedName/ccda:given)">
             "extension": [{
-              "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-              "valueString" : "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
+                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
             }]
         </xsl:if>
+
+        <!-- use -->
         <xsl:if test="$selectedName/@use">
             <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
             "use": "<xsl:choose>
-                <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
-                <xsl:otherwise><xsl:value-of select="$selectedName/@use"/></xsl:otherwise>
-            </xsl:choose>"
-        </xsl:if>                        
-        <xsl:if test="string($selectedName/ccda:prefix)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix)">, </xsl:if>
+                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
+                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$selectedName/@use"/>
+                        </xsl:otherwise>
+                    </xsl:choose>"
+        </xsl:if>
+
+        <!-- prefix -->
+        <xsl:if test="string($selectedName/ccda:prefix)">
+            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
             "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:given)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix)">, </xsl:if>
+
+        <!-- given -->
+        <xsl:if test="string($selectedName/ccda:given)">
+            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
             "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:family)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given)">, </xsl:if>
+
+        <!-- family -->
+        <xsl:if test="string($selectedName/ccda:family)">
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given)
+            ">, </xsl:if>
             "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
         </xsl:if>
+
+        <!-- suffix -->
         <xsl:if test="string($selectedName/ccda:suffix)">
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given) or string($selectedName/ccda:family)">, </xsl:if>
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:family)
+            ">, </xsl:if>
             "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
         </xsl:if>
-        <xsl:if test="($selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')) or 
-                  ($selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))">
-          <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:family) or string($selectedName/ccda:suffix)">, </xsl:if>
-          "period": {
-              <xsl:if test="$selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')">
-                  "start": "<xsl:call-template name="formatDateTime">
-                                <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:low/@value"/>
+
+        <!-- period -->
+        <xsl:if test="
+            ($selectedName/ccda:validTime/ccda:low and
+            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            or
+            ($selectedName/ccda:validTime/ccda:high and
+            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+        ">
+            <xsl:if test="
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:family) or
+                string($selectedName/ccda:suffix) or
+                $selectedName/@use
+            ">, </xsl:if>
+
+            "period": {
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:low and
+                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                ">
+                    "start": "<xsl:call-template name="formatDateTime">
+                                  <xsl:with-param name="dateTime"
+                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                              </xsl:call-template>"
+                    <xsl:if test="
+                        $selectedName/ccda:validTime/ccda:high and
+                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    ">,</xsl:if>
+                </xsl:if>
+
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:high and
+                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                ">
+                    "end": "<xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime"
+                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
                             </xsl:call-template>"
-                  <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">,</xsl:if>
-              </xsl:if>
-              <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">
-                  "end": "<xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:high/@value"/>
-                          </xsl:call-template>"
-              </xsl:if>
-          }
+                </xsl:if>
+            }
         </xsl:if>
     }
 </xsl:template>
@@ -1951,9 +2070,9 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
+                <xsl:variable name="questionCode" select="ccda:code/@code"/>
 
-                <xsl:variable name="resourceUUID">
+                <!-- <xsl:variable name="resourceUUID">
                   <xsl:choose>
                     <xsl:when test="normalize-space(ccda:id/@extension)">
                       <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
@@ -1962,14 +2081,47 @@
                       <xsl:value-of select="normalize-space(ccda:id/@root)"/>
                     </xsl:otherwise>
                   </xsl:choose>
+                </xsl:variable> -->
+
+                <xsl:variable name="encounterEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+
+                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+                <xsl:variable name="observationIdSource">
+                  <xsl:choose>
+                    <!-- Use extension if present and not empty -->
+                    <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                      <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
+                    </xsl:when>
+
+                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <xsl:otherwise>
+                      <xsl:value-of
+                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
                 </xsl:variable>
 
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                    <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
+                    <!-- <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/> -->
+                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
                   </xsl:call-template>
                 </xsl:variable>
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -1207,13 +1207,47 @@
                 </xsl:variable>
 
           <xsl:if test="string($categoryCode)">
+              <xsl:variable name="encounterEffectiveTime">
+                  <xsl:choose>
+                      <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
+                          <xsl:call-template name="formatDateTime">
+                              <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
+                          </xsl:call-template>
+                      </xsl:when>
+                      <xsl:when test="$encounterEffectiveTimeValue">
+                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$currentTimestamp"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+              <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+              <xsl:variable name="observationIdSource">
+                <xsl:choose>
+                  <!-- Use extension if present and not empty -->
+                  <xsl:when test="ccda:observation/ccda:id/@extension and normalize-space(ccda:observation/ccda:id/@extension) != ''">
+                    <!-- <xsl:value-of select="ccda:observation/ccda:id/@extension"/> -->
+                    <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
+                  </xsl:when>
+
+                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                  <xsl:otherwise>
+                    <xsl:value-of
+                      select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:variable>
 
               <xsl:variable name="observationResourceId">
                 <xsl:call-template name="generateFixedLengthResourceId">
                   <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
                   <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                   <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                  <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
+                  <!-- <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/> -->
+                  <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
                 </xsl:call-template>
               </xsl:variable>
               ,{
@@ -1365,16 +1399,56 @@
                         <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                           "derivedFrom": [
                             <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                              <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
-                              <xsl:variable name="observationResourceId">
+                              <!-- <xsl:variable name="observationResourceId">
                                 <xsl:call-template name="generateFixedLengthResourceId">
-                                  <!-- <xsl:with-param name="prefixString" select="$code"/>
-                                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                                   <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
                                   <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                                 </xsl:call-template>
+                              </xsl:variable> -->
+
+                              <xsl:variable name="encounterEffectiveTimeDF">
+                                  <xsl:choose>
+                                      <xsl:when test="ccda:effectiveTime/@value">
+                                          <xsl:call-template name="formatDateTime">
+                                              <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                                          </xsl:call-template>
+                                      </xsl:when>
+                                      <xsl:when test="$encounterEffectiveTimeValue">
+                                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                                      </xsl:when>
+                                      <xsl:otherwise>
+                                          <xsl:value-of select="$currentTimestamp"/>
+                                      </xsl:otherwise>
+                                  </xsl:choose>
                               </xsl:variable>
-                              { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
+
+                              <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                              <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
+
+                              <xsl:variable name="observationIdSourceDF">
+                                <xsl:choose>
+                                  <!-- Use extension if present and not empty -->
+                                  <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                                    <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                                    <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
+                                  </xsl:when>
+
+                                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                                  <xsl:otherwise>
+                                    <xsl:value-of
+                                      select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                                  </xsl:otherwise>
+                                </xsl:choose>
+                              </xsl:variable>
+
+                              <xsl:variable name="observationResourceIdDF">
+                                <xsl:call-template name="generateFixedLengthResourceId">
+                                  <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                                  <xsl:with-param name="sha256ResourceId" select="$observationIdSourceDF"/>
+                                </xsl:call-template>
+                              </xsl:variable>
+
+                              { "reference": "Observation/<xsl:value-of select='$observationResourceIdDF'/>" }<xsl:if test="position() != last()">,</xsl:if>
                             </xsl:for-each>
                           ],
                         </xsl:if>
@@ -1406,7 +1480,7 @@
                       "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                     }
                   </xsl:if>
-                  <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
+                  <!-- <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
                     , "effectiveDateTime": "<xsl:choose>
                                               <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
                                                   <xsl:call-template name="formatDateTime">
@@ -1420,7 +1494,8 @@
                                                   <xsl:value-of select="$currentTimestamp"/>
                                               </xsl:otherwise>
                                           </xsl:choose>"
-                  </xsl:if>
+                  </xsl:if> -->
+                  , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
                   <xsl:if test="string($organizationResourceId)">
                   , "performer": [{
                                 "reference": "Organization/<xsl:value-of select='$organizationResourceId'/>"
@@ -1788,52 +1863,105 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- middle name extension -->
         <xsl:if test="string($selectedName/ccda:given)">
             "extension": [{
-              "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-              "valueString" : "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
+                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
             }]
         </xsl:if>
+
+        <!-- use -->
         <xsl:if test="$selectedName/@use">
             <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
             "use": "<xsl:choose>
-                <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
-                <xsl:otherwise><xsl:value-of select="$selectedName/@use"/></xsl:otherwise>
-            </xsl:choose>"
-        </xsl:if>                        
-        <xsl:if test="string($selectedName/ccda:prefix)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix)">, </xsl:if>
+                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
+                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$selectedName/@use"/>
+                        </xsl:otherwise>
+                    </xsl:choose>"
+        </xsl:if>
+
+        <!-- prefix -->
+        <xsl:if test="string($selectedName/ccda:prefix)">
+            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
             "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:given)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix)">, </xsl:if>
+
+        <!-- given -->
+        <xsl:if test="string($selectedName/ccda:given)">
+            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
             "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:family)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given)">, </xsl:if>
+
+        <!-- family -->
+        <xsl:if test="string($selectedName/ccda:family)">
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given)
+            ">, </xsl:if>
             "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
         </xsl:if>
+
+        <!-- suffix -->
         <xsl:if test="string($selectedName/ccda:suffix)">
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given) or string($selectedName/ccda:family)">, </xsl:if>
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:family)
+            ">, </xsl:if>
             "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
         </xsl:if>
-        <xsl:if test="($selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')) or 
-                  ($selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))">
-          <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:family) or string($selectedName/ccda:suffix)">, </xsl:if>
-          "period": {
-              <xsl:if test="$selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')">
-                  "start": "<xsl:call-template name="formatDateTime">
-                                <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:low/@value"/>
+
+        <!-- period -->
+        <xsl:if test="
+            ($selectedName/ccda:validTime/ccda:low and
+            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            or
+            ($selectedName/ccda:validTime/ccda:high and
+            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+        ">
+            <xsl:if test="
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:family) or
+                string($selectedName/ccda:suffix) or
+                $selectedName/@use
+            ">, </xsl:if>
+
+            "period": {
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:low and
+                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                ">
+                    "start": "<xsl:call-template name="formatDateTime">
+                                  <xsl:with-param name="dateTime"
+                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                              </xsl:call-template>"
+                    <xsl:if test="
+                        $selectedName/ccda:validTime/ccda:high and
+                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    ">,</xsl:if>
+                </xsl:if>
+
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:high and
+                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                ">
+                    "end": "<xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime"
+                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
                             </xsl:call-template>"
-                  <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">,</xsl:if>
-              </xsl:if>
-              <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">
-                  "end": "<xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:high/@value"/>
-                          </xsl:call-template>"
-              </xsl:if>
-          }
+                </xsl:if>
+            }
         </xsl:if>
     }
 </xsl:template>
@@ -1989,15 +2117,55 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
-                <xsl:variable name="observationResourceId">
+                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
                     <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                   </xsl:call-template>
+                </xsl:variable> -->
+
+                <xsl:variable name="encounterEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:variable>
+
+                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+                <xsl:variable name="observationIdSource">
+                  <xsl:choose>
+                    <!-- Use extension if present and not empty -->
+                    <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                      <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
+                    </xsl:when>
+
+                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <xsl:otherwise>
+                      <xsl:value-of
+                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </xsl:variable>
+
+                <xsl:variable name="observationResourceId">
+                  <xsl:call-template name="generateFixedLengthResourceId">
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
+                  </xsl:call-template>
+                </xsl:variable>
+
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
               </xsl:for-each>
             ]

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.4 -->
+<!-- Version : 0.1.2 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -1090,13 +1090,46 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
-            <xsl:variable name="observationPrefix">
+            <!-- <xsl:variable name="observationPrefix">
                 <xsl:choose>                  
-                  <xsl:when test="ccda:observation/ccda:code/@code = '95614-4'"> <!-- Total Safety Score -->
+                  <xsl:when test="ccda:observation/ccda:code/@code = '95614-4'"> Total Safety Score
                     <xsl:value-of select="concat($facilityID, '-', ccda:observation/ccda:value/@value)"/>
                   </xsl:when>
                   <xsl:otherwise>
                     <xsl:value-of select="concat($facilityID, '-')"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:variable> -->
+            <xsl:variable name="encounterEffectiveTime">
+                  <xsl:choose>
+                      <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
+                          <xsl:call-template name="formatDateTime">
+                              <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
+                          </xsl:call-template>
+                      </xsl:when>
+                      <xsl:when test="$encounterEffectiveTimeValue">
+                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$currentTimestamp"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+              <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+              <xsl:variable name="observationIdSource">
+                <xsl:choose>
+                  <!-- Use extension if present and not empty -->
+                  <xsl:when test="ccda:observation/ccda:id/@extension and normalize-space(ccda:observation/ccda:id/@extension) != ''">
+                    <!-- <xsl:value-of select="ccda:observation/ccda:id/@extension"/> -->
+                    <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
+                  </xsl:when>
+
+                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                  <xsl:otherwise>
+                    <xsl:value-of
+                      select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
                   </xsl:otherwise>
                 </xsl:choose>
               </xsl:variable>
@@ -1105,8 +1138,10 @@
               <xsl:call-template name="generateFixedLengthResourceId">
                 <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
                 <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
-                <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
-                <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
+                <!-- <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/> -->
+                <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                <!-- <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/> -->
+                <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
               </xsl:call-template>
             </xsl:variable>
             ,{
@@ -1256,16 +1291,54 @@
                           <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                             "derivedFrom": [
                               <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                                <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
-                                <xsl:variable name="observationResourceId">
+                                <!-- <xsl:variable name="observationResourceId">
                                   <xsl:call-template name="generateFixedLengthResourceId">
-                                    <!-- <xsl:with-param name="prefixString" select="$code"/>
-                                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
                                     <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                                   </xsl:call-template>
+                                </xsl:variable> -->
+                                <xsl:variable name="encounterEffectiveTimeDF">
+                                    <xsl:choose>
+                                        <xsl:when test="ccda:effectiveTime/@value">
+                                            <xsl:call-template name="formatDateTime">
+                                                <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                                            </xsl:call-template>
+                                        </xsl:when>
+                                        <xsl:when test="$encounterEffectiveTimeValue">
+                                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:value-of select="$currentTimestamp"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
                                 </xsl:variable>
-                                { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
+
+                                <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                                <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
+
+                                <xsl:variable name="observationIdSourceDF">
+                                  <xsl:choose>
+                                    <!-- Use extension if present and not empty -->
+                                    <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                                      <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
+                                    </xsl:when>
+
+                                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                                    <xsl:otherwise>
+                                      <xsl:value-of
+                                        select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                                    </xsl:otherwise>
+                                  </xsl:choose>
+                                </xsl:variable>
+
+                                <xsl:variable name="observationResourceIdDF">
+                                  <xsl:call-template name="generateFixedLengthResourceId">
+                                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                                    <xsl:with-param name="sha256ResourceId" select="$observationIdSourceDF"/>
+                                  </xsl:call-template>
+                                </xsl:variable>
+                                { "reference": "Observation/<xsl:value-of select='$observationResourceIdDF'/>" }<xsl:if test="position() != last()">,</xsl:if>
                               </xsl:for-each>
                             ],
                           </xsl:if>
@@ -1297,7 +1370,7 @@
                     "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                   }
                 </xsl:if>
-                <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
+                <!-- <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
                   , "effectiveDateTime": "<xsl:choose>
                                             <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
                                                 <xsl:call-template name="formatDateTime">
@@ -1311,7 +1384,8 @@
                                                 <xsl:value-of select="$currentTimestamp"/>
                                             </xsl:otherwise>
                                         </xsl:choose>"
-                </xsl:if>
+                </xsl:if> -->
+                , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
                 <xsl:if test="string($organizationResourceId)">
                 , "performer": [{
                               "reference": "Organization/<xsl:value-of select='$organizationResourceId'/>"
@@ -1696,52 +1770,105 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- middle name extension -->
         <xsl:if test="string($selectedName/ccda:given)">
             "extension": [{
-              "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-              "valueString" : "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
+                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
             }]
         </xsl:if>
+
+        <!-- use -->
         <xsl:if test="$selectedName/@use">
             <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
             "use": "<xsl:choose>
-                <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
-                <xsl:otherwise><xsl:value-of select="$selectedName/@use"/></xsl:otherwise>
-            </xsl:choose>"
-        </xsl:if>                        
-        <xsl:if test="string($selectedName/ccda:prefix)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix)">, </xsl:if>
+                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
+                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$selectedName/@use"/>
+                        </xsl:otherwise>
+                    </xsl:choose>"
+        </xsl:if>
+
+        <!-- prefix -->
+        <xsl:if test="string($selectedName/ccda:prefix)">
+            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
             "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:given)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix)">, </xsl:if>
+
+        <!-- given -->
+        <xsl:if test="string($selectedName/ccda:given)">
+            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
             "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:family)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given)">, </xsl:if>
+
+        <!-- family -->
+        <xsl:if test="string($selectedName/ccda:family)">
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given)
+            ">, </xsl:if>
             "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
         </xsl:if>
+
+        <!-- suffix -->
         <xsl:if test="string($selectedName/ccda:suffix)">
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given) or string($selectedName/ccda:family)">, </xsl:if>
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:family)
+            ">, </xsl:if>
             "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
         </xsl:if>
-        <xsl:if test="($selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')) or 
-                  ($selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))">
-          <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:family) or string($selectedName/ccda:suffix)">, </xsl:if>
-          "period": {
-              <xsl:if test="$selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')">
-                  "start": "<xsl:call-template name="formatDateTime">
-                                <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:low/@value"/>
+
+        <!-- period -->
+        <xsl:if test="
+            ($selectedName/ccda:validTime/ccda:low and
+            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            or
+            ($selectedName/ccda:validTime/ccda:high and
+            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+        ">
+            <xsl:if test="
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:family) or
+                string($selectedName/ccda:suffix) or
+                $selectedName/@use
+            ">, </xsl:if>
+
+            "period": {
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:low and
+                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                ">
+                    "start": "<xsl:call-template name="formatDateTime">
+                                  <xsl:with-param name="dateTime"
+                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                              </xsl:call-template>"
+                    <xsl:if test="
+                        $selectedName/ccda:validTime/ccda:high and
+                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    ">,</xsl:if>
+                </xsl:if>
+
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:high and
+                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                ">
+                    "end": "<xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime"
+                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
                             </xsl:call-template>"
-                  <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">,</xsl:if>
-              </xsl:if>
-              <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">
-                  "end": "<xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:high/@value"/>
-                          </xsl:call-template>"
-              </xsl:if>
-          }
+                </xsl:if>
+            }
         </xsl:if>
     }
 </xsl:template>
@@ -1995,26 +2122,65 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
-                <xsl:variable name="observationPrefix">
+                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="observationPrefix">
                   <xsl:choose>                  
-                    <xsl:when test="ccda:code/@code = '95614-4'"> <!-- Total Safety Score -->
+                    <xsl:when test="ccda:code/@code = '95614-4'"> Total Safety Score
                       <xsl:value-of select="concat($facilityID, '-', ccda:value/@value)"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <xsl:value-of select="concat($facilityID, '-')"/>
                     </xsl:otherwise>
                   </xsl:choose>
+                </xsl:variable> -->
+
+                <!-- <xsl:variable name="observationResourceId">
+                  <xsl:call-template name="generateFixedLengthResourceId">
+                    <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
+                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
+                  </xsl:call-template>
+                </xsl:variable> -->
+                <xsl:variable name="encounterEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+
+                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+                <xsl:variable name="observationIdSource">
+                  <xsl:choose>
+                    <!-- Use extension if present and not empty -->
+                    <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                      <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
+                    </xsl:when>
+
+                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <xsl:otherwise>
+                      <xsl:value-of
+                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
                 </xsl:variable>
 
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
-                    <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
-                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
                   </xsl:call-template>
                 </xsl:variable>
+
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
               </xsl:for-each>
             ]

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -1207,13 +1207,47 @@
                 </xsl:variable>
 
           <xsl:if test="string($categoryCode)">
+              <xsl:variable name="encounterEffectiveTime">
+                  <xsl:choose>
+                      <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
+                          <xsl:call-template name="formatDateTime">
+                              <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
+                          </xsl:call-template>
+                      </xsl:when>
+                      <xsl:when test="$encounterEffectiveTimeValue">
+                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$currentTimestamp"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+              <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+              <xsl:variable name="observationIdSource">
+                <xsl:choose>
+                  <!-- Use extension if present and not empty -->
+                  <xsl:when test="ccda:observation/ccda:id/@extension and normalize-space(ccda:observation/ccda:id/@extension) != ''">
+                    <!-- <xsl:value-of select="ccda:observation/ccda:id/@extension"/> -->
+                    <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
+                  </xsl:when>
+
+                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                  <xsl:otherwise>
+                    <xsl:value-of
+                      select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:variable>
 
               <xsl:variable name="observationResourceId">
                 <xsl:call-template name="generateFixedLengthResourceId">
                   <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
                   <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                   <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                  <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
+                  <!-- <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/> -->
+                  <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
                 </xsl:call-template>
               </xsl:variable>
               ,{
@@ -1365,16 +1399,56 @@
                         <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                           "derivedFrom": [
                             <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                              <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
-                              <xsl:variable name="observationResourceId">
+                              <!-- <xsl:variable name="observationResourceId">
                                 <xsl:call-template name="generateFixedLengthResourceId">
-                                  <!-- <xsl:with-param name="prefixString" select="$code"/>
-                                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                                   <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
                                   <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                                 </xsl:call-template>
+                              </xsl:variable> -->
+
+                              <xsl:variable name="encounterEffectiveTimeDF">
+                                  <xsl:choose>
+                                      <xsl:when test="ccda:effectiveTime/@value">
+                                          <xsl:call-template name="formatDateTime">
+                                              <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                                          </xsl:call-template>
+                                      </xsl:when>
+                                      <xsl:when test="$encounterEffectiveTimeValue">
+                                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                                      </xsl:when>
+                                      <xsl:otherwise>
+                                          <xsl:value-of select="$currentTimestamp"/>
+                                      </xsl:otherwise>
+                                  </xsl:choose>
                               </xsl:variable>
-                              { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
+
+                              <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                              <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
+
+                              <xsl:variable name="observationIdSourceDF">
+                                <xsl:choose>
+                                  <!-- Use extension if present and not empty -->
+                                  <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                                    <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                                    <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
+                                  </xsl:when>
+
+                                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                                  <xsl:otherwise>
+                                    <xsl:value-of
+                                      select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                                  </xsl:otherwise>
+                                </xsl:choose>
+                              </xsl:variable>
+
+                              <xsl:variable name="observationResourceIdDF">
+                                <xsl:call-template name="generateFixedLengthResourceId">
+                                  <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                                  <xsl:with-param name="sha256ResourceId" select="$observationIdSourceDF"/>
+                                </xsl:call-template>
+                              </xsl:variable>
+
+                              { "reference": "Observation/<xsl:value-of select='$observationResourceIdDF'/>" }<xsl:if test="position() != last()">,</xsl:if>
                             </xsl:for-each>
                           ],
                         </xsl:if>
@@ -1406,7 +1480,7 @@
                       "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                     }
                   </xsl:if>
-                  <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
+                  <!-- <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
                     , "effectiveDateTime": "<xsl:choose>
                                               <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
                                                   <xsl:call-template name="formatDateTime">
@@ -1420,7 +1494,8 @@
                                                   <xsl:value-of select="$currentTimestamp"/>
                                               </xsl:otherwise>
                                           </xsl:choose>"
-                  </xsl:if>
+                  </xsl:if> -->
+                  , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
                   <xsl:if test="string($organizationResourceId)">
                   , "performer": [{
                                 "reference": "Organization/<xsl:value-of select='$organizationResourceId'/>"
@@ -1788,52 +1863,105 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- middle name extension -->
         <xsl:if test="string($selectedName/ccda:given)">
             "extension": [{
-              "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-              "valueString" : "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
+                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
             }]
         </xsl:if>
+
+        <!-- use -->
         <xsl:if test="$selectedName/@use">
             <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
             "use": "<xsl:choose>
-                <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
-                <xsl:otherwise><xsl:value-of select="$selectedName/@use"/></xsl:otherwise>
-            </xsl:choose>"
-        </xsl:if>                        
-        <xsl:if test="string($selectedName/ccda:prefix)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix)">, </xsl:if>
+                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
+                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$selectedName/@use"/>
+                        </xsl:otherwise>
+                    </xsl:choose>"
+        </xsl:if>
+
+        <!-- prefix -->
+        <xsl:if test="string($selectedName/ccda:prefix)">
+            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
             "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:given)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix)">, </xsl:if>
+
+        <!-- given -->
+        <xsl:if test="string($selectedName/ccda:given)">
+            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
             "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:family)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given)">, </xsl:if>
+
+        <!-- family -->
+        <xsl:if test="string($selectedName/ccda:family)">
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given)
+            ">, </xsl:if>
             "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
         </xsl:if>
+
+        <!-- suffix -->
         <xsl:if test="string($selectedName/ccda:suffix)">
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given) or string($selectedName/ccda:family)">, </xsl:if>
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:family)
+            ">, </xsl:if>
             "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
         </xsl:if>
-        <xsl:if test="($selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')) or 
-                  ($selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))">
-          <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:family) or string($selectedName/ccda:suffix)">, </xsl:if>
-          "period": {
-              <xsl:if test="$selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')">
-                  "start": "<xsl:call-template name="formatDateTime">
-                                <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:low/@value"/>
+
+        <!-- period -->
+        <xsl:if test="
+            ($selectedName/ccda:validTime/ccda:low and
+            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            or
+            ($selectedName/ccda:validTime/ccda:high and
+            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+        ">
+            <xsl:if test="
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:family) or
+                string($selectedName/ccda:suffix) or
+                $selectedName/@use
+            ">, </xsl:if>
+
+            "period": {
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:low and
+                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                ">
+                    "start": "<xsl:call-template name="formatDateTime">
+                                  <xsl:with-param name="dateTime"
+                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                              </xsl:call-template>"
+                    <xsl:if test="
+                        $selectedName/ccda:validTime/ccda:high and
+                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    ">,</xsl:if>
+                </xsl:if>
+
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:high and
+                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                ">
+                    "end": "<xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime"
+                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
                             </xsl:call-template>"
-                  <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">,</xsl:if>
-              </xsl:if>
-              <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">
-                  "end": "<xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:high/@value"/>
-                          </xsl:call-template>"
-              </xsl:if>
-          }
+                </xsl:if>
+            }
         </xsl:if>
     }
 </xsl:template>
@@ -1989,15 +2117,55 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
-                <xsl:variable name="observationResourceId">
+                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
                     <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                   </xsl:call-template>
+                </xsl:variable> -->
+
+                <xsl:variable name="encounterEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:variable>
+
+                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+                <xsl:variable name="observationIdSource">
+                  <xsl:choose>
+                    <!-- Use extension if present and not empty -->
+                    <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                      <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
+                    </xsl:when>
+
+                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <xsl:otherwise>
+                      <xsl:value-of
+                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </xsl:variable>
+
+                <xsl:variable name="observationResourceId">
+                  <xsl:call-template name="generateFixedLengthResourceId">
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
+                  </xsl:call-template>
+                </xsl:variable>
+
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
               </xsl:for-each>
             ]

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1090,13 +1090,46 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
-            <xsl:variable name="observationPrefix">
+            <!-- <xsl:variable name="observationPrefix">
                 <xsl:choose>                  
-                  <xsl:when test="ccda:observation/ccda:code/@code = '95614-4'"> <!-- Total Safety Score -->
+                  <xsl:when test="ccda:observation/ccda:code/@code = '95614-4'"> Total Safety Score
                     <xsl:value-of select="concat($facilityID, '-', ccda:observation/ccda:value/@value)"/>
                   </xsl:when>
                   <xsl:otherwise>
                     <xsl:value-of select="concat($facilityID, '-')"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:variable> -->
+            <xsl:variable name="encounterEffectiveTime">
+                  <xsl:choose>
+                      <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
+                          <xsl:call-template name="formatDateTime">
+                              <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
+                          </xsl:call-template>
+                      </xsl:when>
+                      <xsl:when test="$encounterEffectiveTimeValue">
+                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$currentTimestamp"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+              <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+              <xsl:variable name="observationIdSource">
+                <xsl:choose>
+                  <!-- Use extension if present and not empty -->
+                  <xsl:when test="ccda:observation/ccda:id/@extension and normalize-space(ccda:observation/ccda:id/@extension) != ''">
+                    <!-- <xsl:value-of select="ccda:observation/ccda:id/@extension"/> -->
+                    <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
+                  </xsl:when>
+
+                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                  <xsl:otherwise>
+                    <xsl:value-of
+                      select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
                   </xsl:otherwise>
                 </xsl:choose>
               </xsl:variable>
@@ -1105,8 +1138,10 @@
               <xsl:call-template name="generateFixedLengthResourceId">
                 <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
                 <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
-                <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
-                <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/>
+                <!-- <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/> -->
+                <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                <!-- <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/> -->
+                <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
               </xsl:call-template>
             </xsl:variable>
             ,{
@@ -1256,16 +1291,54 @@
                           <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                             "derivedFrom": [
                               <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                                <!-- <xsl:variable name="code" select="ccda:code/@code"/> -->
-                                <xsl:variable name="observationResourceId">
+                                <!-- <xsl:variable name="observationResourceId">
                                   <xsl:call-template name="generateFixedLengthResourceId">
-                                    <!-- <xsl:with-param name="prefixString" select="$code"/>
-                                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
                                     <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
                                   </xsl:call-template>
+                                </xsl:variable> -->
+                                <xsl:variable name="encounterEffectiveTimeDF">
+                                    <xsl:choose>
+                                        <xsl:when test="ccda:effectiveTime/@value">
+                                            <xsl:call-template name="formatDateTime">
+                                                <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                                            </xsl:call-template>
+                                        </xsl:when>
+                                        <xsl:when test="$encounterEffectiveTimeValue">
+                                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:value-of select="$currentTimestamp"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
                                 </xsl:variable>
-                                { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
+
+                                <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                                <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
+
+                                <xsl:variable name="observationIdSourceDF">
+                                  <xsl:choose>
+                                    <!-- Use extension if present and not empty -->
+                                    <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                                      <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
+                                    </xsl:when>
+
+                                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                                    <xsl:otherwise>
+                                      <xsl:value-of
+                                        select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                                    </xsl:otherwise>
+                                  </xsl:choose>
+                                </xsl:variable>
+
+                                <xsl:variable name="observationResourceIdDF">
+                                  <xsl:call-template name="generateFixedLengthResourceId">
+                                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                                    <xsl:with-param name="sha256ResourceId" select="$observationIdSourceDF"/>
+                                  </xsl:call-template>
+                                </xsl:variable>
+                                { "reference": "Observation/<xsl:value-of select='$observationResourceIdDF'/>" }<xsl:if test="position() != last()">,</xsl:if>
                               </xsl:for-each>
                             ],
                           </xsl:if>
@@ -1297,7 +1370,7 @@
                     "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                   }
                 </xsl:if>
-                <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
+                <!-- <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
                   , "effectiveDateTime": "<xsl:choose>
                                             <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
                                                 <xsl:call-template name="formatDateTime">
@@ -1311,7 +1384,8 @@
                                                 <xsl:value-of select="$currentTimestamp"/>
                                             </xsl:otherwise>
                                         </xsl:choose>"
-                </xsl:if>
+                </xsl:if> -->
+                , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
                 <xsl:if test="string($organizationResourceId)">
                 , "performer": [{
                               "reference": "Organization/<xsl:value-of select='$organizationResourceId'/>"
@@ -1696,52 +1770,105 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- middle name extension -->
         <xsl:if test="string($selectedName/ccda:given)">
             "extension": [{
-              "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-              "valueString" : "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
+                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
             }]
         </xsl:if>
+
+        <!-- use -->
         <xsl:if test="$selectedName/@use">
             <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
             "use": "<xsl:choose>
-                <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
-                <xsl:otherwise><xsl:value-of select="$selectedName/@use"/></xsl:otherwise>
-            </xsl:choose>"
-        </xsl:if>                        
-        <xsl:if test="string($selectedName/ccda:prefix)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix)">, </xsl:if>
+                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
+                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$selectedName/@use"/>
+                        </xsl:otherwise>
+                    </xsl:choose>"
+        </xsl:if>
+
+        <!-- prefix -->
+        <xsl:if test="string($selectedName/ccda:prefix)">
+            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
             "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:given)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix)">, </xsl:if>
+
+        <!-- given -->
+        <xsl:if test="string($selectedName/ccda:given)">
+            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
             "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
         </xsl:if>
-        <xsl:if test="string($selectedName/ccda:family)"> 
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given)">, </xsl:if>
+
+        <!-- family -->
+        <xsl:if test="string($selectedName/ccda:family)">
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given)
+            ">, </xsl:if>
             "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
         </xsl:if>
+
+        <!-- suffix -->
         <xsl:if test="string($selectedName/ccda:suffix)">
-            <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:prefix) or string($selectedName/ccda:given) or string($selectedName/ccda:family)">, </xsl:if>
+            <xsl:if test="
+                $selectedName/@use or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:family)
+            ">, </xsl:if>
             "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
         </xsl:if>
-        <xsl:if test="($selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')) or 
-                  ($selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))">
-          <xsl:if test="string($selectedName/ccda:given) or string($selectedName/ccda:prefix) or string($selectedName/ccda:family) or string($selectedName/ccda:suffix)">, </xsl:if>
-          "period": {
-              <xsl:if test="$selectedName/ccda:validTime/ccda:low and not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')">
-                  "start": "<xsl:call-template name="formatDateTime">
-                                <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:low/@value"/>
+
+        <!-- period -->
+        <xsl:if test="
+            ($selectedName/ccda:validTime/ccda:low and
+            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            or
+            ($selectedName/ccda:validTime/ccda:high and
+            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+        ">
+            <xsl:if test="
+                string($selectedName/ccda:given) or
+                string($selectedName/ccda:prefix) or
+                string($selectedName/ccda:family) or
+                string($selectedName/ccda:suffix) or
+                $selectedName/@use
+            ">, </xsl:if>
+
+            "period": {
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:low and
+                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                ">
+                    "start": "<xsl:call-template name="formatDateTime">
+                                  <xsl:with-param name="dateTime"
+                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                              </xsl:call-template>"
+                    <xsl:if test="
+                        $selectedName/ccda:validTime/ccda:high and
+                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    ">,</xsl:if>
+                </xsl:if>
+
+                <xsl:if test="
+                    $selectedName/ccda:validTime/ccda:high and
+                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
+                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                ">
+                    "end": "<xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime"
+                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
                             </xsl:call-template>"
-                  <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">,</xsl:if>
-              </xsl:if>
-              <xsl:if test="$selectedName/ccda:validTime/ccda:high and not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')">
-                  "end": "<xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="$selectedName/ccda:validTime/ccda:high/@value"/>
-                          </xsl:call-template>"
-              </xsl:if>
-          }
+                </xsl:if>
+            }
         </xsl:if>
     }
 </xsl:template>
@@ -1995,26 +2122,65 @@
 
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
-                <!-- <xsl:variable name="questionCode" select="ccda:code/@code"/> -->
-                <xsl:variable name="observationPrefix">
+                <xsl:variable name="questionCode" select="ccda:code/@code"/>
+                <!-- <xsl:variable name="observationPrefix">
                   <xsl:choose>                  
-                    <xsl:when test="ccda:code/@code = '95614-4'"> <!-- Total Safety Score -->
+                    <xsl:when test="ccda:code/@code = '95614-4'"> Total Safety Score
                       <xsl:value-of select="concat($facilityID, '-', ccda:value/@value)"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <xsl:value-of select="concat($facilityID, '-')"/>
                     </xsl:otherwise>
                   </xsl:choose>
+                </xsl:variable> -->
+
+                <!-- <xsl:variable name="observationResourceId">
+                  <xsl:call-template name="generateFixedLengthResourceId">
+                    <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
+                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
+                  </xsl:call-template>
+                </xsl:variable> -->
+                <xsl:variable name="encounterEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+
+                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+
+                <xsl:variable name="observationIdSource">
+                  <xsl:choose>
+                    <!-- Use extension if present and not empty -->
+                    <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
+                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
+                      <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
+                    </xsl:when>
+
+                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <xsl:otherwise>
+                      <xsl:value-of
+                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
                 </xsl:variable>
 
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
-                    <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
-                    <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
-                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
+                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
                   </xsl:call-template>
                 </xsl:variable>
+
                 { "reference": "Observation/<xsl:value-of select='$observationResourceId'/>" }<xsl:if test="position() != last()">,</xsl:if>
               </xsl:for-each>
             ]


### PR DESCRIPTION
- updated xslt files to change the logic of resource id generation of Observation resources for Epic, Medent and AthenaHealth CCDA files using id.extension, code.code and effectiveTime.
- fixed issue with comma in patient address structure