### PR TITLE
fix: update XSLT files for whitespace handling to prevent validation warnings in CCDA-to-FHIR conversion #2688

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-channel-files/mirth-connect/README.md
+++ b/integration-artifacts/ccda/ccda-techbd-channel-files/mirth-connect/README.md
@@ -18,6 +18,8 @@ This repository contains Mirth Connect channel for processing and validating CCD
   - `X-TechBD-Facility-ID` (mandatory)
   - `X-TechBD-Encounter-Type` (mandatory)
   - `X-TechBD-Screening-Code` (optional, if not specified then for Epic files, '100698-0' will be considered as the grouper screening code.)
+  - `X-TechBD-Base-FHIR-URL`  (optional, when need to specify the Base-FHIR-URL)
+  - `X-TechBD-Validation-Severity-Level`  (optional, to set the Severity-Level for validation errors to be handled)
 - **Validation**:
   - Ensures the file is .xml or .txt files and parses correctly.
   - Validates environment variables for XSLT and profile URLs.

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/README.md
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/README.md
@@ -15,22 +15,24 @@ All schema files in this folder are referenced by integration channels and valid
 
 ## � File List
 
-| File Name                      | Description (if known)                |
-|------------------------------- |---------------------------------------|
-| CDA.xsd                        | Core CCDA schema                      |
-| CDA.xsl                        | XSL stylesheet for CCDA               |
-| NarrativeBlock.xsd             | Narrative block schema                |
-| POCD_MT000040.xsd              | Main CCDA document schema             |
-| cda-fhir-bundle-epic.xslt      | XSLT for FHIR bundle (Epic)           |
-| cda-fhir-bundle-medent.xslt    | XSLT for FHIR bundle (Medent)         |
-| cda-fhir-bundle.xslt           | XSLT for FHIR bundle                  |
-| cda-phi-filter-epic.xslt       | XSLT for PHI filtering (Epic)         |
-| cda-phi-filter-medent.xslt     | XSLT for PHI filtering (Medent)       |
-| cda-phi-filter.xslt            | XSLT for PHI filtering                |
-| datatypes-base.xsd             | Datatypes base schema                 |
-| datatypes.xsd                  | Datatypes schema                      |
-| sdtc.xsd                       | SDTC schema extension                 |
-| voc.xsd                        | Vocabulary schema                     |
+| File Name                         | Description (if known)                |
+|---------------------------------- |---------------------------------------|
+| CDA.xsd                           | Core CCDA schema                      |
+| CDA.xsl                           | XSL stylesheet for CCDA               |
+| NarrativeBlock.xsd                | Narrative block schema                |
+| POCD_MT000040.xsd                 | Main CCDA document schema             |
+| cda-fhir-bundle-epic.xslt         | XSLT for FHIR bundle (Epic)           |
+| cda-fhir-bundle-medent.xslt       | XSLT for FHIR bundle (Medent)         |
+| cda-fhir-bundle-athenahealth.xslt | XSLT for FHIR bundle (AthenaHealth)   |
+| cda-fhir-bundle.xslt              | XSLT for FHIR bundle                  |
+| cda-phi-filter-epic.xslt          | XSLT for PHI filtering (Epic)         |
+| cda-phi-filter-medent.xslt        | XSLT for PHI filtering (Medent)       |
+| cda-phi-filter-athenahealth.xslt  | XSLT for PHI filtering (AthenaHealth) |
+| cda-phi-filter.xslt               | XSLT for PHI filtering                |
+| datatypes-base.xsd                | Datatypes base schema                 |
+| datatypes.xsd                     | Datatypes schema                      |
+| sdtc.xsd                          | SDTC schema extension                 |
+| voc.xsd                           | Vocabulary schema                     |
 
 
 ## �🔗 Related Documentation

--- a/integration-artifacts/hl7v2/hl7-techbd-schema-files/README.md
+++ b/integration-artifacts/hl7v2/hl7-techbd-schema-files/README.md
@@ -14,6 +14,8 @@ HL7v2 schemas and XSLT files are essential for:
 | File Name                | Description (if known)                |
 |--------------------------|---------------------------------------|
 | hl7v2-fhir-bundle.xslt   | XSLT for transforming HL7v2 to FHIR   |
+| hl7v2-validation-schema  | XSLT for validating the HL7 file      |
+| TechBD HL7 Workflow.xml  | TechBD HL7 workflow definition        |
 
 ## 🔗 Related Documentation
 

--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -12,12 +12,25 @@
   
   <xsl:param name="currentTimestamp"/>
   <xsl:param name="patientCIN"/>
+  <xsl:param name="patient-MRN"/>
   <xsl:param name="organizationNPI"/>
   <xsl:param name="organizationTIN"/>
   <xsl:param name="encounterType"/>
   <xsl:param name="facilityID"/>
   <xsl:variable name="patientRoleId" select="//ccda:patientRole/ccda:id[not(@assigningAuthorityName)]/@extension"/>
-  <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/>
+  <!-- <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/> -->
+  <xsl:variable name="given_trimmed">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1]"/>
+      </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="family_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1]"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="patientResourceName" select="concat($family_trimmed, ' ', $given_trimmed)"/>
+
   <xsl:variable name="bundleTimestamp" select="/ccda:ClinicalDocument/ccda:effectiveTime/@value"/>
 
   <xsl:param name="bundleId"/>
@@ -169,7 +182,8 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-    <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/>
+    <!-- <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/> -->
+  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
 
 
   <xsl:template match="/">
@@ -235,20 +249,37 @@
                 </xsl:call-template>
             ]
         </xsl:if>
