### PR TITLE
fix: Wrap HTTP response early to enforce ACK Content-Type header #2686

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1016.0</revision>
+        <revision>0.1017.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
 **Problem**:
- Spring WS commits the SOAP response early, so overriding the Content-Type header later in the filter chain does not work reliably.

**Fix**:

1. Wrapped the HttpServletResponse early using ContentTypeOverrideResponseWrapper

2. Ensures the configured ackContentType is enforced before Spring WS writes the response

3. Maintains existing mTLS flow by passing the wrapped response through the full filter chain #2686 