### PR TITLE
fix: update XSLT file for whitespace handling to prevent validation warnings in HL7-to-FHIR conversion #2739

### DIFF
--- a/support/specifications/develop/hl7/hl7v2-fhir-bundle.xslt
+++ b/support/specifications/develop/hl7/hl7v2-fhir-bundle.xslt
@@ -18,32 +18,66 @@
   <xsl:param name="facilityID"/>
   <xsl:param name="OrganizationName"/>
   
+  <!-- <xsl:if test="string-length(string(//PID[1]/PID.5/PID.5.1)) &gt; 0">     -->
+    <xsl:variable name="givenName5">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="string(//PID[1]/PID.5/PID.5.2)"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="middleName5">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="string(//PID[1]/PID.5/PID.5.3)"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="familyName5">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="string(//PID[1]/PID.5/PID.5.1)"/>
+      </xsl:call-template>
+    </xsl:variable>
+  <!-- </xsl:if> -->
+
+  <!-- <xsl:if test="string-length(string(//PID[1]/PID.9/PID.9.1)) &gt; 0"> -->
+    <xsl:variable name="givenName9">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="string(//PID[1]/PID.9/PID.9.2)"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="middleName9">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="string(//PID[1]/PID.9/PID.9.3)"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="familyName9">
+      <xsl:call-template name="string-trim">
+        <xsl:with-param name="text" select="string(//PID[1]/PID.9/PID.9.1)"/>
+      </xsl:call-template>
+    </xsl:variable>
+  <!-- </xsl:if> -->
+
   <xsl:variable name="patientResourceName">
     <xsl:choose>
       <!-- Prefer Legal Name (PID-5) -->
-      <xsl:when test="normalize-space(//PID[1]/PID.5/PID.5.1)">
-        <xsl:value-of select="normalize-space(
-          concat(
-            //PID[1]/PID.5/PID.5.2, ' ',
-            //PID[1]/PID.5/PID.5.3, ' ',
-            //PID[1]/PID.5/PID.5.1
-          )
-        )"/>
+      <xsl:when test="string-length(string(//PID[1]/PID.5/PID.5.1)) &gt; 0">        
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text"
+            select="concat($givenName5, ' ', $middleName5, ' ', $familyName5)"/>
+        </xsl:call-template>
       </xsl:when>
 
       <!-- Fallback to Alias (PID-9) -->
-      <xsl:when test="normalize-space(//PID[1]/PID.9/PID.9.1)">
-        <xsl:value-of select="normalize-space(
-          concat(
-            //PID[1]/PID.9/PID.9.2, ' ',
-            //PID[1]/PID.9/PID.9.3, ' ',
-            //PID[1]/PID.9/PID.9.1
-          )
-        )"/>
+      <xsl:when test="string-length(string(//PID[1]/PID.9/PID.9.1)) &gt; 0">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text"
+            select="concat($givenName9, ' ', $middleName9, ' ', $familyName9)"/>
+        </xsl:call-template> 
       </xsl:when>
 
       <!-- Absolute fallback -->
-      <xsl:otherwise>Unknown Patient</xsl:otherwise>
+      <xsl:otherwise><xsl:text>Unknown Patient</xsl:text></xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
 
@@ -211,10 +245,16 @@
           ]
         </xsl:if>
 
+        <xsl:variable name="genderCodeNorm"
+            select="translate(
+                normalize-space(//PID.8),
+                'abcdefghijklmnopqrstuvwxyz',
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+            )"/>
         , "gender": "<xsl:choose>
-                <xsl:when test="normalize-space(//PID.8) = 'M'">male</xsl:when>
-                <xsl:when test="normalize-space(//PID.8) = 'F'">female</xsl:when>
-                <xsl:when test="normalize-space(//PID.8) = 'O'">other</xsl:when>
+                <xsl:when test="$genderCodeNorm = 'M'">male</xsl:when>
+                <xsl:when test="$genderCodeNorm = 'F'">female</xsl:when>
+                <xsl:when test="$genderCodeNorm = 'O'">other</xsl:when>
                 <xsl:otherwise>unknown</xsl:otherwise>
               </xsl:choose>"
 
@@ -329,19 +369,26 @@
             <!-- use -->
             <xsl:if test="normalize-space(*[2])">
               "use": "<xsl:choose>