+
+        <xsl:variable name="genderCodeNorm"
+            select="translate(
+                normalize-space(ccda:patient/ccda:administrativeGenderCode/@code),
+                'abcdefghijklmnopqrstuvwxyz',
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+            )"/>
         , "gender": "<xsl:choose>
                     <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@nullFlavor">
                         <xsl:call-template name="getNullFlavorDisplay">
                             <xsl:with-param name="nullFlavor" select="ccda:patient/ccda:administrativeGenderCode/@nullFlavor"/>
                         </xsl:call-template>
                     </xsl:when>
+
+                    <!-- Code-based mapping -->
+                    <xsl:when test="$genderCodeNorm = 'M'">male</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'F'">female</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'UN'">unknown</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'OTH'">other</xsl:when>
+
+                    <!-- DisplayName-based mapping -->
                     <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@displayName">
                         <xsl:value-of select="translate(ccda:patient/ccda:administrativeGenderCode/@displayName, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
-                    </xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='M'">male</xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='F'">female</xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='UN'">other</xsl:when>
-                    <xsl:otherwise><xsl:value-of select="ccda:patient/ccda:administrativeGenderCode/@code"/></xsl:otherwise>
+                    </xsl:when>  
+
+                    <!-- final fallback -->                  
+                    <xsl:otherwise>
+                        <xsl:value-of select="translate(ccda:patient/ccda:administrativeGenderCode/@code, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+                    </xsl:otherwise>
                 </xsl:choose>"
+                
         <xsl:if test="string(ccda:patient/ccda:birthTime/@value)">
         , "birthDate": "<xsl:choose>
                         <xsl:when test='string-length(ccda:patient/ccda:birthTime/@value) >= 8'>
@@ -392,7 +423,7 @@
                 <xsl:variable name="raceSystem">
                   <xsl:choose>
                     <xsl:when test="$raceCode = 'UNK' or $raceCode = 'ASKU'">http://terminology.hl7.org/CodeSystem/v3-NullFlavor</xsl:when>
-                    <xsl:when test="@code">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
+                    <xsl:when test="@codeSystem">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
                     <xsl:otherwise></xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -458,7 +489,7 @@
 
                 <xsl:variable name="ethSystem">
                   <xsl:choose>
-                    <xsl:when test="@code">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
+                    <xsl:when test="@codeSystem">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
                     <xsl:otherwise></xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -514,8 +545,8 @@
                                             translate(concat(substring(@extension,1,3), substring(@extension,5,2), substring(@extension,8,4)), '0123456789', '') = ''
                                           ])[1]/@extension"/>
 
-       <!-- MRN (Athena rule): @extension from first ID tag under Patient Role, take the value that appears immediately after "P-" which is not in the SSN format -->       
-      <xsl:variable name="mrnId"
+      <!-- MRN (Athena rule): @extension from first ID tag under Patient Role, take the value that appears immediately after "P-" which is not in the SSN format -->       
+      <!-- <xsl:variable name="mrnId"
         select="substring-after((ccda:id[
             not(
                 string-length(substring-after(@extension,'P-')) = 11 and
@@ -531,7 +562,8 @@
                     ''
                 ) = ''
             )
-        ])[1]/@extension,'P-')" />
+        ])[1]/@extension,'P-')" /> -->
+      <xsl:variable name="mrnId" select="$patient-MRN"/>
 
       <!-- Only output "identifier" array if any variable has value -->
       <xsl:if test="$cinId or $ssnId or $mrnId">
@@ -722,14 +754,32 @@
                 }
             ]
         </xsl:if>
-        <xsl:if test="string($locationResourceId) or string(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)">
+
+        <xsl:variable name="locationDisplayRaw">
+            <xsl:choose>
+                <!-- Primary location -->
+                <xsl:when test="string(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)">
+                  <xsl:value-of select="ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>
+                </xsl:when>
+
+                <!-- Fallback location -->
+                <xsl:otherwise>
+                  <xsl:value-of select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:if test="string($locationResourceId) or string(normalize-space($locationDisplayRaw))">
         , "location": [
             {
                 "location": {
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>"
+                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>" -->
+                    "display": "<xsl:call-template name="string-trim">
+                                  <xsl:with-param name="text" select="$locationDisplayRaw"/>
+                                </xsl:call-template>"
                 }
             }
         ]
@@ -890,10 +940,20 @@
             <!-- </xsl:choose> -->
           ],
         </xsl:if>
-        "name" : "<xsl:choose>
+        <!-- "name" : "<xsl:choose>
                     <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
                     <xsl:otherwise><xsl:value-of select="normalize-space(ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/></xsl:otherwise>
