### PR TITLE
fix: Handle CSV null character validation errors with proper description in nexus #2380

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/service/CsvBundleProcessorService.java
+++ b/csv-service/src/main/java/org/techbd/csv/service/CsvBundleProcessorService.java
@@ -603,7 +603,7 @@ private List<Object> processScreening(final String groupKey,
         List<Map<String, Object>> errors = new ArrayList<>();
     
         for (Map.Entry<String, List<FileDetail>> entry : grouped.entrySet()) {
-            String[] keyParts = entry.getKey().split("\\|", 2);
+            String[] keyParts = entry.getKey().split("\\|", 3);
             String subType = keyParts[0];
             String reason = keyParts.length > 1 ? keyParts[1] : "Unknown reason";
             String errorDetail = (keyParts.length > 2 && keyParts[2] != null) ? keyParts[2] : "";

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.999.0</revision>
+        <revision>0.1000.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Fixed CSV null character validation error messaging in Nexus, updating the description from “Unknown Error” to the appropriate error detail (#2380)