-                <xsl:when test="*[2]='WPN' or *[2]='WP'">work</xsl:when>
-                <xsl:when test="*[2]='PRN' or *[2]='H'">home</xsl:when>
-                <xsl:when test="*[2]='NET' or *[2]='MC'">mobile</xsl:when>
-                <xsl:when test="*[2]='TMP'">temp</xsl:when>
-                <xsl:when test="*[2]='BAD'">old</xsl:when>
+                <xsl:when test="normalize-space(*[2])='WPN' or normalize-space(*[2])='WP'">work</xsl:when>
+                <xsl:when test="normalize-space(*[2])='PRN' or normalize-space(*[2])='H'">home</xsl:when>
+                <xsl:when test="normalize-space(*[2])='NET' or normalize-space(*[2])='MC'">mobile</xsl:when>
+                <xsl:when test="normalize-space(*[2])='TMP'">temp</xsl:when>
+                <xsl:when test="normalize-space(*[2])='BAD'">old</xsl:when>
                 <xsl:otherwise>
-                  <xsl:value-of select="*[2]"/>
+                  <xsl:value-of select="normalize-space(*[2])"/>
                 </xsl:otherwise>
               </xsl:choose>",
             </xsl:if>
 
             <!-- value -->
-            "value": "<xsl:value-of select="normalize-space(*[1])"/>"
+            <!-- "value": "<xsl:value-of select="normalize-space(*[1])"/>" -->
+            <xsl:variable name="trimmedValue">
+              <xsl:call-template name="string-trim">
+                <xsl:with-param name="text" select="string(*[1])"/>
+              </xsl:call-template>
+            </xsl:variable>
+            "value": "<xsl:value-of select="$trimmedValue"/>"
+
             }<xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each>
           ]
@@ -505,7 +552,12 @@
 
       <xsl:variable name="cinId" select="$patientCIN"/>
 		  <xsl:variable name="ssnId" select="normalize-space(//PID/PID.19/PID.19.1)"/>		
-		  <xsl:variable name="mrnId" select="//PID.3/PID.3.1"/>
+		  <!-- <xsl:variable name="mrnId" select="//PID.3/PID.3.1"/> -->
+      <xsl:variable name="mrnId">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="//PID.3/PID.3.1"/>
+        </xsl:call-template>
+      </xsl:variable>
 
       <xsl:if test="$cinId or $ssnId or $mrnId">
       , "identifier": [
@@ -1169,10 +1221,16 @@
 		
         "name": "<xsl:choose>
            <xsl:when test='normalize-space($OrganizationName)'>
-             <xsl:value-of select='$OrganizationName'/>
+             <!-- <xsl:value-of select='$OrganizationName'/> -->
+              <xsl:call-template name="string-trim">
+                <xsl:with-param name="text" select="$OrganizationName"/>
+              </xsl:call-template>
            </xsl:when>
            <xsl:otherwise>
-             <xsl:value-of select='//MSH/MSH.6'/>
+             <!-- <xsl:value-of select='//MSH/MSH.6'/> -->
+             <xsl:call-template name="string-trim">
+                <xsl:with-param name="text" select="//MSH/MSH.6"/>
+              </xsl:call-template>
            </xsl:otherwise>
          </xsl:choose>"
 
@@ -1186,16 +1244,25 @@
                                     or normalize-space(ORC.23.3)
                                   ]">
               {
-                <xsl:if test="normalize-space(ORC.23.1)">
+                <!-- <xsl:if test="normalize-space(ORC.23.1)">
                   "value": "<xsl:value-of select='ORC.23.1'/>"
+                </xsl:if> -->
+                <xsl:if test="normalize-space(ORC.23.1)">                  
+                  <xsl:variable name="trimmedValue">
+                    <xsl:call-template name="string-trim">
+                      <xsl:with-param name="text" select="ORC.23.1"/>
+                    </xsl:call-template>
+                  </xsl:variable>
+                  "value": "<xsl:value-of select="$trimmedValue"/>"
+
                 </xsl:if>
 
                 <xsl:if test="normalize-space(ORC.23.3)">
                   <xsl:if test="normalize-space(ORC.23.1)">, </xsl:if>
                   "system": "<xsl:choose>
-                    <xsl:when test="ORC.23.3 = 'PH'">phone</xsl:when>
-                    <xsl:when test="ORC.23.3 = 'FX'">fax</xsl:when>
-                    <xsl:when test="ORC.23.3 = 'Internet'">email</xsl:when>
+                    <xsl:when test="normalize-space(ORC.23.3) = 'PH'">phone</xsl:when>
+                    <xsl:when test="normalize-space(ORC.23.3) = 'FX'">fax</xsl:when>
+                    <xsl:when test="normalize-space(ORC.23.3) = 'Internet'">email</xsl:when>
                     <xsl:otherwise>other</xsl:otherwise>
                   </xsl:choose>"
                 </xsl:if>
@@ -1204,12 +1271,12 @@
                   <xsl:if test="normalize-space(ORC.23.1) 
                                 or normalize-space(ORC.23.3)">, </xsl:if>
                   "use": "<xsl:choose>
-                    <xsl:when test="ORC.23.2 = 'WP'">work</xsl:when>
-                    <xsl:when test="ORC.23.2 = 'H'">home</xsl:when>
-                    <xsl:when test="ORC.23.2 = 'TMP'">temp</xsl:when>
-                    <xsl:when test="ORC.23.2 = 'MC' or ORC.23.2 = 'PG'">mobile</xsl:when>
+                    <xsl:when test="normalize-space(ORC.23.2) = 'WP'">work</xsl:when>
+                    <xsl:when test="normalize-space(ORC.23.2) = 'H'">home</xsl:when>
+                    <xsl:when test="normalize-space(ORC.23.2) = 'TMP'">temp</xsl:when>
+                    <xsl:when test="normalize-space(ORC.23.2) = 'MC' or normalize-space(ORC.23.2) = 'PG'">mobile</xsl:when>
                     <xsl:otherwise>
-                      <xsl:value-of select="ORC.23.2"/>
+                      <xsl:value-of select="normalize-space(ORC.23.2)"/>
                     </xsl:otherwise>
                   </xsl:choose>"
                 </xsl:if>
@@ -1492,23 +1559,37 @@
           }
         ]
       </xsl:if>