-                  </xsl:choose>"
+                  </xsl:choose>" -->
+        <xsl:variable name="orgNameRaw">
+          <xsl:choose>
+            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        "name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                  </xsl:call-template>"
+                  
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
             , "telecom": [
                 <xsl:for-each select="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
@@ -1010,7 +1070,7 @@
 
       <xsl:variable name="sexualOrientationResourceUUId">
         <xsl:call-template name="generateFixedLengthResourceId">
-          <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+          <xsl:with-param name="prefixString" select="concat($facilityID, '-', position())"/>
           <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
         </xsl:call-template>
       </xsl:variable>
@@ -1815,102 +1875,145 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- given -->
+        <xsl:variable name="given_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:given"/>
+          </xsl:call-template>
+        </xsl:variable>
+
         <!-- middle name extension -->
-        <xsl:if test="string($selectedName/ccda:given)">
+        <xsl:if test="string($given_trimmed)">
             "extension": [{
                 "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "valueString": "<xsl:value-of select="$given_trimmed"/>"
             }]
         </xsl:if>
 
         <!-- use -->
-        <xsl:if test="$selectedName/@use">
-            <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
+        <xsl:if test="normalize-space($selectedName/@use)">
+            <xsl:if test="string($given_trimmed)">, </xsl:if>
             "use": "<xsl:choose>
-                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:when test="normalize-space($selectedName/@use)='L'">official</xsl:when>
+                        <xsl:when test="normalize-space($selectedName/@use)='P'">usual</xsl:when>
                         <xsl:otherwise>
-                            <xsl:value-of select="$selectedName/@use"/>
+                            <xsl:value-of select="normalize-space($selectedName/@use)"/>
                         </xsl:otherwise>
                     </xsl:choose>"
         </xsl:if>
 
         <!-- prefix -->
-        <xsl:if test="string($selectedName/ccda:prefix)">
-            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
-            "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
+        <xsl:variable name="prefix_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:prefix"/>
+          </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:if test="string($prefix_trimmed)">
+            <xsl:if test="string($given_trimmed) or normalize-space($selectedName/@use)">, </xsl:if>
+            "prefix": ["<xsl:value-of select="$prefix_trimmed"/>"]
         </xsl:if>
 
         <!-- given -->
-        <xsl:if test="string($selectedName/ccda:given)">
-            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
-            "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
+        <xsl:if test="string($given_trimmed)">
+            <xsl:if test="normalize-space($selectedName/@use) or string($prefix_trimmed)">, </xsl:if>            
+            "given": ["<xsl:value-of select="$given_trimmed"/>"]
         </xsl:if>
 
         <!-- family -->
-        <xsl:if test="string($selectedName/ccda:family)">
+        <xsl:variable name="family_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:family"/>
+          </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:if test="string($family_trimmed)">
             <xsl:if test="
-                $selectedName/@use or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:given)
-            ">, </xsl:if>
-            "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
+                normalize-space($selectedName/@use) or
+                string($prefix_trimmed) or
+                string($given_trimmed)
+            ">, </xsl:if>              
+              "family": "<xsl:value-of select="$family_trimmed"/>"
         </xsl:if>
 
         <!-- suffix -->
-        <xsl:if test="string($selectedName/ccda:suffix)">
+        <xsl:variable name="suffix_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:suffix"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:if test="string($suffix_trimmed)">
             <xsl:if test="
-                $selectedName/@use or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:given) or
-                string($selectedName/ccda:family)
+                normalize-space($selectedName/@use) or
+                string($prefix_trimmed) or
+                string($given_trimmed) or
+                string($family_trimmed)
             ">, </xsl:if>
-            "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
+            "suffix": ["<xsl:value-of select="$suffix_trimmed"/>"]
         </xsl:if>
 
         <!-- period -->
         <xsl:if test="
-            ($selectedName/ccda:validTime/ccda:low and
-            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
-                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            (
+              $selectedName/ccda:validTime/ccda:low
+              and normalize-space($selectedName/ccda:validTime/ccda:low/@value)
+              and not(
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK'
+                or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'
+              )
+            )
             or
-            ($selectedName/ccda:validTime/ccda:high and
-            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+            (
+              $selectedName/ccda:validTime/ccda:high
+              and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+              and not(
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+              )
+            )
         ">
             <xsl:if test="
-                string($selectedName/ccda:given) or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:family) or
-                string($selectedName/ccda:suffix) or
-                $selectedName/@use
+                string($given_trimmed) or
+                string($prefix_trimmed) or
+                string($family_trimmed) or
+                string($suffix_trimmed) or
+                normalize-space($selectedName/@use)
             ">, </xsl:if>
 
             "period": {
                 <xsl:if test="
-                    $selectedName/ccda:validTime/ccda:low and
-                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
-                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                    $selectedName/ccda:validTime/ccda:low
+                    and normalize-space($selectedName/ccda:validTime/ccda:low/@value)
+                    and not(
+                      $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK'
+                      or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'
+                    )
                 ">
                     "start": "<xsl:call-template name="formatDateTime">
                                   <xsl:with-param name="dateTime"
-                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                                      select="normalize-space($selectedName/ccda:validTime/ccda:low/@value)"/>
                               </xsl:call-template>"
                     <xsl:if test="
-                        $selectedName/ccda:validTime/ccda:high and
-                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                        $selectedName/ccda:validTime/ccda:high
+                        and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+                        and not(
+                          $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                          or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+                        )
                     ">,</xsl:if>
                 </xsl:if>
 
                 <xsl:if test="
-                    $selectedName/ccda:validTime/ccda:high and
-                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    $selectedName/ccda:validTime/ccda:high
+                    and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+                    and not(
+                      $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                      or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+                    )
                 ">
                     "end": "<xsl:call-template name="formatDateTime">
                                 <xsl:with-param name="dateTime"
-                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
+                                    select="normalize-space($selectedName/ccda:validTime/ccda:high/@value)"/>
                             </xsl:call-template>"
                 </xsl:if>
             }
@@ -2149,7 +2252,10 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:name)">
-          ,"name": "<xsl:value-of select="normalize-space(ccda:name)"/>"
+          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:name)"/>" -->
+          ,"name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="ccda:name"/>
+                  </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
@@ -2235,7 +2341,10 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:playingEntity/ccda:name)">
-          ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>"
+          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>" -->
+          ,"name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="ccda:playingEntity/ccda:name"/>
+                  </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
@@ -2373,6 +2482,34 @@
 
       <!-- Output trimmed -->
       <xsl:value-of select="normalize-space($fullAddress)"/>
