### PR TITLE
fix: align FhirValidationServiceClient timeout with CSV channel, update MC_JDBC_URL usage in FHIR bundle submission channel, set bundle submission URL to localhost in Lookup Manager, bump version to 0.1022.0 #2380

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/service/FhirValidationServiceClient.java
+++ b/csv-service/src/main/java/org/techbd/csv/service/FhirValidationServiceClient.java
@@ -60,7 +60,7 @@ public class FhirValidationServiceClient {
     public FhirValidationServiceClient(
             @Value("${TECHBD_BL_BASEURL}") String baseUrl,
             @Value("${FHIR_CLIENT_MAX_BUFFER_SIZE:10485760}") int maxBufferSize,
-            @Value("${FHIR_CLIENT_CONNECT_TIMEOUT_MS:5000}") int connectTimeoutMs,
+            @Value("${FHIR_CLIENT_CONNECT_TIMEOUT_MS:30000}") int connectTimeoutMs,
             @Value("${FHIR_CLIENT_READ_TIMEOUT_SECONDS:60}") int readTimeoutSeconds,
             @Value("${FHIR_CLIENT_WRITE_TIMEOUT_SECONDS:60}") int writeTimeoutSeconds,
             @Value("${FHIR_CLIENT_BLOCK_TIMEOUT_SECONDS:90}") int blockTimeoutSeconds) {

--- a/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundlleSubmission.xml
+++ b/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundlleSubmission.xml
@@ -2,14 +2,35 @@
   <id>78fd5c66-613e-46dd-bd45-c3dd0021a5fb</id>
   <nextMetaDataId>4</nextMetaDataId>
   <name>FhirBundlleSubmission</name>
-  <description>Version: 0.8.9
-increase request time out to 30000</description>
-  <revision>6</revision>
+  <description>Version: 0.8.10
+channel map usage fix for mc jdbc url</description>
+  <revision>4</revision>
   <sourceConnector version="4.6.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.6.1">
       <pluginProperties>
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
+  <sslEnabled>false</sslEnabled>
+          <mutualTlsEnabled>false</mutualTlsEnabled>
+          <verifyHostname>false</verifyHostname>
+          <keystorePath/>
+          <keystorePassword/>
+          <certAlias/>
+          <certPassword/>
+          <truststorePath/>
+          <truststorePassword/>
+          <tls13>true</tls13>
+          <tls12>true</tls12>
+          <tls11>true</tls11>
+          <keystoreType/>
+          <truststoreType/>
+          <keystoreSettingFromSystem>false</keystoreSettingFromSystem>
+          <keystoreUid/>
+          <myCertificateAlias/>
+          <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
+          <truststoreUid/>
+        </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.6.1">
   <authType>NONE</authType>
         </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
@@ -190,7 +211,7 @@ try {
         throw &quot; MC_JDBC_URL retrieved from Lookup Manager is empty.&quot;;
     }
     jdbcUrl = jdbcUrl.trim(); // IMPORTANT: remove trailing spaces
-    channelMap.put(&quot;jdbcUrl&quot;, jdbcUrl);
+     globalMap.put(&quot;jdbcUrl&quot;, jdbcUrl);
      
      logger.info(&quot;JDBC URL loaded successfully from Lookup Manager: &quot; + jdbcUrl);
 
@@ -499,7 +520,29 @@ responseMap.put(&apos;status&apos;, &apos;200&apos;); // Set HTTP status 200
       <metaDataId>1</metaDataId>
       <name>dest_bundle</name>
       <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="4.6.1">
-        <pluginProperties/>
+        <pluginProperties>
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
+  <sslEnabled>false</sslEnabled>
+            <mutualTlsEnabled>false</mutualTlsEnabled>
+            <verifyHostname>false</verifyHostname>
+            <keystorePath/>
+            <keystorePassword/>
+            <certAlias/>
+            <certPassword/>
+            <truststorePath/>
+            <truststorePassword/>
+            <tls13>true</tls13>
+            <tls12>true</tls12>
+            <tls11>true</tls11>
+            <keystoreType/>
+            <truststoreType/>
+            <keystoreSettingFromSystem>false</keystoreSettingFromSystem>
+            <keystoreUid/>
+            <myCertificateAlias/>
+            <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
+            <truststoreUid/>
+          </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        </pluginProperties>
         <destinationConnectorProperties version="4.6.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
@@ -706,7 +749,29 @@ responseMap.put(&apos;status&apos;, &apos;200&apos;); // Set HTTP status 200
       <metaDataId>3</metaDataId>
       <name>dest_datalake</name>
       <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="4.6.1">
-        <pluginProperties/>
+        <pluginProperties>
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
+  <sslEnabled>false</sslEnabled>
+            <mutualTlsEnabled>false</mutualTlsEnabled>
+            <verifyHostname>false</verifyHostname>
+            <keystorePath/>
+            <keystorePassword/>
+            <certAlias/>
+            <certPassword/>
+            <truststorePath/>
+            <truststorePassword/>
+            <tls13>true</tls13>
+            <tls12>true</tls12>
+            <tls11>true</tls11>
+            <keystoreType/>
+            <truststoreType/>
+            <keystoreSettingFromSystem>false</keystoreSettingFromSystem>
+            <keystoreUid/>
+            <myCertificateAlias/>
+            <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
+            <truststoreUid/>
+          </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        </pluginProperties>
         <destinationConnectorProperties version="4.6.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
@@ -2099,25 +2164,25 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1770889735520</time>
+        <time>1771401791715</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
         <archiveEnabled>true</archiveEnabled>
         <pruneErroredMessages>false</pruneErroredMessages>
       </pruningSettings>
-      <userId>1</userId>
+      <userId>10</userId>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>e8ac8112-03cb-4910-9227-a080b4fd581c</id>
-        <name>0_8_9</name>
+        <id>0bf67a4f-277c-4977-b4bc-f9ec6ab1468c</id>
+        <name>0_8_10</name>
         <channelIds>
           <string>78fd5c66-613e-46dd-bd45-c3dd0021a5fb</string>
         </channelIds>
         <backgroundColor>
           <red>255</red>
-          <green>0</green>
+          <green>255</green>
           <blue>0</blue>
           <alpha>255</alpha>
         </backgroundColor>

--- a/integration-artifacts/lookup-manager/nexus/lookup_group_config_export.json
+++ b/integration-artifacts/lookup-manager/nexus/lookup_group_config_export.json
@@ -20,7 +20,7 @@
     "HL7_XSLT_PATH" : "/opt/bridgelink/hl7-techbd-schema-files",
     "HUB_UI_URL" : "https://hub.sandbox.dev.techbd.org",
     "MC_CCDA_SCHEMA_FOLDER" : "/opt/bridgelink/ccda-techbd-schema-files/",
-    "MC_FHIR_BUNDLE_SUBMISSION_API_URL" : "https://1.nexus-txd.sbx.techbd.org:9000/Bundle",
+    "MC_FHIR_BUNDLE_SUBMISSION_API_URL" : "http://localhost:9000/Bundle",
     "MC_VALID_FHIR_URLS" : "http://shinny.org/us/ny/hrsn,http://test.shinny.org/us/ny/hrsn",
     "PROFILE_URL_BUNDLE" : "/StructureDefinition/SHINNYBundleProfile",
     "PROFILE_URL_CONSENT" : "/StructureDefinition/shinny-Consent",
@@ -38,5 +38,5 @@
     "TECHBD_CSV_SERVICE_API_URL" : "https://nexus.csv.sandbox.techbd.org",
     "TECHBD_DEFAULT_DATALAKE_API_URL" : "https://uzrlhp39e0.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle"
   },
-  "exportDate" : "2026-02-10T12:51:54.352+00:00"
+  "exportDate" : "2026-02-18T08:13:27.535+00:00"
 }

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -3,9 +3,9 @@
     {
       "type": "FHIR",
       "channel": "FhirBundlleSubmission.xml",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "editedby": "jewelbonnie",
-      "date": "2026-02-12"
+      "date": "2026-02-18"
     },
     {
       "type": "FHIR",
@@ -68,14 +68,14 @@
       "channel": "lookup_group_schemafiles_export.json",
       "version": "",
       "editedby": "jewelbonnie",
-      "date": "2026-02-17"
+      "date": "2026-02-18"
     },
     {
       "type": "Lookup Manager",
       "channel": "lookup_group_config_export.json",
       "version": "",
       "editedby": "jewelbonnie",
-      "date": "2026-02-10"
+      "date": "2026-02-18"
     },
     {
       "type": "Lookup Manager",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1021.0</revision>
+        <revision>0.1022.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
This PR includes the following updates:

- Updated FhirValidationServiceClient timeout to 30000ms to align with CSV channel processing.

- Updated MC_JDBC_URL channel map usage in the FHIR bundle submission channel.

- Updated MC_FHIR_BUNDLE_SUBMISSION_API_URL to localhost in Lookup Manager configuration.

- Bumped application version to 0.1022.0.