+      
+      <!-- Trim required PV1 components first -->
+      <xsl:variable name="pv1_3_1_trimmed">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="string(//PV1[1]/PV1.3/PV1.3.1)"/>
+        </xsl:call-template>
+      </xsl:variable>
 
-      <xsl:if test="normalize-space(//PV1[1]/PV1.3/PV1.3.1)">
+      <xsl:variable name="pv1_3_4_trimmed">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="string(//PV1[1]/PV1.3/PV1.3.4)"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="pv1_3_7_trimmed">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="string(//PV1[1]/PV1.3/PV1.3.7)"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <!-- Only emit location if PV1.3.1 exists -->
+      <xsl:if test="string($pv1_3_1_trimmed)">
         <xsl:text>,</xsl:text>
         "location": [
           {
             "location": {
               "display": "<xsl:choose>
-                <xsl:when test="normalize-space(//PV1[1]/PV1.3/PV1.3.4)">
-                  <xsl:value-of select="normalize-space(//PV1[1]/PV1.3/PV1.3.4)"/>
-                </xsl:when>
-                <xsl:when test="normalize-space(//PV1[1]/PV1.3/PV1.3.7)">
-                  <xsl:value-of select="normalize-space(//PV1[1]/PV1.3/PV1.3.7)"/>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:value-of select="normalize-space(//PV1[1]/PV1.3/PV1.3.1)"/>
-                </xsl:otherwise>
-              </xsl:choose>"
+                            <xsl:when test="string($pv1_3_4_trimmed)"><xsl:value-of select="$pv1_3_4_trimmed"/></xsl:when>
+                            <xsl:when test="string($pv1_3_7_trimmed)"><xsl:value-of select="$pv1_3_7_trimmed"/></xsl:when>
+                            <xsl:otherwise><xsl:value-of select="$pv1_3_1_trimmed"/></xsl:otherwise>
+                          </xsl:choose>"
             }
           }
         ]
@@ -1916,61 +1997,114 @@
 <xsl:template name="generateNameJson">
   <xsl:param name="nameNode"/>
 