+  </xsl:template>
+
+  <!-- ========================== -->
+  <!-- "Function" to trim leading and trailing spaces -->  
+  <xsl:template name="string-trim">
+    <xsl:param name="text"/>
+
+    <!-- trim leading spaces -->
+    <xsl:choose>
+      <xsl:when test="starts-with($text, ' ')">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="substring($text, 2)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- trim trailing spaces -->
+      <xsl:when test="substring($text, string-length($text)) = ' '">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text"
+            select="substring($text, 1, string-length($text) - 1)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- Return result -->
+      <xsl:otherwise>
+        <xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -12,12 +12,25 @@
   
   <xsl:param name="currentTimestamp"/>
   <xsl:param name="patientCIN"/>
+  <xsl:param name="patient-MRN"/>
   <xsl:param name="organizationNPI"/>
   <xsl:param name="organizationTIN"/>
   <xsl:param name="encounterType"/>
   <xsl:param name="facilityID"/>
   <xsl:variable name="patientRoleId" select="//ccda:patientRole/ccda:id[not(@assigningAuthorityName)]/@extension"/>
-  <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/>
+  <!-- <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/> -->
+  <xsl:variable name="given_trimmed">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1]"/>
+      </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="family_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1]"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="patientResourceName" select="concat($family_trimmed, ' ', $given_trimmed)"/>
+  
   <xsl:variable name="bundleTimestamp" select="/ccda:ClinicalDocument/ccda:effectiveTime/@value"/>
 
   <xsl:param name="bundleId"/>
@@ -143,7 +156,8 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name)"/>
+  <!-- <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name)"/> -->
+  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
 
   <xsl:template match="/">
   {
@@ -208,20 +222,37 @@
                 </xsl:call-template>
             ]
         </xsl:if>
+
+        <xsl:variable name="genderCodeNorm"
+            select="translate(
+                normalize-space(ccda:patient/ccda:administrativeGenderCode/@code),
+                'abcdefghijklmnopqrstuvwxyz',
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+            )"/>
         , "gender": "<xsl:choose>
                     <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@nullFlavor">
                         <xsl:call-template name="getNullFlavorDisplay">
                             <xsl:with-param name="nullFlavor" select="ccda:patient/ccda:administrativeGenderCode/@nullFlavor"/>
                         </xsl:call-template>
                     </xsl:when>
+
+                    <!-- Code-based mapping -->
+                    <xsl:when test="$genderCodeNorm = 'M'">male</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'F'">female</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'UN'">unknown</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'OTH'">other</xsl:when>
+
+                    <!-- DisplayName-based mapping -->
                     <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@displayName">
                         <xsl:value-of select="translate(ccda:patient/ccda:administrativeGenderCode/@displayName, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
-                    </xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='M'">male</xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='F'">female</xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='UN'">other</xsl:when>
-                    <xsl:otherwise><xsl:value-of select="ccda:patient/ccda:administrativeGenderCode/@code"/></xsl:otherwise>
+                    </xsl:when>  
+
+                    <!-- final fallback -->                  
+                    <xsl:otherwise>
+                        <xsl:value-of select="translate(ccda:patient/ccda:administrativeGenderCode/@code, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+                    </xsl:otherwise>
                 </xsl:choose>"
+                
         <xsl:if test="string(ccda:patient/ccda:birthTime/@value)">
         , "birthDate": "<xsl:choose>
                         <xsl:when test='string-length(ccda:patient/ccda:birthTime/@value) >= 8'>
@@ -364,7 +395,7 @@
                 <xsl:variable name="raceSystem">
                   <xsl:choose>
                     <xsl:when test="$raceCode = 'UNK' or $raceCode = 'ASKU'">http://terminology.hl7.org/CodeSystem/v3-NullFlavor</xsl:when>
-                    <xsl:when test="@code">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
+                    <xsl:when test="@codeSystem">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
                     <xsl:otherwise></xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -430,7 +461,7 @@
 
                 <xsl:variable name="ethSystem">
                   <xsl:choose>
-                    <xsl:when test="@code">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
+                    <xsl:when test="@codeSystem">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
                     <xsl:otherwise></xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -486,8 +517,9 @@
                                             translate(concat(substring(@extension,1,3), substring(@extension,5,2), substring(@extension,8,4)), '0123456789', '') = ''
                                           ])[1]/@extension"/>
 
-      <xsl:variable name="mrnId" select="ccda:id[@assigningAuthorityName='EPI' and 
-                                                (@root='1.2.840.114350.1.13.570.2.7.5.737384.14' or @root != '1.2.840.114350.1.1')][1]/@extension"/>
+      <!-- <xsl:variable name="mrnId" select="ccda:id[@assigningAuthorityName='EPI' and 
+                                                (@root='1.2.840.114350.1.13.570.2.7.5.737384.14' or @root != '1.2.840.114350.1.1')][1]/@extension"/> -->
+      <xsl:variable name="mrnId" select="$patient-MRN"/>
 
       <!-- Only output "identifier" array if any variable has value -->
       <xsl:if test="$cinId or $ssnId or $mrnId">
@@ -678,14 +710,32 @@
                 }
             ]
         </xsl:if>
-        <xsl:if test="string($locationResourceId) or string(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)">
+
+        <xsl:variable name="locationDisplayRaw">
+            <xsl:choose>
+                <!-- Primary location -->
+                <xsl:when test="string(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)">
+                  <xsl:value-of select="ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>
+                </xsl:when>
+
+                <!-- Fallback location -->
+                <xsl:otherwise>
+                  <xsl:value-of select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:if test="string($locationResourceId) or string(normalize-space($locationDisplayRaw))">
         , "location": [
             {
                 "location": {
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>"
+                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>" -->
+                    "display": "<xsl:call-template name="string-trim">
+                                  <xsl:with-param name="text" select="$locationDisplayRaw"/>
+                                </xsl:call-template>"
                 }
             }
         ]
@@ -787,14 +837,32 @@
                 }
             ]
         </xsl:if>
