### PR TITLE
chore: temporarily hardcode BCP-47 system for preferred language #2571

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/converters/PatientConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/PatientConverter.java
@@ -442,7 +442,12 @@ public class PatientConverter extends BaseConverter {
                 .ifPresent(languageCode -> {
                     String langCode = fetchCode(languageCode, CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId);
                     Coding coding = new Coding();
-                    coding.setSystem(fetchSystem(langCode, data.getPreferredLanguageCodeSystem(), CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId));
+                    //coding.setSystem(fetchSystem(langCode, data.getPreferredLanguageCodeSystem(), CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId));
+                    // Temporary fix (#2571):
+                    // Hardcoding system to "urn:ietf:bcp:47" to avoid ambiguity caused by multiple
+                    // system mappings for the same language code (e.g., 'en') in DB.
+                    // This will be reverted once the SHINNY language system structure is finalized.
+                    coding.setSystem("urn:ietf:bcp:47");
                     coding.setCode(langCode);
                     coding.setDisplay(fetchDisplay(langCode, data.getPreferredLanguageCodeDescription(), CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId));
                     CodeableConcept language = new CodeableConcept();

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/PatientConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/PatientConverter.java
@@ -442,7 +442,12 @@ public class PatientConverter extends BaseConverter {
                 .ifPresent(languageCode -> {
                     String langCode = fetchCode(languageCode, CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId);
                     Coding coding = new Coding();
-                    coding.setSystem(fetchSystem(langCode, data.getPreferredLanguageCodeSystem(), CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId));
+                    //coding.setSystem(fetchSystem(langCode, data.getPreferredLanguageCodeSystem(), CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId));
+                    // Temporary fix (#2571):
+                    // Hardcoding system to "urn:ietf:bcp:47" to avoid ambiguity caused by multiple
+                    // system mappings for the same language code (e.g., 'en') in DB.
+                    // This will be reverted once the SHINNY language system structure is finalized.
+                    coding.setSystem("urn:ietf:bcp:47");
                     coding.setCode(langCode);
                     coding.setDisplay(fetchDisplay(langCode, data.getPreferredLanguageCodeDescription(), CsvConstants.PREFERRED_LANGUAGE_CODE, interactionId));
                     CodeableConcept language = new CodeableConcept();


### PR DESCRIPTION
- Replace fetchSystem() with hardcoded "urn:ietf:bcp:47"
- Prevent ambiguity caused by multiple system mappings for same language code in DB
- Marked as temporary until SHINNY language system structure is finalized