### PR TITLE
feat: use baseFHIRUrl with default fallback for resource and extension URLs #2571

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/converters/ConsentConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/ConsentConverter.java
@@ -111,11 +111,15 @@ public class ConsentConverter extends BaseConverter {
 
         populateConsentPolicy(consent, screeningProfileData);
         
-        String fullUrl = "http://shinny.org/us/ny/hrsn/Consent/" + consent.getId();
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String fullUrl =  baseUrl + "/Consent/" + consent.getId();
         BundleEntryComponent bundleEntryComponent = new BundleEntryComponent();
         bundleEntryComponent.setFullUrl(fullUrl);
         bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                .setUrl("http://shinny.org/us/ny/hrsn/Consent/" + consent.getId()));
+                .setUrl(baseUrl + "/Consent/" + consent.getId()));
         bundleEntryComponent.setResource(consent);
         LOG.info("ConsentConverter :: convert  END for transaction id :{}", interactionId);
         return List.of(bundleEntryComponent);

--- a/csv-service/src/main/java/org/techbd/csv/converters/EncounterConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/EncounterConverter.java
@@ -81,7 +81,11 @@ public class EncounterConverter extends BaseConverter {
         
         idsGenerated.put(CsvConstants.ENCOUNTER_ID, encounter.getId());
 
-        String fullUrl = "http://shinny.org/us/ny/hrsn/Encounter/" + encounter.getId();
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String fullUrl = baseUrl + "/Encounter/" + encounter.getId();
 
         Meta meta = encounter.getMeta();
 
@@ -113,7 +117,7 @@ public class EncounterConverter extends BaseConverter {
         BundleEntryComponent bundleEntryComponent = new BundleEntryComponent();
         bundleEntryComponent.setFullUrl(fullUrl);
         bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                .setUrl("http://shinny.org/us/ny/hrsn/Encounter/" + encounter.getId()));
+                .setUrl(baseUrl + "/Encounter/" + encounter.getId()));
         bundleEntryComponent.setResource(encounter);
 
         return List.of(bundleEntryComponent);

--- a/csv-service/src/main/java/org/techbd/csv/converters/OrganizationConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/OrganizationConverter.java
@@ -78,7 +78,11 @@ public class OrganizationConverter extends BaseConverter {
         setMeta(organization,baseFHIRUrl);
         organization.setId(CsvConversionUtil.sha256(qeAdminData.getFacilityId())); // Assuming qrAdminData contains orgId
         idsGenerated.put(CsvConstants.ORGANIZATION_ID,organization.getId());
-        String fullUrl = "http://shinny.org/us/ny/hrsn/Organization/" + organization.getId();
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String fullUrl = baseUrl + "/Organization/" + organization.getId();
         Meta meta = organization.getMeta();
         meta.setLastUpdated(DateUtil.parseDate(qeAdminData.getFacilityLastUpdated()));
         populateOrganizationName(organization, qeAdminData);
@@ -89,7 +93,7 @@ public class OrganizationConverter extends BaseConverter {
          
         BundleEntryComponent bundleEntryComponent = new BundleEntryComponent();
         bundleEntryComponent.setFullUrl(fullUrl);
-        bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST).setUrl("http://shinny.org/us/ny/hrsn/Organization/" + organization.getId()));
+        bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST).setUrl(baseUrl + "/Organization/" + organization.getId()));
         bundleEntryComponent.setResource(organization);
         return List.of(bundleEntryComponent);
     }

--- a/csv-service/src/main/java/org/techbd/csv/converters/PatientConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/PatientConverter.java
@@ -84,7 +84,11 @@ public class PatientConverter extends BaseConverter {
                 .sha256(generateUniqueId(screeningProfileData.getEncounterId(), qeAdminData.getFacilityId(),
                         demographicData.getPatientMrIdValue())));
         idsGenerated.put(CsvConstants.PATIENT_ID, patient.getId());
