### PR TITLE
fix: blank response while incorrect file is selected in CSV and CSV Bundle (#2380)

### DIFF
--- a/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundle.xml
+++ b/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundle.xml
@@ -2,9 +2,9 @@
   <id>2c91216f-12dc-434d-ad65-2c4a96d64746</id>
   <nextMetaDataId>2</nextMetaDataId>
   <name>FlatFileCsvBundle</name>
-  <description>Version: 0.9.6
-correct the error messgae while content type is empty/invalid value</description>
-  <revision>4</revision>
+  <description>Version: 0.9.7
+correct the error messgae while tenant id is invalid</description>
+  <revision>5</revision>
   <sourceConnector version="4.6.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -333,7 +333,7 @@ channelMap.put(&apos;baseFhirURL&apos;, baseFhirURL);
 // Check if the header is null or empty
 if (tenantId == null || String(tenantId).trim() === &quot;&quot;) {
     // Log the error for debugging
-    var errorMessage = &apos;[CHANNEL: &apos;+ channelName +&apos;] Bad Request: Missing required header X-TechBD-Tenant-ID&apos;;
+    var errorMessage = &apos;Bad Request: Missing required header X-TechBD-Tenant-ID&apos;;
     logger.error(errorMessage);
     setErrorResponse(400, errorMessage); // Set the HTTP response status to 400 (Bad Request)
     throw errorMessage; // Stop further processing by throwing an exception
@@ -345,7 +345,7 @@ var rawData = connectorMessage.getRawData();
 
 // Check if rawData is empty
 if (!rawData || rawData.trim().length === 0) {
-    errorMessage = &quot;[CHANNEL: &quot;+ channelName +&quot;] No file provided in the request.&quot;;
+    errorMessage = &quot;No file provided in the request.&quot;;
     setErrorResponse(400, errorMessage); // Set the HTTP response status to 400 (Bad Request)
     throw errorMessage;
 }
@@ -371,7 +371,7 @@ for each (var part in parts) {
 
 // Validate the file content
 if (!fileContent || fileContent == &apos;&apos; || fileContent.trim().length === 0) {
-    errorMessage = &quot;[CHANNEL: &quot;+ channelName +&quot;] Uploaded file is empty or missing.&quot;;
+    errorMessage = &quot;Uploaded file is empty or missing.&quot;;
     // Set the HTTP response status to 400 (Bad Request)
     setErrorResponse(400, errorMessage);
     throw errorMessage;
@@ -748,7 +748,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1771216551260</time>
+        <time>1771236660677</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -759,14 +759,14 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>888e826f-fb47-4911-9019-dec88a141724</id>
-        <name>0_9_6</name>
+        <id>58240bf1-ac3a-47fb-bb23-148e2b9bd749</id>
+        <name>0_9_7</name>
         <channelIds>
           <string>2c91216f-12dc-434d-ad65-2c4a96d64746</string>
         </channelIds>
         <backgroundColor>
           <red>255</red>
-          <green>0</green>
+          <green>255</green>
           <blue>0</blue>
           <alpha>255</alpha>
         </backgroundColor>

--- a/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundleValidate.xml
+++ b/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundleValidate.xml
@@ -2,9 +2,9 @@
   <id>e16273f4-2ea3-459a-b792-dea1fab43c99</id>
   <nextMetaDataId>2</nextMetaDataId>
   <name>FlatFileCsvBundleValidate</name>
-  <description>Version: 0.8.2
-Correct the error message of missing headers.</description>
-  <revision>3</revision>
+  <description>Version: 0.8.3
+Correct the blank response of incorrect file is selected.</description>
+  <revision>7</revision>
   <sourceConnector version="4.6.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -158,6 +158,33 @@ var rawData = connectorMessage.getRawData();
 if (!rawData || rawData.trim().length === 0) {
     errorMessage = &quot;No file provided in the request.&quot;;
     setErrorResponse(400, errorMessage); // Set the HTTP response status to 400 (Bad Request)
+    throw errorMessage;
+}
+
+
+//Check the file type, only .xml and .txt allowed
+var filename = null;
+var filenameMatch = rawData.match(/filename=&quot;([^&quot;]+)&quot;/); // Use regex to extract the filename from the Content-Disposition line
+
+if (filenameMatch &amp;&amp; filenameMatch.length &gt; 1) {
+    filename = filenameMatch[1];
+    logger.info(&quot;Filename: &quot; + filename);
+    channelMap.put(&apos;filename&apos;, filename);
+
+    //var extensionMatch = filename.match(/\.([0-9a-z]+)(?=[?#])?/i);
+    var extensionMatch = filename.match(/\.([0-9a-z]+)$/i);
+    var extension = extensionMatch ? extensionMatch[1].toLowerCase().trim() : null;
+    logger.info(&quot;File extension: &quot; + extension);
+
+    if (extension !== &quot;zip&quot;) {
+       var errorMessage = &quot;Unsupported file extension: &quot; + extension + &quot;. Only zip files are allowed.&quot;;
+       setErrorResponse(400, errorMessage); // Set the HTTP response status to 400 (Bad Request)
+    	  throw errorMessage; // Stop further processing by throwing an exception
+    }
+} else {
+    logger.warn(&quot;Filename not found in message content.&quot;);
+    errorMessage = &quot;Uploaded file is empty or missing.&quot;;
+    setErrorResponse(400, errorMessage);
     throw errorMessage;
 }
 
@@ -564,7 +591,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1771216292128</time>
+        <time>1771243644224</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -575,13 +602,13 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>989bb0ca-99be-40f9-a116-a6da9257c181</id>
-        <name>0_8_2</name>
+        <id>7b392d39-c6af-4558-86f3-a98f5238e670</id>
+        <name>0_8_3</name>
         <channelIds>
           <string>e16273f4-2ea3-459a-b792-dea1fab43c99</string>
         </channelIds>
         <backgroundColor>
-          <red>128</red>
+          <red>255</red>
           <green>0</green>
           <blue>0</blue>
           <alpha>255</alpha>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -31,14 +31,14 @@
     {
       "type": "FLAT FILE",
       "channel": "FlatFileCsvBundle.xml",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "editedby": "abhiramisanthosh90",
       "date": "2026-02-16"
     },
     {
       "type": "FLAT FILE",
       "channel": "FlatFileCsvBundleValidate.xml",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "editedby": "abhiramisanthosh90",
       "date": "2026-02-16"
     },


### PR DESCRIPTION
Fixed blank response is coming while invalid file is selected in csv validate.
Corrected error message while invalid tenant id in csv bundle.