-        <xsl:if test="string($locationResourceId) or string(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)">
+
+        <xsl:variable name="locationDisplayRaw">
+            <xsl:choose>
+                <!-- Primary location -->
+                <xsl:when test="string(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)">
+                  <xsl:value-of select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>
+                </xsl:when>
+
+                <!-- Fallback location -->
+                <xsl:otherwise>
+                  <xsl:value-of select="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location/ccda:healthCareFacility/ccda:location/ccda:name"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        
+        <xsl:if test="string($locationResourceId) or string(normalize-space($locationDisplayRaw))">
         , "location": [
             {
                 "location": {
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>"
+                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>" -->
+                    "display": "<xsl:call-template name="string-trim">
+                                  <xsl:with-param name="text" select="$locationDisplayRaw"/>
+                                </xsl:call-template>"
                 }
             }
         ]
@@ -956,10 +1024,20 @@
             <!-- </xsl:choose> -->
           ],
         </xsl:if>
-        "name" : "<xsl:choose>
+        <!-- "name" : "<xsl:choose>
                     <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
                     <xsl:otherwise><xsl:value-of select="normalize-space(ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/></xsl:otherwise>
-                  </xsl:choose>"
+                  </xsl:choose>" -->
+        <xsl:variable name="orgNameRaw">
+          <xsl:choose>
+            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        "name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                  </xsl:call-template>"
+
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
             , "telecom": [
                 <xsl:for-each select="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
@@ -1079,7 +1157,7 @@
 
       <xsl:variable name="sexualOrientationResourceUUId">
         <xsl:call-template name="generateFixedLengthResourceId">
-          <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+          <xsl:with-param name="prefixString" select="concat($facilityID, '-', position())"/>
           <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
         </xsl:call-template>
       </xsl:variable>
@@ -1863,102 +1941,145 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- given -->
+        <xsl:variable name="given_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:given"/>
+          </xsl:call-template>
+        </xsl:variable>
+
         <!-- middle name extension -->
-        <xsl:if test="string($selectedName/ccda:given)">
+        <xsl:if test="string($given_trimmed)">
             "extension": [{
                 "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "valueString": "<xsl:value-of select="$given_trimmed"/>"
             }]
         </xsl:if>
 
         <!-- use -->
-        <xsl:if test="$selectedName/@use">
-            <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
+        <xsl:if test="normalize-space($selectedName/@use)">
+            <xsl:if test="string($given_trimmed)">, </xsl:if>
             "use": "<xsl:choose>
-                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:when test="normalize-space($selectedName/@use)='L'">official</xsl:when>
+                        <xsl:when test="normalize-space($selectedName/@use)='P'">usual</xsl:when>
                         <xsl:otherwise>
-                            <xsl:value-of select="$selectedName/@use"/>
+                            <xsl:value-of select="normalize-space($selectedName/@use)"/>
                         </xsl:otherwise>
                     </xsl:choose>"
         </xsl:if>
 
         <!-- prefix -->
-        <xsl:if test="string($selectedName/ccda:prefix)">
-            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
-            "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
+        <xsl:variable name="prefix_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:prefix"/>
+          </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:if test="string($prefix_trimmed)">
+            <xsl:if test="string($given_trimmed) or normalize-space($selectedName/@use)">, </xsl:if>
+            "prefix": ["<xsl:value-of select="$prefix_trimmed"/>"]
         </xsl:if>
 
         <!-- given -->
-        <xsl:if test="string($selectedName/ccda:given)">
-            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
-            "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
+        <xsl:if test="string($given_trimmed)">
+            <xsl:if test="normalize-space($selectedName/@use) or string($prefix_trimmed)">, </xsl:if>            
+            "given": ["<xsl:value-of select="$given_trimmed"/>"]
         </xsl:if>
 
         <!-- family -->
-        <xsl:if test="string($selectedName/ccda:family)">
+        <xsl:variable name="family_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:family"/>
+          </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:if test="string($family_trimmed)">
             <xsl:if test="
-                $selectedName/@use or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:given)
-            ">, </xsl:if>
-            "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
+                normalize-space($selectedName/@use) or
+                string($prefix_trimmed) or
+                string($given_trimmed)
+            ">, </xsl:if>              
+              "family": "<xsl:value-of select="$family_trimmed"/>"
         </xsl:if>
 
         <!-- suffix -->
-        <xsl:if test="string($selectedName/ccda:suffix)">
+        <xsl:variable name="suffix_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:suffix"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:if test="string($suffix_trimmed)">
             <xsl:if test="
-                $selectedName/@use or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:given) or
-                string($selectedName/ccda:family)
+                normalize-space($selectedName/@use) or
+                string($prefix_trimmed) or
+                string($given_trimmed) or
+                string($family_trimmed)
             ">, </xsl:if>
-            "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
+            "suffix": ["<xsl:value-of select="$suffix_trimmed"/>"]
         </xsl:if>
 
         <!-- period -->
         <xsl:if test="
