### PR TITLE
fix: destroy Python process after validation to prevent memory leak #2725

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/service/engine/CsvOrchestrationEngine.java
+++ b/csv-service/src/main/java/org/techbd/csv/service/engine/CsvOrchestrationEngine.java
@@ -924,6 +924,9 @@ public class CsvOrchestrationEngine {
         public String validateCsvUsingPython(final List<FileDetail> fileDetails, final String zipFileInteractionId)
                 throws Exception {
             log.info("CsvService : validateCsvUsingPython BEGIN for zipFileInteractionId :{} " + zipFileInteractionId);
+
+            Process process = null; // ← CHANGE: Declare outside try block
+
             try {
                 final var config = appConfig.getCsv().validation();
                 if (config == null) {
@@ -961,7 +964,7 @@ public class CsvOrchestrationEngine {
                 processBuilder.command(command);
                 processBuilder.redirectErrorStream(true);
 
-                final Process process = processBuilder.start();
+                process = processBuilder.start();
 
                 // Capture and handle output/error streams
                 final StringBuilder output = new StringBuilder();
@@ -984,6 +987,10 @@ public class CsvOrchestrationEngine {
                 }
 
                 final int exitCode = process.waitFor();
+
+                // Force destroy process immediately after waitFor
+                process.destroyForcibly();
+
                 if (exitCode != 0) {
                     log.error("Python script execution failed. Exit code: {}, Error: {} for zipFileInteractionId : {}",
                             exitCode, errorOutput.toString(), zipFileInteractionId);
@@ -995,8 +1002,21 @@ public class CsvOrchestrationEngine {
                 return output.toString();
 
             } catch (IOException | InterruptedException e) {
-                log.error("Error during CSV validation: {} for zipFileInteractionId : {}", e.getMessage(), zipFileInteractionId, e);
-                throw new RuntimeException("Error during CSV validation : "+e.getMessage(), e);
+                log.error("Error during CSV validation: {} for zipFileInteractionId : {}", e.getMessage(),
+                        zipFileInteractionId, e);
+                throw new RuntimeException("Error during CSV validation : " + e.getMessage(), e);
+            } finally {
+                // Cleanup block to force-kill process if still alive
+                if (process != null && process.isAlive()) {
+                    log.warn("Python process still alive, forcing destruction for zipFileInteractionId: {}",
+                            zipFileInteractionId);
+                    process.destroyForcibly();
+                    try {
+                        process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
             }
         }
 

--- a/nexus-core-lib/src/main/java/org/techbd/service/csv/engine/CsvOrchestrationEngine.java
+++ b/nexus-core-lib/src/main/java/org/techbd/service/csv/engine/CsvOrchestrationEngine.java
@@ -923,6 +923,9 @@ public class CsvOrchestrationEngine {
         public String validateCsvUsingPython(final List<FileDetail> fileDetails, final String zipFileInteractionId)
                 throws Exception {
             log.info("CsvService : validateCsvUsingPython BEGIN for zipFileInteractionId :{} " + zipFileInteractionId);
+
+            Process process = null; // ← CHANGE: Declare outside try block
+
             try {
                 final var config = coreAppConfig.getCsv().validation();
                 if (config == null) {
@@ -960,7 +963,7 @@ public class CsvOrchestrationEngine {
                 processBuilder.command(command);
                 processBuilder.redirectErrorStream(true);
 
-                final Process process = processBuilder.start();
+                process = processBuilder.start();
 
                 // Capture and handle output/error streams
                 final StringBuilder output = new StringBuilder();
@@ -983,19 +986,37 @@ public class CsvOrchestrationEngine {
                 }
 
                 final int exitCode = process.waitFor();
+
+                //Force destroy process immediately after waitFor
+                process.destroyForcibly();
+
                 if (exitCode != 0) {
                     log.error("Python script execution failed. Exit code: {}, Error: {} for zipFileInteractionId : {}",
                             exitCode, errorOutput.toString(), zipFileInteractionId);
                     throw new IOException("Python script execution failed with exit code " +
                             exitCode + ": " + errorOutput.toString());
                 }
-                log.info("CsvService : validateCsvUsingPython END for zipFileInteractionId :{} " + zipFileInteractionId);
+                log.info(
+                        "CsvService : validateCsvUsingPython END for zipFileInteractionId :{} " + zipFileInteractionId);
                 // Return parsed validation results
                 return output.toString();
 
             } catch (IOException | InterruptedException e) {
-                log.error("Error during CSV validation: {} for zipFileInteractionId : {}", e.getMessage(), zipFileInteractionId, e);
-                throw new RuntimeException("Error during CSV validation : "+e.getMessage(), e);
+                log.error("Error during CSV validation: {} for zipFileInteractionId : {}", e.getMessage(),
+                        zipFileInteractionId, e);
+                throw new RuntimeException("Error during CSV validation : " + e.getMessage(), e);
+            } finally {
+                // Cleanup block to force-kill process if still alive
+                if (process != null && process.isAlive()) {
+                    log.warn("Python process still alive, forcing destruction for zipFileInteractionId: {}",
+                            zipFileInteractionId);
+                    process.destroyForcibly();
+                    try {
+                        process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- Add finally block to force-kill process if still alive on exceptions