### PR TITLE
fix: add Patient MRN parameter mapping in CCDA channel, bump version to 0.1024.0 #2380

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-channel-files/nexus-sandbox/TechBD CCD Workflow.xml
+++ b/integration-artifacts/ccda/ccda-techbd-channel-files/nexus-sandbox/TechBD CCD Workflow.xml
@@ -1,10 +1,10 @@
 <channel version="4.6.1">
-  <id>0a09378a-5189-44b7-9ce2-009029f3865d</id>
+  <id>e634b038-8196-4ac4-80fc-819a0a9c9bb1</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version 0.5.15
-Revert the changes in bad gateway occur for CCDA.</description>
-  <revision>8</revision>
+  <description>Version 0.5.16
+Added Patient MRN as a transformer parameter by mapping it from the channel map.</description>
+  <revision>12</revision>
   <sourceConnector version="4.6.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -1829,6 +1829,8 @@ function setResourceIdParameters(transformer) {
                               .*::section.(@ID != &apos;sexualOrientation&apos;)
                               .*::entry;
 	transformer = generateSHA256Id(Questionnaire, &quot;Questionnaire&quot;, &quot;questionnaireResourceId&quot;, transformer);
+	transformer.setParameter(&apos;patient-MRN&apos;, channelMap.get(&apos;Patient-MRN&apos;));
+
 	
 	// Extract `observations`
 	try {
@@ -3550,7 +3552,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1770870276083</time>
+        <time>1771414613426</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -3561,13 +3563,13 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>c3d4a03d-caef-4d7b-aa16-f7fc7021f5d2</id>
-        <name>0_5_15</name>
+        <id>2bdb1455-4236-4a6d-a582-6b19c9f2ceaf</id>
+        <name>0_5_16</name>
         <channelIds>
-          <string>0a09378a-5189-44b7-9ce2-009029f3865d</string>
+          <string>e634b038-8196-4ac4-80fc-819a0a9c9bb1</string>
         </channelIds>
         <backgroundColor>
-          <red>128</red>
+          <red>255</red>
           <green>0</green>
           <blue>0</blue>
           <alpha>255</alpha>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -94,9 +94,9 @@
     {
       "type": "CCDA",
       "channel": "TechBD CCD Workflow.xml",
-      "version": "0.5.15",
-      "editedby": "abhiramisanthosh90",
-      "date": "2026-02-12"
+      "version": "0.5.16",
+      "editedby": "jewelbonnie",
+      "date": "2026-02-18"
     }
   ],
   "transformations": {

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1023.0</revision>
+        <revision>0.1024.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- This PR includes Patient MRN parameter mapping in the CCDA channel and a version bump to 0.1024.0.