-        String fullUrl = "http://shinny.org/us/ny/hrsn/Patient/" + patient.getId();
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String fullUrl = baseUrl + "/Patient/" + patient.getId();
         Meta meta = patient.getMeta();
         if (StringUtils.isNotEmpty(demographicData.getPatientLastUpdated())) {
             meta.setLastUpdated(DateUtil.parseDate(demographicData.getPatientLastUpdated())); // max date available in all
@@ -92,11 +96,11 @@ public class PatientConverter extends BaseConverter {
             meta.setLastUpdated(new java.util.Date());
         }                                                                                         
         patient.setLanguage("en");
-        populatePatientWithExtensions(patient, demographicData, interactionId);
+        populatePatientWithExtensions(patient, demographicData, interactionId, baseUrl);
         populateMrIdentifier(patient, demographicData,qeAdminData, idsGenerated );
         populateMaIdentifier(patient, demographicData);
         populateSsnIdentifier(patient, demographicData);
-        populatePatientName(patient, demographicData);
+        populatePatientName(patient, demographicData, baseUrl);
         populateAdministrativeSex(patient, demographicData, interactionId);
         populateBirthDate(patient, demographicData);
         populatePhone(patient, demographicData, interactionId);
@@ -107,13 +111,13 @@ public class PatientConverter extends BaseConverter {
         // populatePatientText(patient, demographicData);
         BundleEntryComponent bundleEntryComponent = new BundleEntryComponent();
         bundleEntryComponent.setFullUrl(fullUrl);
-        bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST).setUrl("http://shinny.org/us/ny/hrsn/Patient/" + patient.getId()));
+        bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST).setUrl(baseUrl + "Patient/" + patient.getId()));
         bundleEntryComponent.setResource(patient);
         LOG.info("PatientConverter :: convert  END for transaction id :{}", interactionId);
         return List.of(bundleEntryComponent);
     }
 
