### PR TITLE
fix: add ZIP Upload Rejection and Missing File Validation in HL7 Channel #2380

### DIFF
--- a/integration-artifacts/hl7v2/hl7-techbd-channel-files/nexus-sandbox/TechBD HL7 Workflow.xml
+++ b/integration-artifacts/hl7v2/hl7-techbd-channel-files/nexus-sandbox/TechBD HL7 Workflow.xml
@@ -1,16 +1,19 @@
-<channel version="4.6.0">
-  <id>32f45bb4-d1ac-41b2-8603-904c9397438a</id>
+<channel version="4.6.1">
+  <id>42c12cfa-3058-4362-ba17-0ba4df9a6252</id>
   <nextMetaDataId>3</nextMetaDataId>
   <name>TechBD HL7 Workflow</name>
-  <description>Version: 0.1.17
-JDBC attributes reverted from Secrets Manager configuration.</description>
-  <revision>20</revision>
-  <sourceConnector version="4.6.0">
+  <description>Version: 0.1.18
+Add ZIP Upload Rejection and Missing File Validation in HL7 Channel</description>
+  <revision>64</revision>
+  <sourceConnector version="4.6.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.6.0">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.6.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.0">
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.6.1">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
           <verifyHostname>false</verifyHostname>
@@ -31,15 +34,12 @@ JDBC attributes reverted from Secrets Manager configuration.</description>
           <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
           <truststoreUid/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.6.0">
-  <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="4.6.0">
+      <listenerConnectorProperties version="4.6.1">
         <host>0.0.0.0</host>
         <port>9006</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="4.6.0">
+      <sourceConnectorProperties version="4.6.1">
         <responseVariable>finalResponse</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -94,9 +94,9 @@ JDBC attributes reverted from Secrets Manager configuration.</description>
       <timeout>30000</timeout>
       <staticResources/>
     </properties>
-    <transformer version="4.6.0">
+    <transformer version="4.6.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
           <name>FileName validation</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -137,6 +137,12 @@ var logPrefix = &quot;[CHANNEL: &quot; + channelName + &quot;] [INTERACTION ID: 
 var contentType = $(&apos;headers&apos;).getHeader(&apos;Content-Type&apos;);
 logger.info(logPrefix + &quot;Content-Type: &quot; + contentType);
 
+if (!contentType) {
+    var errorMessage = &quot;Uploaded file is empty or missing.&quot;;
+    setErrorResponse(400, errorMessage);
+    throw errorMessage;
+}
+
 if (!contentType || !contentType.toLowerCase().startsWith(&quot;multipart/form-data&quot;)) {
     var errorMessage = &quot;Bad Request: Content-Type must be &apos;multipart/form-data&apos; with boundary details.&quot;;
     setErrorResponse(400, errorMessage); 
@@ -150,11 +156,7 @@ var saveHL7Payload = globalMap.get(&apos;saveHL7Payload&apos;);
 	    errorMessage = &quot;Uploaded file is empty or missing.&quot;;
 	    setErrorResponse(400, errorMessage);
 	    throw errorMessage;
-	}&#xd;
-
-var xml = new XML(rawData);
-var hl7Message = xml.Content.Part.Content.toString();
-logger.info(logPrefix + &quot;hl7Message : &quot; + hl7Message);
+	}
 
 var filename = null;
 var filenameMatch = rawData.match(/filename=&quot;([^&quot;]+)&quot;/);
@@ -179,6 +181,10 @@ if (filenameMatch &amp;&amp; filenameMatch.length &gt; 1) {
     setErrorResponse(400, errorMessage);
     throw errorMessage;
 }
+
+var xml = new XML(rawData);
+var hl7Message = xml.Content.Part.Content.toString();
+logger.info(logPrefix + &quot;hl7Message : &quot; + hl7Message);
 
 // Parse request as XML
 var requestXml = new XML(connectorMessage.getRawData());