-  <!-- Collect name properties safely -->
+  <!-- ========================= -->
+  <!-- Trim All Components First -->
+  <!-- ========================= -->
+  <xsl:variable name="family_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="string($nameNode/*[1])"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <xsl:variable name="given_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="string($nameNode/*[2])"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <xsl:variable name="middle_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="string($nameNode/*[3])"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <xsl:variable name="suffix_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="string($nameNode/*[4])"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <xsl:variable name="prefix_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="string($nameNode/*[5])"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <xsl:variable name="use_trimmed">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text" select="string($nameNode/*[7])"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <!-- Combine Given + Middle safely -->
+  <xsl:variable name="combined_given">
+    <xsl:call-template name="string-trim">
+      <xsl:with-param name="text"
+        select="concat($given_trimmed, ' ', $middle_trimmed)"/>
+    </xsl:call-template>
+  </xsl:variable>
+
+  <!-- ========================= -->
+  <!-- Collect JSON Properties   -->
+  <!-- ========================= -->
   <xsl:variable name="props">
 
-    <!-- extension -->
-    <xsl:if test="string($nameNode/*[2]) or string($nameNode/*[3])">
+    <!-- extension (middle name) -->
+    <xsl:if test="string($middle_trimmed)">
       <p>
         "extension": [{
           "url": "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/middle-name",
-          "valueString": "<xsl:value-of select="normalize-space(concat($nameNode/*[2], ' ', $nameNode/*[3]))"/>"
+          "valueString": "<xsl:value-of select="$middle_trimmed"/>"
         }]
       </p>
     </xsl:if>
 
     <!-- use -->
-    <xsl:if test="string($nameNode/*[7])">
+    <xsl:if test="string($use_trimmed)">
       <p>
         "use": "<xsl:choose>
-          <xsl:when test="$nameNode/*[7] = 'L'">official</xsl:when>
-          <xsl:when test="$nameNode/*[7] = 'P'">usual</xsl:when>
-          <xsl:otherwise> <xsl:value-of select="$nameNode/*[7]"/> </xsl:otherwise>
+          <xsl:when test="$use_trimmed = 'L'">official</xsl:when>
+          <xsl:when test="$use_trimmed = 'P'">usual</xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$use_trimmed"/>
+          </xsl:otherwise>
         </xsl:choose>"
       </p>
     </xsl:if>
 
     <!-- prefix -->
-    <xsl:if test="string($nameNode/*[5])">
+    <xsl:if test="string($prefix_trimmed)">
       <p>
-        "prefix": ["<xsl:value-of select="$nameNode/*[5]"/>"]
+        "prefix": ["<xsl:value-of select="$prefix_trimmed"/>"]
       </p>
     </xsl:if>
 
     <!-- given -->
-    <xsl:if test="string($nameNode/*[2]) or string($nameNode/*[3])">
+    <xsl:if test="string($combined_given)">
       <p>
-        "given": ["<xsl:value-of select="normalize-space(concat($nameNode/*[2], ' ', $nameNode/*[3]))"/>"]
+        "given": ["<xsl:value-of select="$combined_given"/>"]
       </p>
     </xsl:if>
 
     <!-- family -->
-    <xsl:if test="string($nameNode/*[1])">
+    <xsl:if test="string($family_trimmed)">
       <p>
-        "family": "<xsl:value-of select="$nameNode/*[1]"/>"
+        "family": "<xsl:value-of select="$family_trimmed"/>"
       </p>
     </xsl:if>
 
     <!-- suffix -->
-    <xsl:if test="string($nameNode/*[4])">
+    <xsl:if test="string($suffix_trimmed)">
       <p>
-        "suffix": ["<xsl:value-of select="$nameNode/*[4]"/>"]
+        "suffix": ["<xsl:value-of select="$suffix_trimmed"/>"]
       </p>
     </xsl:if>
 
   </xsl:variable>
 
-  <!-- Emit JSON object safely -->
+  <!-- ========================= -->
+  <!-- Emit JSON Safely          -->
+  <!-- ========================= -->
   {
     <xsl:for-each select="exsl:node-set($props)/p">
       <xsl:value-of select="."/>
@@ -2069,4 +2203,30 @@
   </xsl:choose>
 </xsl:template>
 
+<!-- "Function" to trim leading and trailing spaces -->  
+  <xsl:template name="string-trim">
+    <xsl:param name="text"/>
+
+    <!-- trim leading spaces -->
+    <xsl:choose>
+      <xsl:when test="starts-with($text, ' ')">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="substring($text, 2)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- trim trailing spaces -->
+      <xsl:when test="substring($text, string-length($text)) = ' '">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text"
+            select="substring($text, 1, string-length($text) - 1)"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- Return result -->
+      <xsl:otherwise>
+        <xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Updated XSLT file for whitespace handling to prevent validation warnings in HL7-to-FHIR conversion.

**1.** The leading and trailing spaces removed for 

- Patient MRN, Family, Given, prefix and sufix, telecom, 
- Organization name, telecom, location name, 
- location.display in Encounter resource.

**2.** Patient gender - displayName mapped from code