-            ($selectedName/ccda:validTime/ccda:low and
-            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
-                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            (
+              $selectedName/ccda:validTime/ccda:low
+              and normalize-space($selectedName/ccda:validTime/ccda:low/@value)
+              and not(
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK'
+                or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'
+              )
+            )
             or
-            ($selectedName/ccda:validTime/ccda:high and
-            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+            (
+              $selectedName/ccda:validTime/ccda:high
+              and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+              and not(
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+              )
+            )
         ">
             <xsl:if test="
-                string($selectedName/ccda:given) or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:family) or
-                string($selectedName/ccda:suffix) or
-                $selectedName/@use
+                string($given_trimmed) or
+                string($prefix_trimmed) or
+                string($family_trimmed) or
+                string($suffix_trimmed) or
+                normalize-space($selectedName/@use)
             ">, </xsl:if>
 
             "period": {
                 <xsl:if test="
-                    $selectedName/ccda:validTime/ccda:low and
-                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
-                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                    $selectedName/ccda:validTime/ccda:low
+                    and normalize-space($selectedName/ccda:validTime/ccda:low/@value)
+                    and not(
+                      $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK'
+                      or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'
+                    )
                 ">
                     "start": "<xsl:call-template name="formatDateTime">
                                   <xsl:with-param name="dateTime"
-                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                                      select="normalize-space($selectedName/ccda:validTime/ccda:low/@value)"/>
                               </xsl:call-template>"
                     <xsl:if test="
-                        $selectedName/ccda:validTime/ccda:high and
-                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                        $selectedName/ccda:validTime/ccda:high
+                        and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+                        and not(
+                          $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                          or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+                        )
                     ">,</xsl:if>
                 </xsl:if>
 
                 <xsl:if test="
-                    $selectedName/ccda:validTime/ccda:high and
-                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    $selectedName/ccda:validTime/ccda:high
+                    and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+                    and not(
+                      $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                      or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+                    )
                 ">
                     "end": "<xsl:call-template name="formatDateTime">
                                 <xsl:with-param name="dateTime"
-                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
+                                    select="normalize-space($selectedName/ccda:validTime/ccda:high/@value)"/>
                             </xsl:call-template>"
                 </xsl:if>
             }
@@ -2191,7 +2312,10 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:name)">
-          ,"name": "<xsl:value-of select="normalize-space(ccda:name)"/>"
+          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:name)"/>" -->
+          ,"name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="ccda:name"/>
+                  </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
@@ -2277,7 +2401,10 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:playingEntity/ccda:name)">
-          ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>"
+          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>" -->
+          ,"name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="ccda:playingEntity/ccda:name"/>
+                  </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
@@ -2415,6 +2542,34 @@
 
       <!-- Output trimmed -->
       <xsl:value-of select="normalize-space($fullAddress)"/>
+  </xsl:template>
+
+  <!-- ========================== -->
+  <!-- "Function" to trim leading and trailing spaces -->  
+  <xsl:template name="string-trim">
+    <xsl:param name="text"/>
+
+    <!-- trim leading spaces -->
+    <xsl:choose>
+      <xsl:when test="starts-with($text, ' ')">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="substring($text, 2)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- trim trailing spaces -->
+      <xsl:when test="substring($text, string-length($text)) = ' '">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text"
+            select="substring($text, 1, string-length($text) - 1)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- Return result -->
+      <xsl:otherwise>
+        <xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -12,12 +12,25 @@
   
   <xsl:param name="currentTimestamp"/>
   <xsl:param name="patientCIN"/>
+  <xsl:param name="patient-MRN"/>
   <xsl:param name="organizationNPI"/>
   <xsl:param name="organizationTIN"/>
   <xsl:param name="encounterType"/>
   <xsl:param name="facilityID"/>
   <xsl:variable name="patientRoleId" select="//ccda:patientRole/ccda:id[not(@assigningAuthorityName)]/@extension"/>
-  <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/>
+  <!-- <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/> -->
+  <xsl:variable name="given_trimmed">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1]"/>
+      </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="family_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1]"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="patientResourceName" select="concat($family_trimmed, ' ', $given_trimmed)"/>
+
   <xsl:variable name="bundleTimestamp" select="/ccda:ClinicalDocument/ccda:effectiveTime/@value"/>
 
   <xsl:param name="bundleId"/>
@@ -133,7 +146,8 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name)"/>
+  <!-- <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name)"/> -->
+  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
 
   <xsl:template match="/">
   {
@@ -198,20 +212,36 @@
             ]
         </xsl:if>
 
+        <xsl:variable name="genderCodeNorm"
+            select="translate(
+                normalize-space(ccda:patient/ccda:administrativeGenderCode/@code),
+                'abcdefghijklmnopqrstuvwxyz',
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+            )"/>
         , "gender": "<xsl:choose>
                     <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@nullFlavor">
                         <xsl:call-template name="getNullFlavorDisplay">
                             <xsl:with-param name="nullFlavor" select="ccda:patient/ccda:administrativeGenderCode/@nullFlavor"/>
                         </xsl:call-template>
                     </xsl:when>
+
+                    <!-- Code-based mapping -->
+                    <xsl:when test="$genderCodeNorm = 'M'">male</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'F'">female</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'UN'">unknown</xsl:when>
+                    <xsl:when test="$genderCodeNorm = 'OTH'">other</xsl:when>
+
+                    <!-- DisplayName-based mapping -->
                     <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@displayName">
                         <xsl:value-of select="translate(ccda:patient/ccda:administrativeGenderCode/@displayName, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
-                    </xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='M'">male</xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='F'">female</xsl:when>
-                    <xsl:when test="ccda:patient/ccda:administrativeGenderCode/@code='UN'">other</xsl:when>
-                    <xsl:otherwise><xsl:value-of select="ccda:patient/ccda:administrativeGenderCode/@code"/></xsl:otherwise>
+                    </xsl:when>  
+
+                    <!-- final fallback -->                  
+                    <xsl:otherwise>
+                        <xsl:value-of select="translate(ccda:patient/ccda:administrativeGenderCode/@code, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+                    </xsl:otherwise>
                 </xsl:choose>"
+                
         <xsl:if test="string(ccda:patient/ccda:birthTime/@value)">
         , "birthDate": "<xsl:choose>
                         <xsl:when test='string-length(ccda:patient/ccda:birthTime/@value) >= 8'>
