### PR TITLE
fix: add missing slash in Observation request URL construction (#2571)

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/SexualOrientationObservationConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/SexualOrientationObservationConverter.java
@@ -107,7 +107,7 @@ public class SexualOrientationObservationConverter extends BaseConverter {
             BundleEntryComponent entry = new BundleEntryComponent();
             entry.setFullUrl(fullUrl);
             entry.setRequest(new Bundle.BundleEntryRequestComponent().setMethod(HTTPVerb.POST)
-                    .setUrl(baseUrl + "Observation/" + observation.getId()));
+                    .setUrl(baseUrl + "/Observation/" + observation.getId()));
             entry.setResource(observation);
             LOG.info("SexualOrientationObservationConverter:: convert END for interaction id :{} ", interactionId);
             return List.of(entry);


### PR DESCRIPTION
- Add "/" before "Observation" in BundleEntryRequestComponent URL
- Fix incorrect endpoint path caused by missing slash