-    public void populatePatientWithExtensions(Patient patient,DemographicData demographicData, String interactionId) {
+    public void populatePatientWithExtensions(Patient patient,DemographicData demographicData, String interactionId, String baseUrl) {
         if (StringUtils.isNotEmpty(demographicData.getRaceCode())) {
             Extension raceExtension = new Extension("http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
 
@@ -209,7 +213,7 @@ public class PatientConverter extends BaseConverter {
             String[] codes = demographicData.getPersonalPronounsCode().split(";");
             String[] displays = StringUtils.defaultString(demographicData.getPersonalPronounsDescription()).split(";");
 
-            Extension pronounsExtension = new Extension("http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-personal-pronouns");
+            Extension pronounsExtension = new Extension(baseUrl + "/StructureDefinition/shinny-personal-pronouns");
             CodeableConcept concept = new CodeableConcept();
 
             for (int i = 0; i < codes.length; i++) {
@@ -239,7 +243,7 @@ public class PatientConverter extends BaseConverter {
             String[] systems = StringUtils.defaultString(demographicData.getGenderIdentityCodeSystem()).split(";");
             String[] descriptions = StringUtils.defaultString(demographicData.getGenderIdentityCodeDescription()).split(";");
 
-            Extension genderIdentityExtension = new Extension("http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-gender-identity");
+            Extension genderIdentityExtension = new Extension(baseUrl + "/StructureDefinition/shinny-gender-identity");
             CodeableConcept genderConcept = new CodeableConcept();
 
             for (int i = 0; i < rawCodes.length; i++) {
@@ -267,14 +271,14 @@ public class PatientConverter extends BaseConverter {
             }
         }
     }
-    private static Patient populatePatientName(Patient patient, DemographicData demographicData) {
+    private static Patient populatePatientName(Patient patient, DemographicData demographicData, String baseUrl) {
         HumanName name = new HumanName();
         if (demographicData.getGivenName() != null) {
             name.addGiven(demographicData.getGivenName());
         }
         if (demographicData.getMiddleName() != null) {
             Extension middleNameExtension = new Extension();
-            middleNameExtension.setUrl("http://shinny.org/us/ny/hrsn/StructureDefinition/middle-name"); // TODO : remove
+            middleNameExtension.setUrl(baseUrl+ "/StructureDefinition/middle-name"); // TODO : remove
                                                                                                         // static
                                                                                                         // reference
             middleNameExtension.setValue(new StringType(demographicData.getMiddleName()));

--- a/csv-service/src/main/java/org/techbd/csv/converters/ProcedureConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/ProcedureConverter.java
@@ -95,7 +95,7 @@ public class ProcedureConverter extends BaseConverter {
         if (StringUtils.isNotEmpty(screeningProfileData.getProcedureCode())) {
             Procedure procedure = createProcedure(screeningProfileData, baseFHIRUrl);
             populateProcedureDetails(procedure, screeningProfileData, screeningObservationData, idsGenerated, interactionId);
-            BundleEntryComponent entry = createBundleEntry(procedure);
+            BundleEntryComponent entry = createBundleEntry(procedure, baseFHIRUrl);
             return List.of(entry);
         } else {
             LOG.info(
@@ -125,8 +125,13 @@ public class ProcedureConverter extends BaseConverter {
         return encounterId + "_" + facilityId + "_" + procedureCode;
     }
 
-    private BundleEntryComponent createBundleEntry(Procedure procedure) {
-        String fullUrl = PROCEDURE_BASE_URL + procedure.getId();
+    private BundleEntryComponent createBundleEntry(Procedure procedure, String baseFHIRUrl) {
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        //String fullUrl = PROCEDURE_BASE_URL + procedure.getId();
+        String fullUrl = baseUrl + "/Procedure/" + procedure.getId();
 
         return new BundleEntryComponent()
                 .setFullUrl(fullUrl)

--- a/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
@@ -105,7 +105,12 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                 //                                 data.getQuestionCode() + data.getEncounterId());
                                 observation.setId(observationIdHashed);
                                 data.setObservationId(observationId);
-                                String fullUrl = "http://shinny.org/us/ny/hrsn/Observation/" + observationIdHashed;
+                                String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl
+                                        : "http://shinny.org/us/ny/hrsn";
+                                if (baseUrl.endsWith("/")) {
+                                    baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+                                }
+                                String fullUrl = baseUrl + "/Observation/" + observationIdHashed;
                                 setMeta(observation,baseFHIRUrl);
                                 Meta meta = observation.getMeta();
                                 if (StringUtils.isNotEmpty(screeningProfileData.getScreeningLastUpdated())) {
@@ -123,7 +128,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
 
                                 if (StringUtils.isNotEmpty(screeningLangCode) && !"en".equals(screeningLangCode)) {
                                     Extension languageExtension = new Extension(
-                                            "http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-observation-language");
+                                        baseUrl + "/StructureDefinition/shinny-observation-language");
                                     CodeableConcept valueConcept = new CodeableConcept();
                                     valueConcept.addCoding(new Coding().setCode(screeningLangCode));
                                     languageExtension.setValue(valueConcept);
@@ -387,7 +392,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                 BundleEntryComponent entry = new BundleEntryComponent();
                                 entry.setFullUrl(fullUrl);
                                 entry.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                                                .setUrl("http://shinny.org/us/ny/hrsn/Observation/" + observationIdHashed));
+                                                .setUrl(baseUrl + "/Observation/" + observationIdHashed));
                                 entry.setResource(observation);
                                 bundleEntryComponents.add(entry);
                         }
@@ -480,10 +485,14 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                 String screeningLangCode = fetchCode(screeningProfileData.getScreeningLanguageCode(),
                         CsvConstants.SCREENING_LANGUAGE_CODE, interactionId);
                 groupObservation.setLanguage("en");
+                String baseUrl = StringUtils.isNotBlank(baseFhirUrl) ? baseFhirUrl : "http://shinny.org/us/ny/hrsn";
+                if (baseUrl.endsWith("/")) {
+                    baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+                }
 
                 if (StringUtils.isNotEmpty(screeningLangCode) && !"en".equals(screeningLangCode)) {
                     Extension languageExtension = new Extension(
-                            "http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-observation-language");
+                        baseUrl + "/StructureDefinition/shinny-observation-language");
                     CodeableConcept valueConcept = new CodeableConcept();
                     valueConcept.addCoding(new Coding().setCode(screeningLangCode));
                     languageExtension.setValue(valueConcept);
@@ -623,7 +632,8 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                 groupObservation.setHasMember(hasMemberReferences);
 
                 // Create bundle entry
-                String fullUrl = OBSERVATION_URL_BASE + observationId;
+                //String fullUrl = OBSERVATION_URL_BASE + observationId;
+                String fullUrl = baseUrl + "/Observation/" + observationId;
                 BundleEntryComponent groupEntry = new BundleEntryComponent();
                 groupEntry.setFullUrl(fullUrl);
                 groupEntry.setResource(groupObservation);

--- a/csv-service/src/main/java/org/techbd/csv/converters/SexualOrientationObservationConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/SexualOrientationObservationConverter.java
@@ -63,7 +63,11 @@ public class SexualOrientationObservationConverter extends BaseConverter {
             observation.setId(CsvConversionUtil.sha256("SexualOrientation-" + screeningProfileData.getPatientMrIdValue()
                     + screeningProfileData.getEncounterId()));
             Meta meta = observation.getMeta();
-            String fullUrl = "http://shinny.org/us/ny/hrsn/Observation/" + observation.getId();
+            String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+            if (baseUrl.endsWith("/")) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+            }
+            String fullUrl = baseUrl + "/Observation/" + observation.getId();
             
             if (StringUtils.isNotEmpty(demographicData.getSexualOrientationLastUpdated())) {
                 meta.setLastUpdated(DateUtil.parseDate(demographicData.getSexualOrientationLastUpdated()));
@@ -103,7 +107,7 @@ public class SexualOrientationObservationConverter extends BaseConverter {
             BundleEntryComponent entry = new BundleEntryComponent();
             entry.setFullUrl(fullUrl);
             entry.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                    .setUrl("http://shinny.org/us/ny/hrsn/Observation/" + observation.getId()));
+                    .setUrl(baseUrl + "/Observation/" + observation.getId()));
             entry.setResource(observation);
             LOG.info("SexualOrientationObservationConverter:: convert END for interaction id :{} ", interactionId);
             return List.of(entry);

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/ConsentConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/ConsentConverter.java
@@ -112,11 +112,15 @@ public class ConsentConverter extends BaseConverter {
 
         populateConsentPolicy(consent, screeningProfileData);
         
-        String fullUrl = "http://shinny.org/us/ny/hrsn/Consent/" + consent.getId();
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String fullUrl =  baseUrl + "/Consent/" + consent.getId();
         BundleEntryComponent bundleEntryComponent = new BundleEntryComponent();
         bundleEntryComponent.setFullUrl(fullUrl);
         bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                .setUrl("http://shinny.org/us/ny/hrsn/Consent/" + consent.getId()));
+                .setUrl( baseUrl + "/Consent/" + consent.getId()));
         bundleEntryComponent.setResource(consent);
         LOG.info("ConsentConverter :: convert  END for transaction id :{}", interactionId);
         return List.of(bundleEntryComponent);

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/EncounterConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/EncounterConverter.java
@@ -81,7 +81,11 @@ public class EncounterConverter extends BaseConverter {
         
         idsGenerated.put(CsvConstants.ENCOUNTER_ID, encounter.getId());
 
-        String fullUrl = "http://shinny.org/us/ny/hrsn/Encounter/" + encounter.getId();
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String fullUrl = baseUrl + "/Encounter/" + encounter.getId();
 
         Meta meta = encounter.getMeta();
 
@@ -113,7 +117,7 @@ public class EncounterConverter extends BaseConverter {
         BundleEntryComponent bundleEntryComponent = new BundleEntryComponent();
         bundleEntryComponent.setFullUrl(fullUrl);
         bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                .setUrl("http://shinny.org/us/ny/hrsn/Encounter/" + encounter.getId()));
+                .setUrl(baseUrl + "/Encounter/" + encounter.getId()));
         bundleEntryComponent.setResource(encounter);
 
         return List.of(bundleEntryComponent);

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/OrganizationConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/OrganizationConverter.java
@@ -78,7 +78,11 @@ public class OrganizationConverter extends BaseConverter {
         setMeta(organization,baseFHIRUrl);
         organization.setId(CsvConversionUtil.sha256(qeAdminData.getFacilityId())); // Assuming qrAdminData contains orgId
         idsGenerated.put(CsvConstants.ORGANIZATION_ID,organization.getId());
-        String fullUrl = "http://shinny.org/us/ny/hrsn/Organization/" + organization.getId();
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String fullUrl = baseUrl + "/Organization/" + organization.getId();
         Meta meta = organization.getMeta();
         meta.setLastUpdated(DateUtil.parseDate(qeAdminData.getFacilityLastUpdated()));
         populateOrganizationName(organization, qeAdminData);
@@ -89,7 +93,7 @@ public class OrganizationConverter extends BaseConverter {
          
         BundleEntryComponent bundleEntryComponent = new BundleEntryComponent();
         bundleEntryComponent.setFullUrl(fullUrl);
-        bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST).setUrl("http://shinny.org/us/ny/hrsn/Organization/" + organization.getId()));
+        bundleEntryComponent.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST).setUrl(baseUrl + "/Organization/" + organization.getId()));
         bundleEntryComponent.setResource(organization);
         return List.of(bundleEntryComponent);
     }

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/ProcedureConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/ProcedureConverter.java
@@ -94,7 +94,7 @@ public class ProcedureConverter extends BaseConverter {
         if (StringUtils.isNotEmpty(screeningProfileData.getProcedureCode())) {
             Procedure procedure = createProcedure(screeningProfileData, baseFHIRUrl);
             populateProcedureDetails(procedure, screeningProfileData, screeningObservationData, idsGenerated, interactionId);
-            BundleEntryComponent entry = createBundleEntry(procedure);
+            BundleEntryComponent entry = createBundleEntry(procedure, baseFHIRUrl);
             return List.of(entry);
         } else {
             LOG.info(
@@ -124,8 +124,13 @@ public class ProcedureConverter extends BaseConverter {
         return encounterId + "_" + facilityId + "_" + procedureCode;
     }
 
-    private BundleEntryComponent createBundleEntry(Procedure procedure) {
-        String fullUrl = PROCEDURE_BASE_URL + procedure.getId();
+    private BundleEntryComponent createBundleEntry(Procedure procedure, String baseFHIRUrl) {
+        String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        //String fullUrl = PROCEDURE_BASE_URL + procedure.getId();
+        String fullUrl = baseUrl + "/Procedure/" + procedure.getId();
 
         return new BundleEntryComponent()
                 .setFullUrl(fullUrl)

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
@@ -105,7 +105,12 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                 //                                 data.getQuestionCode() + data.getEncounterId());
                                 observation.setId(observationIdHashed);
                                 data.setObservationId(observationId);
-                                String fullUrl = "http://shinny.org/us/ny/hrsn/Observation/" + observationIdHashed;
+                                String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl
+                                        : "http://shinny.org/us/ny/hrsn";
+                                if (baseUrl.endsWith("/")) {
+                                    baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+                                }
+                                String fullUrl = baseUrl + "/Observation/" + observationIdHashed;
                                 setMeta(observation,baseFHIRUrl);
                                 Meta meta = observation.getMeta();
                                 if (StringUtils.isNotEmpty(screeningProfileData.getScreeningLastUpdated())) {
@@ -122,7 +127,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
 
                                 if (StringUtils.isNotEmpty(screeningLangCode) && !"en".equals(screeningLangCode)) {
                                     Extension languageExtension = new Extension(
-                                            "http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-observation-language");
+                                        baseUrl + "/StructureDefinition/shinny-observation-language");
                                     CodeableConcept valueConcept = new CodeableConcept();
                                     valueConcept.addCoding(new Coding().setCode(screeningLangCode));
                                     languageExtension.setValue(valueConcept);
@@ -386,7 +391,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                 BundleEntryComponent entry = new BundleEntryComponent();
                                 entry.setFullUrl(fullUrl);
                                 entry.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                                                .setUrl("http://shinny.org/us/ny/hrsn/Observation/" + observationIdHashed));
+                                                .setUrl(baseUrl + "/Observation/" + observationIdHashed));
                                 entry.setResource(observation);
                                 bundleEntryComponents.add(entry);
                         }
@@ -479,10 +484,14 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                 String screeningLangCode = fetchCode(screeningProfileData.getScreeningLanguageCode(),
                         CsvConstants.SCREENING_LANGUAGE_CODE, interactionId);
                 groupObservation.setLanguage("en");
+                String baseUrl = StringUtils.isNotBlank(baseFhirUrl) ? baseFhirUrl : "http://shinny.org/us/ny/hrsn";
+                if (baseUrl.endsWith("/")) {
+                    baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+                }
 
                 if (StringUtils.isNotEmpty(screeningLangCode) && !"en".equals(screeningLangCode)) {
                     Extension languageExtension = new Extension(
-                            "http://shinny.org/us/ny/hrsn/StructureDefinition/shinny-observation-language");
+                        baseUrl + "/StructureDefinition/shinny-observation-language");
                     CodeableConcept valueConcept = new CodeableConcept();
                     valueConcept.addCoding(new Coding().setCode(screeningLangCode));
                     languageExtension.setValue(valueConcept);
@@ -622,7 +631,8 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                 groupObservation.setHasMember(hasMemberReferences);
 
                 // Create bundle entry
-                String fullUrl = OBSERVATION_URL_BASE + observationId;
+                //String fullUrl = OBSERVATION_URL_BASE + observationId;
+                String fullUrl = baseUrl + "/Observation/" + observationId;
                 BundleEntryComponent groupEntry = new BundleEntryComponent();
                 groupEntry.setFullUrl(fullUrl);
                 groupEntry.setResource(groupObservation);

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/SexualOrientationObservationConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/SexualOrientationObservationConverter.java
@@ -63,7 +63,11 @@ public class SexualOrientationObservationConverter extends BaseConverter {
             observation.setId(CsvConversionUtil.sha256("SexualOrientation-" + screeningProfileData.getPatientMrIdValue()
                     + screeningProfileData.getEncounterId()));
             Meta meta = observation.getMeta();
-            String fullUrl = "http://shinny.org/us/ny/hrsn/Observation/" + observation.getId();
+            String baseUrl = StringUtils.isNotBlank(baseFHIRUrl) ? baseFHIRUrl : "http://shinny.org/us/ny/hrsn";
+            if (baseUrl.endsWith("/")) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+            }
+            String fullUrl = baseUrl + "/Observation/" + observation.getId();
             
             if (StringUtils.isNotEmpty(demographicData.getSexualOrientationLastUpdated())) {
                 meta.setLastUpdated(DateUtil.parseDate(demographicData.getSexualOrientationLastUpdated()));
@@ -103,7 +107,7 @@ public class SexualOrientationObservationConverter extends BaseConverter {
             BundleEntryComponent entry = new BundleEntryComponent();
             entry.setFullUrl(fullUrl);
             entry.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                    .setUrl("http://shinny.org/us/ny/hrsn/Observation/" + observation.getId()));
+                    .setUrl(baseUrl + "Observation/" + observation.getId()));
             entry.setResource(observation);
             LOG.info("SexualOrientationObservationConverter:: convert END for interaction id :{} ", interactionId);
             return List.of(entry);


### PR DESCRIPTION
- Replace hardcoded base URL with baseFHIRUrl variable across converters
- Add default fallback to "http://shinny.org/us/ny/hrsn" when baseFHIRUrl is null or empty
- Ensure consistent URL construction for fullUrl and Extension references