@@ -354,7 +384,7 @@
                 <xsl:variable name="raceSystem">
                   <xsl:choose>
                     <xsl:when test="$raceCode = 'UNK' or $raceCode = 'ASKU'">http://terminology.hl7.org/CodeSystem/v3-NullFlavor</xsl:when>
-                    <xsl:when test="@code">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
+                    <xsl:when test="@codeSystem">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
                     <xsl:otherwise></xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -420,7 +450,7 @@
 
                 <xsl:variable name="ethSystem">
                   <xsl:choose>
-                    <xsl:when test="@code">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
+                    <xsl:when test="@codeSystem">urn:oid:<xsl:value-of select="@codeSystem"/></xsl:when>
                     <xsl:otherwise></xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -476,13 +506,14 @@
                                           ])[1]/@extension"/>
 
       <!-- MRN: Take first id element that is NOT SSN -->
-      <xsl:variable name="mrnId" select="(ccda:id[
+      <!-- <xsl:variable name="mrnId" select="(ccda:id[
                                           not(@root='2.16.840.1.113883.4.1') and
                                           not(string-length(@extension) = 11 and 
                                               substring(@extension,4,1) = '-' and 
                                               substring(@extension,7,1) = '-' and 
                                               translate(concat(substring(@extension,1,3), substring(@extension,5,2), substring(@extension,8,4)), '0123456789', '') = '')
-                                        ])[1]/@extension"/>
+                                        ])[1]/@extension"/> -->
+      <xsl:variable name="mrnId" select="$patient-MRN"/>
 
       <xsl:if test="$cinId or $ssnId or $mrnId">
       , "identifier": [
@@ -675,7 +706,10 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>"
+                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>" -->
+                    "display": "<xsl:call-template name="string-trim">
+                                  <xsl:with-param name="text" select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>
+                                </xsl:call-template>"
                 }
             }
         ]
@@ -836,10 +870,20 @@
             <!-- </xsl:choose> -->
           ],
         </xsl:if>
-        "name" : "<xsl:choose>
+        <!-- "name" : "<xsl:choose>
                     <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
                     <xsl:otherwise><xsl:value-of select="normalize-space(ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/></xsl:otherwise>
-                  </xsl:choose>"
+                  </xsl:choose>" -->
+        <xsl:variable name="orgNameRaw">
+          <xsl:choose>
+            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        "name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                  </xsl:call-template>"
+
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
             , "telecom": [
                 <xsl:for-each select="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
@@ -956,7 +1000,7 @@
 
       <xsl:variable name="sexualOrientationResourceUUId">
         <xsl:call-template name="generateFixedLengthResourceId">
-          <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
+          <xsl:with-param name="prefixString" select="concat($facilityID, '-', position())"/>
           <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/>
         </xsl:call-template>
       </xsl:variable>
@@ -1770,102 +1814,145 @@
 <xsl:template name="generateNameJson">
     <xsl:param name="selectedName"/>
     {
+        <!-- given -->
+        <xsl:variable name="given_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:given"/>
+          </xsl:call-template>
+        </xsl:variable>
+
         <!-- middle name extension -->
-        <xsl:if test="string($selectedName/ccda:given)">
+        <xsl:if test="string($given_trimmed)">
             "extension": [{
                 "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-                "valueString": "<xsl:value-of select="$selectedName/ccda:given"/>"
+                "valueString": "<xsl:value-of select="$given_trimmed"/>"
             }]
         </xsl:if>
 
         <!-- use -->
-        <xsl:if test="$selectedName/@use">
-            <xsl:if test="string($selectedName/ccda:given)">, </xsl:if>
+        <xsl:if test="normalize-space($selectedName/@use)">
+            <xsl:if test="string($given_trimmed)">, </xsl:if>
             "use": "<xsl:choose>
-                        <xsl:when test="$selectedName/@use='L'">official</xsl:when>
-                        <xsl:when test="$selectedName/@use='P'">usual</xsl:when>
+                        <xsl:when test="normalize-space($selectedName/@use)='L'">official</xsl:when>
+                        <xsl:when test="normalize-space($selectedName/@use)='P'">usual</xsl:when>
                         <xsl:otherwise>
-                            <xsl:value-of select="$selectedName/@use"/>
+                            <xsl:value-of select="normalize-space($selectedName/@use)"/>
                         </xsl:otherwise>
                     </xsl:choose>"
         </xsl:if>
 
         <!-- prefix -->
-        <xsl:if test="string($selectedName/ccda:prefix)">
-            <xsl:if test="string($selectedName/ccda:given) or $selectedName/@use">, </xsl:if>
-            "prefix": ["<xsl:value-of select='$selectedName/ccda:prefix'/>"]
+        <xsl:variable name="prefix_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:prefix"/>
+          </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:if test="string($prefix_trimmed)">
+            <xsl:if test="string($given_trimmed) or normalize-space($selectedName/@use)">, </xsl:if>
+            "prefix": ["<xsl:value-of select="$prefix_trimmed"/>"]
         </xsl:if>
 
         <!-- given -->
-        <xsl:if test="string($selectedName/ccda:given)">
-            <xsl:if test="$selectedName/@use or string($selectedName/ccda:prefix)">, </xsl:if>
-            "given": ["<xsl:value-of select='$selectedName/ccda:given'/>"]
+        <xsl:if test="string($given_trimmed)">
+            <xsl:if test="normalize-space($selectedName/@use) or string($prefix_trimmed)">, </xsl:if>            
+            "given": ["<xsl:value-of select="$given_trimmed"/>"]
         </xsl:if>
 
         <!-- family -->
-        <xsl:if test="string($selectedName/ccda:family)">
+        <xsl:variable name="family_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:family"/>
+          </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:if test="string($family_trimmed)">
             <xsl:if test="
-                $selectedName/@use or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:given)
-            ">, </xsl:if>
-            "family": "<xsl:value-of select='$selectedName/ccda:family'/>"
+                normalize-space($selectedName/@use) or
+                string($prefix_trimmed) or
+                string($given_trimmed)
+            ">, </xsl:if>              
+              "family": "<xsl:value-of select="$family_trimmed"/>"
         </xsl:if>
 
         <!-- suffix -->
-        <xsl:if test="string($selectedName/ccda:suffix)">
+        <xsl:variable name="suffix_trimmed">
+          <xsl:call-template name="string-trim">
+            <xsl:with-param name="text" select="$selectedName/ccda:suffix"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:if test="string($suffix_trimmed)">
             <xsl:if test="
-                $selectedName/@use or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:given) or
-                string($selectedName/ccda:family)
+                normalize-space($selectedName/@use) or
+                string($prefix_trimmed) or
+                string($given_trimmed) or
+                string($family_trimmed)
             ">, </xsl:if>
