### PR TITLE
feat: add ETH security label to Bundle meta for 42 CFR Part 2 submissions #2571

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/converters/BundleConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/BundleConverter.java
@@ -6,12 +6,14 @@ import java.util.UUID;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.techbd.csv.model.DemographicData;
+import org.techbd.csv.model.QeAdminData;
 import org.techbd.csv.util.CsvConversionUtil;
 import org.techbd.corelib.util.CoreFHIRUtil;
 
@@ -33,7 +35,7 @@ public class BundleConverter {
      * @return a Bundle with type set to COLLECTION, one empty entry, and Meta
      *         information.
      */
-    public Bundle generateEmptyBundle(String interactionId, DemographicData demographicData, String baseFHIRUrl) {
+    public Bundle generateEmptyBundle(String interactionId, DemographicData demographicData, String baseFHIRUrl, QeAdminData qeAdminData) {
         Bundle bundle = new Bundle();
         bundle.setId(CsvConversionUtil.sha256(UUID.randomUUID().toString()));
         bundle.setType(Bundle.BundleType.TRANSACTION);
@@ -44,6 +46,14 @@ public class BundleConverter {
                     new CanonicalType(CoreFHIRUtil.getProfileUrl(baseFHIRUrl, ResourceType.Bundle.name().toLowerCase()))));
         } else {
             meta.setProfile(List.of(new CanonicalType(CoreFHIRUtil.getBundleProfileUrl())));
+        }
+        if ("Yes".equalsIgnoreCase(qeAdminData.getVisitPart2Flag())) {
+            Coding ethCoding = new Coding();
+            ethCoding.setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode");
+            ethCoding.setCode("ETH");
+            ethCoding.setDisplay("Substance abuse information sensitivity");
+
+            meta.addSecurity(ethCoding);
         }
         bundle.setMeta(meta);
         LOG.info("Empty FHIR Bundle template generated with Meta and one empty entry for interactionId : {}.",

--- a/csv-service/src/main/java/org/techbd/csv/converters/CsvToFhirConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/CsvToFhirConverter.java
@@ -35,7 +35,7 @@ public class CsvToFhirConverter {
         Bundle bundle = null;
         try {
             LOG.info("CsvToFhirConvereter::convert - BEGIN for interactionId :{}", interactionId);
-            bundle = bundleConverter.generateEmptyBundle(interactionId, demographicData, baseFHIRUrl);
+            bundle = bundleConverter.generateEmptyBundle(interactionId, demographicData, baseFHIRUrl, qeAdminData);
             LOG.debug("CsvToFhirConvereter::convert - Bundle entry created :{}", interactionId);
             LOG.debug("Conversion of resources - BEGIN for interactionId :{}", interactionId);
             addEntries(bundle, demographicData, screeningDataList, qeAdminData, screeningProfileData, interactionId,baseFHIRUrl);

--- a/csv-service/src/main/java/org/techbd/csv/model/QeAdminData.java
+++ b/csv-service/src/main/java/org/techbd/csv/model/QeAdminData.java
@@ -57,6 +57,9 @@ public class QeAdminData {
     @CsvBindByName(column = "FACILITY_LAST_UPDATED")
     private String facilityLastUpdated;
 
+    @CsvBindByName(column = "VISIT_PART_2_FLAG")
+    private String visitPart2Flag;
+
     // Default constructor
     public QeAdminData() {
     }

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/BundleConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/BundleConverter.java
@@ -6,12 +6,14 @@ import java.util.UUID;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.techbd.model.csv.DemographicData;
+import org.techbd.model.csv.QeAdminData;
 import org.techbd.util.csv.CsvConversionUtil;
 import org.techbd.util.fhir.CoreFHIRUtil;
 
@@ -33,7 +35,7 @@ public class BundleConverter {
      * @return a Bundle with type set to COLLECTION, one empty entry, and Meta
      *         information.
      */
-    public Bundle generateEmptyBundle(String interactionId, DemographicData demographicData, String baseFHIRUrl) {
+    public Bundle generateEmptyBundle(String interactionId, DemographicData demographicData, String baseFHIRUrl, QeAdminData qeAdminData) {
         Bundle bundle = new Bundle();
         bundle.setId(CsvConversionUtil.sha256(UUID.randomUUID().toString()));
         bundle.setType(Bundle.BundleType.TRANSACTION);
@@ -44,6 +46,14 @@ public class BundleConverter {
                     new CanonicalType(CoreFHIRUtil.getProfileUrl(baseFHIRUrl, ResourceType.Bundle.name().toLowerCase()))));
         } else {
             meta.setProfile(List.of(new CanonicalType(CoreFHIRUtil.getBundleProfileUrl())));
+        }
+        if ("Yes".equalsIgnoreCase(qeAdminData.getVisitPart2Flag())) {
+            Coding ethCoding = new Coding();
+            ethCoding.setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode");
+            ethCoding.setCode("ETH");
+            ethCoding.setDisplay("Substance abuse information sensitivity");
+
+            meta.addSecurity(ethCoding);
         }
         bundle.setMeta(meta);
         LOG.info("Empty FHIR Bundle template generated with Meta and one empty entry for interactionId : {}.",

--- a/nexus-core-lib/src/main/java/org/techbd/converters/csv/CsvToFhirConverter.java
+++ b/nexus-core-lib/src/main/java/org/techbd/converters/csv/CsvToFhirConverter.java
@@ -35,7 +35,7 @@ public class CsvToFhirConverter {
         Bundle bundle = null;
         try {
             LOG.info("CsvToFhirConvereter::convert - BEGIN for interactionId :{}", interactionId);
-            bundle = bundleConverter.generateEmptyBundle(interactionId, demographicData, baseFHIRUrl);
+            bundle = bundleConverter.generateEmptyBundle(interactionId, demographicData, baseFHIRUrl, qeAdminData);
             LOG.debug("CsvToFhirConvereter::convert - Bundle entry created :{}", interactionId);
             LOG.debug("Conversion of resources - BEGIN for interactionId :{}", interactionId);
             addEntries(bundle, demographicData, screeningDataList, qeAdminData, screeningProfileData, interactionId,baseFHIRUrl);

--- a/nexus-core-lib/src/main/java/org/techbd/model/csv/QeAdminData.java
+++ b/nexus-core-lib/src/main/java/org/techbd/model/csv/QeAdminData.java
@@ -57,6 +57,9 @@ public class QeAdminData {
     @CsvBindByName(column = "FACILITY_LAST_UPDATED")
     private String facilityLastUpdated;
 
+    @CsvBindByName(column = "VISIT_PART_2_FLAG")
+    private String visitPart2Flag;
+
     // Default constructor
     public QeAdminData() {
     }


### PR DESCRIPTION
- Updated BundleConverter to add meta.security when visitPart2Flag is "Yes"
- Added v3-ActCode ETH (Substance abuse information sensitivity)
- Ensures SHIN-NY / NY eC compliance for Part 2 organization submissions
- Applied changes in nexus-core-lib and csv-service