### PR TITLE
fix: fix propagation of X-TechBD-DataLake-API-URL in CSV to FHIR validation flow #2055

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/controller/CsvController.java
+++ b/csv-service/src/main/java/org/techbd/csv/controller/CsvController.java
@@ -108,7 +108,7 @@ public class CsvController {
     validateTenantId(tenantId);
     // FHIRUtil.validateBaseFHIRProfileUrl(appConfig.getIgPackages(), baseFHIRURL); //TODO CHECK IF VALID IG PACKAGE
     Map <String,Object> requestDetailsMap = CoreFHIRUtil.extractRequestDetails(request);
-    Map<String, Object> headerParameters = CoreFHIRUtil.buildHeaderParametersMap(tenantId, null,
+    Map<String, Object> headerParameters = CoreFHIRUtil.buildHeaderParametersMap(tenantId, customDataLakeApi,
         null,
         null, validationSeverityLevel, null, null,
         null,null);    
@@ -121,6 +121,7 @@ public class CsvController {
       requestDetailsMap.put(Constants.VALIDATION_SEVERITY_LEVEL, validationSeverityLevel);
     }
     headerParameters.put(Constants.BASE_FHIR_URL, baseFHIRURL);
+    requestDetailsMap.put(Constants.DATALAKE_API_URL, customDataLakeApi);
     requestDetailsMap.putAll(headerParameters);
     Map<String, Object> responseParameters = new HashMap<>();
     List<Object> processedFiles = csvService.processZipFile(file, requestDetailsMap, responseParameters);

--- a/csv-service/src/main/java/org/techbd/csv/service/FhirValidationServiceClient.java
+++ b/csv-service/src/main/java/org/techbd/csv/service/FhirValidationServiceClient.java
@@ -140,7 +140,7 @@ public class FhirValidationServiceClient {
         getStringParam(params, "overrideRequestUri").ifPresent(builder::overrideRequestUri);
         getStringParam(params, "provenance").ifPresent(builder::provenance);
         getStringParam(params, "healthCheck").ifPresent(builder::healthCheck);
-        getStringParam(params, "customDataLakeApi").ifPresent(builder::customDataLakeApi);
+        getStringParam(params, "X-TechBD-DataLake-API-URL").ifPresent(builder::customDataLakeApi);
         getStringParam(params, "dataLakeApiContentType").ifPresent(builder::dataLakeApiContentType);
         getStringParam(params, "mtlsStrategy").ifPresent(builder::mtlsStrategy);
         getStringParam(params, "elaboration").ifPresent(builder::elaboration);

--- a/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/CsvController.java
+++ b/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/CsvController.java
@@ -122,6 +122,7 @@ public class CsvController {
       requestDetailsMap.put(Constants.VALIDATION_SEVERITY_LEVEL, validationSeverityLevel);
     }
     headerParameters.put(Constants.BASE_FHIR_URL, baseFHIRURL);
+    requestDetailsMap.put(Constants.DATALAKE_API_URL, customDataLakeApi);
     requestDetailsMap.putAll(headerParameters);
     Map<String, Object> responseParameters = new HashMap<>();
     List<Object> processedFiles = csvService.processZipFile(file, requestDetailsMap, responseParameters);

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1020.0</revision>
+        <revision>0.1021.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- ### Root Cause
- The CSV service was not correctly mapping the DataLake API URL header when calling the FHIR validation channel due to a                 header name mismatch.  
- As a result, the value was being set as `null`, and the FHIR channel was falling back to the default configured DataLake API URL.

### Fix
- Updated parameter mapping logic to correctly extract `x-techbd-datalake-api-url` from the nested headers map.
- Ensured the builder receives the correct DataLake API URL instead of `null`. #2055