-            "suffix": ["<xsl:value-of select='$selectedName/ccda:suffix'/>"]
+            "suffix": ["<xsl:value-of select="$suffix_trimmed"/>"]
         </xsl:if>
 
         <!-- period -->
         <xsl:if test="
-            ($selectedName/ccda:validTime/ccda:low and
-            not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
-                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'))
+            (
+              $selectedName/ccda:validTime/ccda:low
+              and normalize-space($selectedName/ccda:validTime/ccda:low/@value)
+              and not(
+                $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK'
+                or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'
+              )
+            )
             or
-            ($selectedName/ccda:validTime/ccda:high and
-            not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'))
+            (
+              $selectedName/ccda:validTime/ccda:high
+              and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+              and not(
+                $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+              )
+            )
         ">
             <xsl:if test="
-                string($selectedName/ccda:given) or
-                string($selectedName/ccda:prefix) or
-                string($selectedName/ccda:family) or
-                string($selectedName/ccda:suffix) or
-                $selectedName/@use
+                string($given_trimmed) or
+                string($prefix_trimmed) or
+                string($family_trimmed) or
+                string($suffix_trimmed) or
+                normalize-space($selectedName/@use)
             ">, </xsl:if>
 
             "period": {
                 <xsl:if test="
-                    $selectedName/ccda:validTime/ccda:low and
-                    not($selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK' or
-                        $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA')
+                    $selectedName/ccda:validTime/ccda:low
+                    and normalize-space($selectedName/ccda:validTime/ccda:low/@value)
+                    and not(
+                      $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'UNK'
+                      or $selectedName/ccda:validTime/ccda:low/@nullFlavor = 'NA'
+                    )
                 ">
                     "start": "<xsl:call-template name="formatDateTime">
                                   <xsl:with-param name="dateTime"
-                                      select="$selectedName/ccda:validTime/ccda:low/@value"/>
+                                      select="normalize-space($selectedName/ccda:validTime/ccda:low/@value)"/>
                               </xsl:call-template>"
                     <xsl:if test="
-                        $selectedName/ccda:validTime/ccda:high and
-                        not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                            $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                        $selectedName/ccda:validTime/ccda:high
+                        and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+                        and not(
+                          $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                          or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+                        )
                     ">,</xsl:if>
                 </xsl:if>
 
                 <xsl:if test="
-                    $selectedName/ccda:validTime/ccda:high and
-                    not($selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK' or
-                        $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA')
+                    $selectedName/ccda:validTime/ccda:high
+                    and normalize-space($selectedName/ccda:validTime/ccda:high/@value)
+                    and not(
+                      $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'UNK'
+                      or $selectedName/ccda:validTime/ccda:high/@nullFlavor = 'NA'
+                    )
                 ">
                     "end": "<xsl:call-template name="formatDateTime">
                                 <xsl:with-param name="dateTime"
-                                    select="$selectedName/ccda:validTime/ccda:high/@value"/>
+                                    select="normalize-space($selectedName/ccda:validTime/ccda:high/@value)"/>
                             </xsl:call-template>"
                 </xsl:if>
             }
@@ -1886,7 +1973,10 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:playingEntity/ccda:name)">
-          ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>"
+          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>" -->
+          ,"name": "<xsl:call-template name="string-trim">
+                    <xsl:with-param name="text" select="ccda:playingEntity/ccda:name"/>
+                  </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
@@ -2259,6 +2349,34 @@
 
       <!-- Output trimmed -->
       <xsl:value-of select="normalize-space($fullAddress)"/>
+  </xsl:template>
+
+  <!-- ========================== -->
+  <!-- "Function" to trim leading and trailing spaces -->  
+  <xsl:template name="string-trim">
+    <xsl:param name="text"/>
+
+    <!-- trim leading spaces -->
+    <xsl:choose>
+      <xsl:when test="starts-with($text, ' ')">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="substring($text, 2)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- trim trailing spaces -->
+      <xsl:when test="substring($text, string-length($text)) = ' '">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text"
+            select="substring($text, 1, string-length($text) - 1)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- Return result -->
+      <xsl:otherwise>
+        <xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Updated XSLT files for whitespace handling to prevent validation warnings in CCDA-to-FHIR conversion

1. The leading and trailing spaces removed for Patient MRN, Family, Given, prefix and suffix, organization name, location name, location.display in Encounter resource.
2. Fixed issue that error message is displaying when we provide patient MRN on the second one instead of first one.
3. Patient gender - displayName mapped from code
4. Fixed issue with system for Ethnicity and race in Patient Resource.
5. Added position while Resource UUID generation to avoid duplicate resource id when multiple sexualOrientation resources

Updated ReadMe files to add additional information.