@@ -263,11 +269,11 @@ for (var i = 0; i &lt; lines.length; i++) {
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>XML</inboundDataType>
       <outboundDataType>HL7V2</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.0">
-        <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.0">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.1">
+        <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.1">
           <stripNamespaces>false</stripNamespaces>
         </serializationProperties>
-        <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.1">
           <splitType>Element_Name</splitType>
           <elementName></elementName>
           <level>1</level>
@@ -275,8 +281,8 @@ for (var i = 0; i &lt; lines.length; i++) {
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="4.6.0">
-        <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="4.6.0">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="4.6.1">
+        <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="4.6.1">
           <handleRepetitions>true</handleRepetitions>
           <handleSubcomponents>true</handleSubcomponents>
           <useStrictParser>false</useStrictParser>
@@ -285,16 +291,16 @@ for (var i = 0; i &lt; lines.length; i++) {
           <segmentDelimiter>\r</segmentDelimiter>
           <convertLineBreaks>true</convertLineBreaks>
         </serializationProperties>
-        <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="4.6.0">
+        <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="4.6.1">
           <useStrictParser>false</useStrictParser>
           <useStrictValidation>false</useStrictValidation>
           <segmentDelimiter>\r</segmentDelimiter>
         </deserializationProperties>
-        <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="4.6.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="4.6.1">
           <splitType>MSH_Segment</splitType>
           <batchScript></batchScript>
         </batchProperties>
-        <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="4.6.0">
+        <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="4.6.1">
           <segmentDelimiter>\r</segmentDelimiter>
           <successfulACKCode>AA</successfulACKCode>
           <successfulACKMessage></successfulACKMessage>
@@ -305,7 +311,7 @@ for (var i = 0; i &lt; lines.length; i++) {
           <msh15ACKAccept>false</msh15ACKAccept>
           <dateFormat>yyyyMMddHHmmss.SSS</dateFormat>
         </responseGenerationProperties>
-        <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="4.6.0">
+        <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="4.6.1">
           <successfulACKCode>AA,CA</successfulACKCode>
           <errorACKCode>AE,CE</errorACKCode>
           <rejectedACKCode>AR,CR</rejectedACKCode>
@@ -315,9 +321,9 @@ for (var i = 0; i &lt; lines.length; i++) {
         </responseValidationProperties>
       </outboundProperties>
     </transformer>
-    <filter version="4.6.0">
+    <filter version="4.6.1">
       <elements>
-        <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.0">
+        <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.1">
           <name>Accept message if &quot;sourceMap.get(&apos;contextPath&apos;)&quot; equals &apos;/hl7v2/Bundle&apos; or &apos;/hl7v2/Bundle/&apos; or &apos;/hl7v2/Bundle/$validate&apos; or &apos;/hl7v2/Bundle/$validate/&apos;</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -330,7 +336,7 @@ for (var i = 0; i &lt; lines.length; i++) {
             <string>&apos;/hl7v2/Bundle/$validate/&apos;</string>
           </values>
         </com.mirth.connect.plugins.rulebuilder.RuleBuilderRule>
-        <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.0">
+        <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.1">
           <name>Accept message if &quot;sourceMap.get(&apos;method&apos;)&quot; equals &apos;POST&apos;</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -349,12 +355,12 @@ for (var i = 0; i &lt; lines.length; i++) {
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="4.6.0">
+    <connector version="4.6.1">
       <metaDataId>1</metaDataId>
       <name>Destination 1</name>
-      <properties class="com.mirth.connect.connectors.vm.VmDispatcherProperties" version="4.6.0">
+      <properties class="com.mirth.connect.connectors.vm.VmDispatcherProperties" version="4.6.1">
         <pluginProperties/>
-        <destinationConnectorProperties version="4.6.0">
+        <destinationConnectorProperties version="4.6.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -378,9 +384,9 @@ for (var i = 0; i &lt; lines.length; i++) {
         <channelTemplate>${message.encodedData}</channelTemplate>
         <mapVariables/>
       </properties>
-      <transformer version="4.6.0">
+      <transformer version="4.6.1">
         <elements>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
             <name>HL7 Validation</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -646,7 +652,7 @@ function validateOneOfGroups(groups, hl7Text) {
     return violations;
 }</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
             <name>Common Js func.</name>
             <sequenceNumber>1</sequenceNumber>
             <enabled>true</enabled>
@@ -757,7 +763,7 @@ function sendDataLedgerSync(payload) {
     }
 }</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
             <name>Validate HTTP Request and collect headers</name>
             <sequenceNumber>2</sequenceNumber>
             <enabled>true</enabled>
@@ -889,7 +895,7 @@ if (missingEnvVars.length &gt; 0) {
 
 logger.info(&quot;HTTP request validation ended.&quot;);</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
             <name>step_validate_profile_urls_env_variables</name>
             <sequenceNumber>3</sequenceNumber>
             <enabled>true</enabled>
@@ -1318,7 +1324,7 @@ function getMultipleAnswersForComponent(transformer, observations) {
     return transformer;
 }</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
             <name>API endpoint processing</name>
             <sequenceNumber>4</sequenceNumber>
             <enabled>true</enabled>
@@ -1821,8 +1827,8 @@ return value;
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>HL7V2</inboundDataType>
         <outboundDataType>XML</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="4.6.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="4.6.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="4.6.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="4.6.1">
             <handleRepetitions>true</handleRepetitions>
             <handleSubcomponents>true</handleSubcomponents>
             <useStrictParser>false</useStrictParser>
@@ -1831,16 +1837,16 @@ return value;
             <segmentDelimiter>\r</segmentDelimiter>
             <convertLineBreaks>true</convertLineBreaks>
           </serializationProperties>
-          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="4.6.0">
+          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="4.6.1">
             <useStrictParser>false</useStrictParser>
             <useStrictValidation>false</useStrictValidation>
             <segmentDelimiter>\r</segmentDelimiter>
           </deserializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="4.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="4.6.1">
             <splitType>MSH_Segment</splitType>
             <batchScript></batchScript>
           </batchProperties>
-          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="4.6.0">
+          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="4.6.1">
             <segmentDelimiter>\r</segmentDelimiter>
             <successfulACKCode>AA</successfulACKCode>
             <successfulACKMessage></successfulACKMessage>
@@ -1851,7 +1857,7 @@ return value;
             <msh15ACKAccept>false</msh15ACKAccept>
             <dateFormat>yyyyMMddHHmmss.SSS</dateFormat>
           </responseGenerationProperties>
-          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="4.6.0">
+          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="4.6.1">
             <successfulACKCode>AA,CA</successfulACKCode>
             <errorACKCode>AE,CE</errorACKCode>
             <rejectedACKCode>AR,CR</rejectedACKCode>
@@ -1860,11 +1866,11 @@ return value;
             <originalIdMapVariable></originalIdMapVariable>
           </responseValidationProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.1">
             <stripNamespaces>false</stripNamespaces>
           </serializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.1">
             <splitType>Element_Name</splitType>
             <elementName></elementName>
             <level>1</level>
@@ -1873,17 +1879,17 @@ return value;
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="4.6.0">
+      <responseTransformer version="4.6.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>XML</inboundDataType>
         <outboundDataType>XML</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.1">
             <stripNamespaces>false</stripNamespaces>
           </serializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.1">
             <splitType>Element_Name</splitType>
             <elementName></elementName>
             <level>1</level>
@@ -1891,11 +1897,11 @@ return value;
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="4.6.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="4.6.1">
             <stripNamespaces>false</stripNamespaces>
           </serializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="4.6.1">
             <splitType>Element_Name</splitType>
             <elementName></elementName>
             <level>1</level>
@@ -1904,7 +1910,7 @@ return value;
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="4.6.0">
+      <filter version="4.6.1">
         <elements/>
       </filter>
       <transportName>Channel Writer</transportName>
@@ -1912,12 +1918,12 @@ return value;
       <enabled>true</enabled>
       <waitForPrevious>true</waitForPrevious>
     </connector>
-    <connector version="4.6.0">
+    <connector version="4.6.1">
       <metaDataId>2</metaDataId>
       <name>dest_bundle</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="4.6.0">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="4.6.1">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.0">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
   <sslEnabled>false</sslEnabled>
             <mutualTlsEnabled>false</mutualTlsEnabled>
             <verifyHostname>false</verifyHostname>
@@ -1939,7 +1945,7 @@ return value;
             <truststoreUid/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="4.6.0">
+        <destinationConnectorProperties version="4.6.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -2085,14 +2091,14 @@ return value;
         <charset>UTF-8</charset>
         <socketTimeout>30000</socketTimeout>
       </properties>
-      <transformer version="4.6.0">
+      <transformer version="4.6.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>HL7V2</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="4.6.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="4.6.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="4.6.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="4.6.1">
             <handleRepetitions>true</handleRepetitions>
             <handleSubcomponents>true</handleSubcomponents>
             <useStrictParser>false</useStrictParser>
@@ -2101,16 +2107,16 @@ return value;
             <segmentDelimiter>\r</segmentDelimiter>
             <convertLineBreaks>true</convertLineBreaks>
           </serializationProperties>
-          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="4.6.0">
+          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="4.6.1">
             <useStrictParser>false</useStrictParser>
             <useStrictValidation>false</useStrictValidation>
             <segmentDelimiter>\r</segmentDelimiter>
           </deserializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="4.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="4.6.1">
             <splitType>MSH_Segment</splitType>
             <batchScript></batchScript>
           </batchProperties>
-          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="4.6.0">
+          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="4.6.1">
             <segmentDelimiter>\r</segmentDelimiter>
             <successfulACKCode>AA</successfulACKCode>
             <successfulACKMessage></successfulACKMessage>
@@ -2121,7 +2127,7 @@ return value;
             <msh15ACKAccept>false</msh15ACKAccept>
             <dateFormat>yyyyMMddHHmmss.SSS</dateFormat>
           </responseGenerationProperties>
-          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="4.6.0">
+          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="4.6.1">
             <successfulACKCode>AA,CA</successfulACKCode>
             <errorACKCode>AE,CE</errorACKCode>
             <rejectedACKCode>AR,CR</rejectedACKCode>
@@ -2130,33 +2136,33 @@ return value;
             <originalIdMapVariable></originalIdMapVariable>
           </responseValidationProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="4.6.0">
+      <responseTransformer version="4.6.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="4.6.0">
+      <filter version="4.6.1">
         <elements>
-          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.0">
+          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.1">
             <name>Accept message if &quot;$(&apos;endpoint&apos;)&quot; equals &apos;bundle&apos;</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -2166,7 +2172,7 @@ return value;
               <string>&apos;bundle&apos;</string>
             </values>
           </com.mirth.connect.plugins.rulebuilder.RuleBuilderRule>
-          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.0">
+          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="4.6.1">
             <name>Accept message if &quot;sourceMap.get(&apos;contextPath&apos;)&quot; equals &apos;/hl7v2/Bundle&apos; or &apos;/hl7v2/Bundle/&apos;</name>
             <sequenceNumber>1</sequenceNumber>
             <enabled>true</enabled>
@@ -2195,6 +2201,34 @@ if (requestedPath == &quot;/&quot;) {
 var index = message.indexOf(&quot;MSH|&quot;);
 if (index !== -1) {
     message = message.substring(0, index) + &quot;\r\n&quot; + message.substring(index);
+}
+
+var rawData = connectorMessage.getRawData();
+// Extract filename from multipart request
+var filenameMatch = rawData.match(/filename=&quot;([^&quot;]+)&quot;/);
+if (filenameMatch &amp;&amp; filenameMatch.length &gt; 1) {
+
+    var filename = filenameMatch[1];
+
+    // Extract extension
+    var extensionMatch = filename.match(/\.([0-9a-z]+)$/i);
+    var extension = extensionMatch ? extensionMatch[1].toLowerCase() : &quot;&quot;;
+
+    // Reject ZIP uploads
+    if (extension === &quot;zip&quot;) {
+
+        var errorMessage =
+            &quot;ZIP uploads are not supported. Please upload a plain .hl7 or .txt file.&quot;;
+
+        responseMap.put(&quot;status&quot;, &quot;400&quot;);
+        responseMap.put(&quot;message&quot;, errorMessage);
+        responseMap.put(
+            &quot;finalResponse&quot;,
+            JSON.stringify({ status: 400, message: errorMessage })
+        );
+
+        throw errorMessage;
+    }
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///*********************************
@@ -2741,7 +2775,7 @@ globalMap.put(&apos;saveHL7Payload&apos;, saveHL7Payload);</deployScript>
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="4.6.0">
+  <properties version="4.6.1">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>DEVELOPMENT</messageStorageMode>
     <encryptData>false</encryptData>
@@ -2751,7 +2785,7 @@ return;</undeployScript>
     <removeOnlyFilteredOnCompletion>false</removeOnlyFilteredOnCompletion>
     <removeAttachmentsOnCompletion>false</removeAttachmentsOnCompletion>
     <initialState>STARTED</initialState>
-    <storeAttachments>true</storeAttachments>
+    <storeAttachments>false</storeAttachments>
     <metaDataColumns>
       <metaDataColumn>
         <name>SOURCE</name>
@@ -2764,7 +2798,7 @@ return;</undeployScript>
         <mappingName>message_type</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="4.6.0">
+    <attachmentProperties version="4.6.1">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -2779,24 +2813,24 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1769573842081</time>
+        <time>1770724969265</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
         <archiveEnabled>true</archiveEnabled>
         <pruneErroredMessages>false</pruneErroredMessages>
       </pruningSettings>
-      <userId>1</userId>
+      <userId>11</userId>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>92d58912-4ae5-4525-8dff-fa8f01f57578</id>
-        <name>0_1_17</name>
+        <id>5a73058d-b93a-46dd-b157-9fbc440fc625</id>
+        <name>0_1_18</name>
         <channelIds>
-          <string>32f45bb4-d1ac-41b2-8603-904c9397438a</string>
+          <string>42c12cfa-3058-4362-ba17-0ba4df9a6252</string>
         </channelIds>
         <backgroundColor>
-          <red>255</red>
+          <red>128</red>
           <green>0</green>
           <blue>0</blue>
           <alpha>255</alpha>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -45,9 +45,9 @@
     {
       "type": "HL7v2",
       "channel": "TechBD HL7 Workflow.xml",
-      "version": "0.1.17",
-      "editedby": "jewelbonnie",
-      "date": "2026-01-28"
+      "version": "0.1.18",
+      "editedby": "Arjun161201",
+      "date": "2026-02-10"
     },
     {
       "type": "HL7v2",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1008.0</revision>
+        <revision>0.1009.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Added preprocessor validation to explicitly reject .zip file uploads with a proper 400 Bad Request response. #2380

- Added validation for requests where no file is provided, returning a meaningful error instead of a blank/200 response.