### PR TITLE
fix: update mirth connect channel file to resolve the issue with saving input CCDA XML file #2756

### DIFF
--- a/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
+++ b/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
@@ -2,8 +2,8 @@
   <id>0cefb37a-ca0a-48cc-85a1-aa0b727d26a2</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version: 0.4.40</description>
-  <revision>25</revision>
+  <description>Version: 0.4.41</description>
+  <revision>36</revision>
   <sourceConnector version="4.5.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -441,8 +441,11 @@ function extractClinicalDocumentFromRawXML(rawXml) {
 
     try {
         // Normalize input
-        rawXml = String(rawXml).replace(/^\uFEFF/, &apos;&apos;).trim();  //Remove BOM and leading/trailing whitespace
-
+        rawXml = String(rawXml)
+				    .replace(/^\uFEFF/, &apos;&apos;)      // real BOM
+				    .replace(/^ï»¿/, &apos;&apos;)        // mis-decoded BOM
+				    .trim();
+		
         var xmlDeclaration = &apos;&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;\n&apos;;
         var hasXmlDeclaration = rawXml.indexOf(&apos;&lt;?xml&apos;) !== -1;
 
@@ -456,6 +459,7 @@ function extractClinicalDocumentFromRawXML(rawXml) {
 
         end += &apos;&lt;/ClinicalDocument&gt;&apos;.length;
         var extractedXml = rawXml.substring(start, end);
+        extractedXml = extractedXml.trim();  //Trim extra spaces
 
         // Add XML declaration if missing
         if (!hasXmlDeclaration) {
@@ -470,19 +474,57 @@ function extractClinicalDocumentFromRawXML(rawXml) {
     }
 }
 
+function extractBoundaries(rawCcdaXml) {
+	try {
+		// Remove boundary
+		var rawXml = String(rawCcdaXml)
+				    .replace(/^\uFEFF/, &apos;&apos;)      // real BOM
+				    .replace(/^ï»¿/, &apos;&apos;)        // mis-decoded BOM
+				    .trim();		
+		if (rawXml.indexOf(&quot;Content-Disposition:&quot;) !== -1) {
+	        // Extract everything after first blank line
+	        var match = rawXml.match(/\r?\n\r?\n([\s\S]*)/);
+	        if (match &amp;&amp; match[1]) {
+			    rawXml = match[1];
+		   }
+		   
+	        // Remove trailing boundary (last line starting with --)
+	        rawXml = rawXml.replace(/\r?\n--.*--\r?\n?$/, &apos;&apos;);
+	        rawXml = rawXml.replace(/\r?\n--.*$/, &apos;&apos;);
+	    }
+	    rawXml = String(rawXml)
+				    .replace(/^\uFEFF/, &apos;&apos;)      // real BOM
+				    .replace(/^ï»¿/, &apos;&apos;)        // mis-decoded BOM
+				    .trim();
+
+	    return rawXml;
+	} catch (e) {
+        logger.error(&quot;extractBoundaries failed: &quot; + e.message);
+        return null;
+    }
+}
+
 function extractClinicalDocument(rawXml) {
 	try {
+		var rawCcdaXml = rawXml;
+		var extractedXml = extractClinicalDocumentFromRawXML(rawXml);
+		
+		if (!extractedXml || extractedXml.trim().length == 0 || extractedXml.trim() == &apos;&apos;) {
+			rawCcdaXml = extractBoundaries(rawXml);
+		} else {
+			rawCcdaXml = extractedXml;
+		}
+	    logger.info(&quot;Original file content: &quot; + rawCcdaXml);
+
 		// Save Original Payload
 	     saveCcdaPayload(
 	        interactionId,
 	        tenantId,
 	        requestedPath,
-	        rawXml,
+	        rawCcdaXml,
 	        &quot;saveOgCCDAPayload&quot;
-	     );     
-
-	     var extractedXml = extractClinicalDocumentFromRawXML(rawXml);
-
+	     ); 
+		
 		if (!extractedXml || extractedXml.trim().length == 0 || extractedXml.trim() == &apos;&apos;) {
 		    var errorMsg = &quot;Could not find ClinicalDocument boundaries in XML.&quot;;
 		    var errorResponse = getJsonInvalidOperationOutcome(errorMsg, &quot;invalid&quot;);
@@ -499,8 +541,8 @@ function extractClinicalDocument(rawXml) {
 		    return;
 		}
 		
-		channelMap.put(&apos;fileContent&apos;, extractedXml);		
-	    	return extractedXml;
+		channelMap.put(&apos;fileContent&apos;, extractedXml);
+		return extractedXml;
 		    
 	} catch (e) {
         logger.error(&quot;extractClinicalDocument failed: &quot; + e.message);
@@ -1642,7 +1684,6 @@ function validateMandatoryFields() {
 	        var name = patient ? patient.*::name[0] : null;
 	        var givenName = name ? name.*::given.toString() : &quot;&quot;;
 	        var familyName = name ? name.*::family.toString() : &quot;&quot;;
-	        //if (!givenName &amp;&amp; !familyName) { errors.push(&quot;Patient name (given or family) -&gt; ClinicalDocument.recordTarget.patientRole.patient.name.given or family.&quot;); }
 	        if (!givenName) { errors.push(&quot;Patient name (given) -&gt; ClinicalDocument.recordTarget.patientRole.patient.name.given.&quot;); }
 		   if (!familyName) { errors.push(&quot;Patient name (family) -&gt; ClinicalDocument.recordTarget.patientRole.patient.name.family.&quot;); }
 
@@ -1667,20 +1708,8 @@ function validateMandatoryFields() {
 			        &quot;Patient gender -&gt; ClinicalDocument.recordTarget.patientRole.patient.administrativeGenderCode.&quot;
 			    );
 		   }	        
-			/*var genderCode = &quot;&quot;;
-			if (patient) {
-			    var genderEl = patient.*::administrativeGenderCode[0];
-			    if (genderEl &amp;&amp; genderEl.@code) {
-			        genderCode = genderEl.@code.toString();
-			    }
-			}			
-			if (genderCode === &quot;&quot;) {
-			    errors.push(&quot;Patient gender -&gt; ClinicalDocument.recordTarget.patientRole.patient.administrativeGenderCode.&quot;);
-			}*/
-
+			
 	        // 4. Birth Date
-	        //var birthDate = patient ? patient.*::birthTime[0].@value.toString() : &quot;&quot;;
-	        //if (!birthDate) { errors.push(&quot;Patient birthDate is mandatory as per FHIR.&quot;); }
 	        var birthDate = &quot;&quot;;
 		   if (patient) {
 			    var birthEl = patient.*::birthTime[0];
@@ -1702,7 +1731,6 @@ function validateMandatoryFields() {
     	} catch (e) {
 	    logger.error(&quot;Error accessing patientRole: &quot; + e);
 	}
- 	
 
 	// --------------------------------------------------------------------------------------------------------------------
     	// III. Organization (Location / Author Organization)
@@ -2503,7 +2531,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1770296272035</time>
+        <time>1771414229146</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.2 -->
+<!-- Version : 0.1.7 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -18,7 +18,6 @@
   <xsl:param name="encounterType"/>
   <xsl:param name="facilityID"/>
   <xsl:variable name="patientRoleId" select="//ccda:patientRole/ccda:id[not(@assigningAuthorityName)]/@extension"/>
-  <!-- <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/> -->
   <xsl:variable name="given_trimmed">
       <xsl:call-template name="string-trim">
         <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1]"/>
@@ -131,8 +130,6 @@
       select="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:statusCode/@code" />
 
   <!-- Encounter status from the normal encounters section -->
-  <!-- <xsl:variable name="normalEncounterStatus"
-      select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter[1]/ccda:statusCode/@code"/> -->
   <xsl:variable name="normalEncounterStatus">
     <xsl:choose>
       <!-- Case 1: statusCode exists -->
@@ -182,7 +179,6 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-    <!-- <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/> -->
   <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
 
 
@@ -291,69 +287,9 @@
                       </xsl:choose>"
         </xsl:if>
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": [
-                <xsl:for-each select="ccda:addr[not(@nullFlavor)]">
-                    {
-                        <xsl:if test="@use">
-                            "use": "<xsl:choose>
-                                <xsl:when test="@use='HP' or @use='H'">home</xsl:when>
-                                <xsl:when test="@use='WP'">work</xsl:when>
-                                <xsl:when test="@use='TMP'">temp</xsl:when>
-                                <xsl:when test="@use='OLD' or @use='BAD'">old</xsl:when>
-                                <!-- <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise> -->
-                                <xsl:otherwise>home</xsl:otherwise>
-                            </xsl:choose>"
-                        </xsl:if>
-                        <xsl:variable name="formattedAddress">
-                            <xsl:call-template name="format-address">
-                                <xsl:with-param name="addr" select="../ccda:addr"/>
-                            </xsl:call-template>
-                        </xsl:variable>
-
-                        <xsl:if test="normalize-space($formattedAddress) != ''">
-                            , "text": "<xsl:value-of select="$formattedAddress"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            , "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:city)">
-                            , "city": "<xsl:value-of select="normalize-space(ccda:city)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:county)">
-                            , "district": "<xsl:value-of select="normalize-space(ccda:county)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:state)">
-                            , "state": "<xsl:value-of select="normalize-space(ccda:state)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:postalCode)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:country)">
-                            , "country": "<xsl:value-of select="normalize-space(ccda:country)"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    } <xsl:if test="position() != last()">,</xsl:if>
-                </xsl:for-each>
-            ]
+            <xsl:call-template name="build-address-array">
+              <xsl:with-param name="addresses" select="ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>
         </xsl:if>
         <xsl:if test="ccda:telecom[not(@nullFlavor)]">
             , "telecom": [
@@ -554,23 +490,6 @@
                                           ])[1]/@extension"/>
 
       <!-- MRN (Athena rule): @extension from first ID tag under Patient Role, take the value that appears immediately after "P-" which is not in the SSN format -->       
-      <!-- <xsl:variable name="mrnId"
-        select="substring-after((ccda:id[
-            not(
-                string-length(substring-after(@extension,'P-')) = 11 and
-                substring(substring-after(@extension,'P-'),4,1) = '-' and
-                substring(substring-after(@extension,'P-'),7,1) = '-' and
-                translate(
-                    concat(
-                        substring(substring-after(@extension,'P-'),1,3),
-                        substring(substring-after(@extension,'P-'),5,2),
-                        substring(substring-after(@extension,'P-'),8,4)
-                    ),
-                    '0123456789',
-                    ''
-                ) = ''
-            )
-        ])[1]/@extension,'P-')" /> -->
       <xsl:variable name="mrnId" select="$patient-MRN"/>
 
       <!-- Only output "identifier" array if any variable has value -->
@@ -784,7 +703,6 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>" -->
                     "display": "<xsl:call-template name="string-trim">
                                   <xsl:with-param name="text" select="$locationDisplayRaw"/>
                                 </xsl:call-template>"
@@ -902,10 +820,8 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <!-- <xsl:when test="$organizationNPI"> -->
               <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
@@ -922,12 +838,10 @@
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
               </xsl:if>
-              <!-- </xsl:when> -->
               
               <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <!-- <xsl:when test="$organizationTIN"> -->
               <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
@@ -944,14 +858,8 @@
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
               </xsl:if>
-              <!-- </xsl:when> -->
-            <!-- </xsl:choose> -->
           ],
         </xsl:if>
-        <!-- "name" : "<xsl:choose>
-                    <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-                    <xsl:otherwise><xsl:value-of select="normalize-space(ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/></xsl:otherwise>
-                  </xsl:choose>" -->
         <xsl:variable name="orgNameRaw">
           <xsl:choose>
             <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
@@ -998,68 +906,9 @@
             ]
         </xsl:if>
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]">
-            , "address": [
-                <xsl:for-each select="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]">
-                    {
-                        <xsl:if test="string(@use)">
-                            "use": "<xsl:choose>
-                                <xsl:when test="@use='HP' or @use='H'">home</xsl:when>
-                                <xsl:when test="@use='WP'">work</xsl:when>
-                                <xsl:when test="@use='TMP'">temp</xsl:when>
-                                <xsl:when test="@use='OLD' or @use='BAD'">old</xsl:when>
-                                <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
-                            </xsl:choose>"
-                        </xsl:if>
-                        <xsl:variable name="formattedAddress">
-                            <xsl:call-template name="format-address">
-                                <xsl:with-param name="addr" select="../ccda:addr"/>
-                            </xsl:call-template>
-                        </xsl:variable>
-
-                        <xsl:if test="normalize-space($formattedAddress) != ''">
-                            , "text": "<xsl:value-of select="$formattedAddress"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine">
-                            , "line": [
-                                <xsl:for-each select="ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:city)">
-                            , "city": "<xsl:value-of select="normalize-space(ccda:city)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:county)">
-                            , "district": "<xsl:value-of select="normalize-space(ccda:county)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:state)">
-                            , "state": "<xsl:value-of select="normalize-space(ccda:state)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:postalCode)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:country)">
-                            , "country": "<xsl:value-of select="normalize-space(ccda:country)"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    } <xsl:if test="position() != last()">,</xsl:if>
-                </xsl:for-each>
-            ]
+            <xsl:call-template name="build-address-array">
+              <xsl:with-param name="addresses" select="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>
         </xsl:if>
       },
       "request" : {
@@ -1215,16 +1064,6 @@
 
         <xsl:if test="string($categoryCode)">
 
-          <!-- <xsl:variable name="resourceUUID">
-            <xsl:choose>
-              <xsl:when test="normalize-space(ccda:id/@extension)">
-                <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="normalize-space(ccda:id/@root)"/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:variable> -->
           <xsl:variable name="encounterEffectiveTime">
               <xsl:choose>
                   <xsl:when test="ccda:effectiveTime/@value">
@@ -1247,7 +1086,6 @@
             <xsl:choose>
               <!-- Use extension if present and not empty -->
               <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
-                <!-- <xsl:value-of select="ccda:id/@extension"/> -->
                 <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
               </xsl:when>
 
@@ -1261,10 +1099,7 @@
 
           <xsl:variable name="observationResourceId">
             <xsl:call-template name="generateFixedLengthResourceId">
-              <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-              <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
               <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-              <!-- <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/> -->
               <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
             </xsl:call-template>
           </xsl:variable>
@@ -1417,16 +1252,6 @@
                   <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                     "derivedFrom": [
                       <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                        <!-- <xsl:variable name="resourceUUID">
-                          <xsl:choose>
-                            <xsl:when test="normalize-space(ccda:id/@extension)">
-                              <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                              <xsl:value-of select="normalize-space(ccda:id/@root)"/>
-                            </xsl:otherwise>
-                          </xsl:choose>
-                        </xsl:variable> -->
                         <xsl:variable name="encounterEffectiveTimeDF">
                             <xsl:choose>
                                 <xsl:when test="ccda:effectiveTime/@value">
@@ -1450,7 +1275,6 @@
                           <xsl:choose>
                             <!-- Use extension if present and not empty -->
                             <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
-                              <!-- <xsl:value-of select="ccda:id/@extension"/> -->
                               <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
                             </xsl:when>
 
@@ -1503,23 +1327,6 @@
                   "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                 }
               </xsl:if>
-
-              <!-- effectiveDateTime block -->
-              <!-- <xsl:if test="ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
-                , "effectiveDateTime": "<xsl:choose>
-                                          <xsl:when test="ccda:effectiveTime/@value">
-                                              <xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:effectiveTime/@value"/>
-                                              </xsl:call-template>
-                                          </xsl:when>
-                                          <xsl:when test="$encounterEffectiveTimeValue">
-                                              <xsl:value-of select="$encounterEffectiveTimeValue"/>
-                                          </xsl:when>
-                                          <xsl:otherwise>
-                                              <xsl:value-of select="$currentTimestamp"/>
-                                          </xsl:otherwise>
-                                        </xsl:choose>"
-              </xsl:if> -->
               , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
 
               <xsl:if test="string($organizationResourceId)">
@@ -2069,10 +1876,8 @@
     <xsl:variable name="grouperObs" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation"/>
     <xsl:variable name="grouperScreening" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation[1]"/>
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
-
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
-            <!-- <xsl:with-param name="prefixString" select="$grouperScreeningCode"/>-->
             <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
             <xsl:with-param name="sha256ResourceId" select="$grouperObservationResourceSha256Id"/>
           </xsl:call-template>
@@ -2191,17 +1996,6 @@
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
                 <xsl:variable name="questionCode" select="ccda:code/@code"/>
 
-                <!-- <xsl:variable name="resourceUUID">
-                  <xsl:choose>
-                    <xsl:when test="normalize-space(ccda:id/@extension)">
-                      <xsl:value-of select="normalize-space(ccda:id/@extension)"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:value-of select="normalize-space(ccda:id/@root)"/>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </xsl:variable> -->
-
                 <xsl:variable name="encounterEffectiveTime">
                     <xsl:choose>
                         <xsl:when test="ccda:effectiveTime/@value">
@@ -2224,7 +2018,6 @@
                   <xsl:choose>
                     <!-- Use extension if present and not empty -->
                     <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
-                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
                       <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
                     </xsl:when>
 
@@ -2239,7 +2032,6 @@
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                    <!-- <xsl:with-param name="sha256ResourceId" select="$resourceUUID"/> -->
                     <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
                   </xsl:call-template>
                 </xsl:variable>
@@ -2268,72 +2060,15 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:name)">
-          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:name)"/>" -->
           ,"name": "<xsl:call-template name="string-trim">
                     <xsl:with-param name="text" select="ccda:name"/>
                   </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": 
-                    {
-                        <xsl:if test="string(ccda:addr/@use)">
-                            "use": "<xsl:choose>
-                                <xsl:when test="ccda:addr/@use='HP' or ccda:addr/@use='H'">home</xsl:when>
-                                <xsl:when test="ccda:addr/@use='WP'">work</xsl:when>
-                                <xsl:when test="ccda:addr/@use='TMP'">temp</xsl:when>
-                                <xsl:when test="ccda:addr/@use='OLD' or ccda:addr/@use='BAD'">old</xsl:when>
-                                <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
-                            </xsl:choose>"
-                        </xsl:if>
-                        <xsl:variable name="formattedAddress">
-                            <xsl:call-template name="format-address">
-                                <xsl:with-param name="addr" select="ccda:addr"/>
-                            </xsl:call-template>
-                        </xsl:variable>
-
-                        <xsl:if test="normalize-space($formattedAddress) != ''">
-                            , "text": "<xsl:value-of select="$formattedAddress"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            , "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:city)">
-                            , "city": "<xsl:value-of select="normalize-space(ccda:addr/ccda:city)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:county)">
-                            , "district": "<xsl:value-of select="normalize-space(ccda:addr/ccda:county)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:state)">
-                            , "state": "<xsl:value-of select="normalize-space(ccda:addr/ccda:state)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:addr/ccda:postalCode)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:country)">
-                            , "country": "<xsl:value-of select="normalize-space(ccda:addr/ccda:country)"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    } 
+            <xsl:call-template name="build-address-object-only">
+              <xsl:with-param name="addresses" select="ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>
         </xsl:if>
       },
       "request" : {
@@ -2357,72 +2092,15 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:playingEntity/ccda:name)">
-          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>" -->
           ,"name": "<xsl:call-template name="string-trim">
                     <xsl:with-param name="text" select="ccda:playingEntity/ccda:name"/>
                   </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": 
-                    {
-                        <xsl:if test="string(ccda:addr/@use)">
-                            "use": "<xsl:choose>
-                                <xsl:when test="ccda:addr/@use='HP' or ccda:addr/@use='H'">home</xsl:when>
-                                <xsl:when test="ccda:addr/@use='WP'">work</xsl:when>
-                                <xsl:when test="ccda:addr/@use='TMP'">temp</xsl:when>
-                                <xsl:when test="ccda:addr/@use='OLD' or ccda:addr/@use='BAD'">old</xsl:when>
-                                <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
-                            </xsl:choose>"
-                        </xsl:if>
-                        <xsl:variable name="formattedAddress">
-                            <xsl:call-template name="format-address">
-                                <xsl:with-param name="addr" select="ccda:addr"/>
-                            </xsl:call-template>
-                        </xsl:variable>
-
-                        <xsl:if test="normalize-space($formattedAddress) != ''">
-                            , "text": "<xsl:value-of select="$formattedAddress"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine">
-                            , "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine">
-                                    "<xsl:value-of select="."/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:city)">
-                            , "city": "<xsl:value-of select="normalize-space(ccda:addr/ccda:city)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:county)">
-                            , "district": "<xsl:value-of select="normalize-space(ccda:addr/ccda:county)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:state)">
-                            , "state": "<xsl:value-of select="normalize-space(ccda:addr/ccda:state)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:addr/ccda:postalCode)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:country)">
-                            , "country": "<xsl:value-of select="normalize-space(ccda:addr/ccda:country)"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    } 
+            <xsl:call-template name="build-address-object-only">
+              <xsl:with-param name="addresses" select="ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template> 
         </xsl:if>
       },
       "request" : {
@@ -2587,4 +2265,186 @@
 
     </xsl:choose>
   </xsl:template>
+
+  <!-- Render address array if there are any addresses without nullFlavor -->
+  <xsl:template name="build-address-object">
+    <xsl:param name="addr"/>
+    {
+      <!-- Pre-calculate trimmed values -->
+      <xsl:variable name="street">
+        <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+          <xsl:variable name="line">
+            <xsl:call-template name="string-trim">
+              <xsl:with-param name="text" select="."/>
+            </xsl:call-template>
+          </xsl:variable>
+
+          <xsl:if test="string($line)">
+            <xsl:value-of select="$line"/>
+            <xsl:if test="position()!=last()">, </xsl:if>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:variable name="city">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="district">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:county"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="state">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="zip">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="country">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:country"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <!-- Build the final string -->
+      <xsl:variable name="formattedAddress">
+          <xsl:if test="string-length($street) &gt; 0">
+              <xsl:value-of select="$street"/>
+          </xsl:if>
+
+          <xsl:if test="$city != ''">
+              <xsl:if test="$street != ''">, </xsl:if>
+              <xsl:value-of select="$city"/>
+          </xsl:if>
+
+          <xsl:if test="$state != ''">
+              <xsl:if test="$city != '' or $street != ''">, </xsl:if>
+              <xsl:value-of select="$state"/>
+          </xsl:if>
+
+          <xsl:if test="$zip != ''">
+              <xsl:text> </xsl:text>
+              <xsl:value-of select="$zip"/>
+          </xsl:if>
+      </xsl:variable>
+
+      <!-- use -->
+      <xsl:if test="$addr/@use">
+        "use": "<xsl:choose>
+          <xsl:when test="$addr/@use='HP' or $addr/@use='H'">home</xsl:when>
+          <xsl:when test="$addr/@use='WP'">work</xsl:when>
+          <xsl:when test="$addr/@use='TMP'">temp</xsl:when>
+          <xsl:when test="$addr/@use='OLD' or $addr/@use='BAD'">old</xsl:when>
+          <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise>
+        </xsl:choose>"
+        <xsl:if test="string($formattedAddress) or $addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- text -->
+      <xsl:if test="string($formattedAddress)">
+        "text": "<xsl:value-of select="$formattedAddress"/>"
+        <xsl:if test="$addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- line -->
+      <xsl:if test="$addr/ccda:streetAddressLine[not(@nullFlavor)]">
+        "line": [
+          <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor)]">
+            "<xsl:call-template name="string-trim">
+                <xsl:with-param name="text" select="."/>
+              </xsl:call-template>"
+            <xsl:if test="position()!=last()">,</xsl:if>
+          </xsl:for-each>
+        ]
+        <xsl:if test="string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- city -->
+      <xsl:if test="string($city)">
+        "city": "<xsl:value-of select="$city"/>"
+        <xsl:if test="string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- district -->
+      <xsl:if test="string($district)">
+        "district": "<xsl:value-of select="$district"/>"
+        <xsl:if test="string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- state -->
+      <xsl:if test="string($state)">
+        "state": "<xsl:value-of select="$state"/>"
+        <xsl:if test="string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- postalCode -->
+      <xsl:if test="string($zip)">
+        "postalCode": "<xsl:value-of select="$zip"/>"
+        <xsl:if test="string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- country -->
+      <xsl:if test="string($country)">
+        "country": "<xsl:value-of select="$country"/>"
+      </xsl:if>
+
+      <!-- period -->
+      <xsl:variable name="periodLow" select="$addr/ccda:useablePeriod/ccda:low/@value"/>
+      <xsl:variable name="periodHigh" select="$addr/ccda:useablePeriod/ccda:high/@value"/>
+
+      <xsl:if test="string($periodLow) or string($periodHigh)">
+        , "period": {
+          <xsl:if test="string($periodLow)">
+            "start": "<xsl:call-template name="formatDateTime">
+                        <xsl:with-param name="dateTime" select="$periodLow"/>
+                      </xsl:call-template>"
+            <xsl:if test="string($periodHigh)">,</xsl:if>
+          </xsl:if>
+
+          <xsl:if test="string($periodHigh)">
+            "end": "<xsl:call-template name="formatDateTime">
+                      <xsl:with-param name="dateTime" select="$periodHigh"/>
+                    </xsl:call-template>"
+          </xsl:if>
+        }
+      </xsl:if>
+    }
+  </xsl:template>
+
+  <!-- Gives an array of address objects if there are any addresses without nullFlavor, used for Patient Address and Organization Address. -->
+  <xsl:template name="build-address-array">
+    <xsl:param name="addresses"/>
+    <xsl:if test="$addresses[not(@nullFlavor)]">
+      , "address": [
+        <xsl:for-each select="$addresses[not(@nullFlavor)]">
+          <xsl:call-template name="build-address-object">
+            <xsl:with-param name="addr" select="."/>
+          </xsl:call-template>
+          <xsl:if test="position() != last()">,</xsl:if>
+        </xsl:for-each>
+      ]
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Gives an address object if there are any addresses without nullFlavor, used for Location address. -->
+  <xsl:template name="build-address-object-only">
+    <xsl:param name="addresses"/>
+    <xsl:if test="$addresses[not(@nullFlavor)]">
+      , "address":        
+          <xsl:call-template name="build-address-object">
+            <xsl:with-param name="addr" select="$addresses[not(@nullFlavor)][1]"/>
+          </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.2 -->
+<!-- Version : 0.1.8 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -18,7 +18,6 @@
   <xsl:param name="encounterType"/>
   <xsl:param name="facilityID"/>
   <xsl:variable name="patientRoleId" select="//ccda:patientRole/ccda:id[not(@assigningAuthorityName)]/@extension"/>
-  <!-- <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/> -->
   <xsl:variable name="given_trimmed">
       <xsl:call-template name="string-trim">
         <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1]"/>
@@ -156,7 +155,6 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <!-- <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name)"/> -->
   <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
 
   <xsl:template match="/">
@@ -264,7 +262,11 @@
                       </xsl:choose>"
         </xsl:if>
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": [
+            <xsl:call-template name="build-address-array">
+              <xsl:with-param name="addresses" select="ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>
+
+            <!-- , "address": [
                 <xsl:for-each select="ccda:addr[not(@nullFlavor)]">
                     {
                         <xsl:if test="@use">
@@ -325,7 +327,7 @@
                         </xsl:if>
                     } <xsl:if test="position() != last()">,</xsl:if>
                 </xsl:for-each>
-            ]
+            ] -->
         </xsl:if>
         <xsl:if test="ccda:telecom[not(@nullFlavor)]">
             , "telecom": [
@@ -740,7 +742,6 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:location/ccda:healthCareFacility/ccda:location/ccda:name)"/>" -->
                     "display": "<xsl:call-template name="string-trim">
                                   <xsl:with-param name="text" select="$locationDisplayRaw"/>
                                 </xsl:call-template>"
@@ -867,7 +868,6 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>" -->
                     "display": "<xsl:call-template name="string-trim">
                                   <xsl:with-param name="text" select="$locationDisplayRaw"/>
                                 </xsl:call-template>"
@@ -986,10 +986,8 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <!-- <xsl:when test="$organizationNPI"> -->
               <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
@@ -1006,12 +1004,10 @@
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
               </xsl:if>
-              <!-- </xsl:when> -->
               
               <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <!-- <xsl:when test="$organizationTIN"> -->
               <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
@@ -1028,14 +1024,8 @@
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
               </xsl:if>
-              <!-- </xsl:when> -->
-            <!-- </xsl:choose> -->
           ],
         </xsl:if>
-        <!-- "name" : "<xsl:choose>
-                    <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-                    <xsl:otherwise><xsl:value-of select="normalize-space(ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/></xsl:otherwise>
-                  </xsl:choose>" -->
         <xsl:variable name="orgNameRaw">
           <xsl:choose>
             <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
@@ -1082,7 +1072,11 @@
             ]
         </xsl:if>
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]">
-            , "address": [
+            <xsl:call-template name="build-address-array">
+              <xsl:with-param name="addresses" select="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>
+
+            <!-- , "address": [
                 <xsl:for-each select="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]">
                     {
                         <xsl:if test="string(@use)">
@@ -1146,7 +1140,7 @@
                         </xsl:if>
                     } <xsl:if test="position() != last()">,</xsl:if>
                 </xsl:for-each>
-            ]
+            ] -->
         </xsl:if>
       },
       "request" : {
@@ -1323,7 +1317,6 @@
                 <xsl:choose>
                   <!-- Use extension if present and not empty -->
                   <xsl:when test="ccda:observation/ccda:id/@extension and normalize-space(ccda:observation/ccda:id/@extension) != ''">
-                    <!-- <xsl:value-of select="ccda:observation/ccda:id/@extension"/> -->
                     <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
                   </xsl:when>
 
@@ -1337,10 +1330,7 @@
 
               <xsl:variable name="observationResourceId">
                 <xsl:call-template name="generateFixedLengthResourceId">
-                  <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-                  <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
                   <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                  <!-- <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/> -->
                   <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
                 </xsl:call-template>
               </xsl:variable>
@@ -1493,13 +1483,7 @@
                         <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                           "derivedFrom": [
                             <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                              <!-- <xsl:variable name="observationResourceId">
-                                <xsl:call-template name="generateFixedLengthResourceId">
-                                  <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                                  <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
-                                </xsl:call-template>
-                              </xsl:variable> -->
-
+ 
                               <xsl:variable name="encounterEffectiveTimeDF">
                                   <xsl:choose>
                                       <xsl:when test="ccda:effectiveTime/@value">
@@ -1523,7 +1507,6 @@
                                 <xsl:choose>
                                   <!-- Use extension if present and not empty -->
                                   <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
-                                    <!-- <xsl:value-of select="ccda:id/@extension"/> -->
                                     <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
                                   </xsl:when>
 
@@ -1574,21 +1557,6 @@
                       "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                     }
                   </xsl:if>
-                  <!-- <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
-                    , "effectiveDateTime": "<xsl:choose>
-                                              <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
-                                                  <xsl:call-template name="formatDateTime">
-                                                      <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
-                                                  </xsl:call-template>
-                                              </xsl:when>
-                                              <xsl:when test="$encounterEffectiveTimeValue">
-                                                  <xsl:value-of select="$encounterEffectiveTimeValue"/>
-                                              </xsl:when>
-                                              <xsl:otherwise>
-                                                  <xsl:value-of select="$currentTimestamp"/>
-                                              </xsl:otherwise>
-                                          </xsl:choose>"
-                  </xsl:if> -->
                   , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
                   <xsl:if test="string($organizationResourceId)">
                   , "performer": [{
@@ -2137,7 +2105,6 @@
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
-            <!-- <xsl:with-param name="prefixString" select="$grouperScreeningCode"/>-->
             <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
             <xsl:with-param name="sha256ResourceId" select="$grouperObservationResourceSha256Id"/>
           </xsl:call-template>
@@ -2255,12 +2222,6 @@
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
                 <xsl:variable name="questionCode" select="ccda:code/@code"/>
-                <!-- <xsl:variable name="observationResourceId">
-                  <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
-                  </xsl:call-template>
-                </xsl:variable> -->
 
                 <xsl:variable name="encounterEffectiveTime">
                     <xsl:choose>
@@ -2284,7 +2245,6 @@
                   <xsl:choose>
                     <!-- Use extension if present and not empty -->
                     <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
-                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
                       <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
                     </xsl:when>
 
@@ -2328,14 +2288,17 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:name)">
-          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:name)"/>" -->
           ,"name": "<xsl:call-template name="string-trim">
                     <xsl:with-param name="text" select="ccda:name"/>
                   </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": 
+            <xsl:call-template name="build-address-object-only">
+              <xsl:with-param name="addresses" select="ccda:addr"/>
+            </xsl:call-template>
+
+            <!-- , "address": 
                     {
                         <xsl:if test="string(ccda:addr/@use)">
                             "use": "<xsl:choose>
@@ -2393,7 +2356,7 @@
                                 </xsl:if>
                             }
                         </xsl:if>
-                    } 
+                    }  -->
         </xsl:if>
       },
       "request" : {
@@ -2417,14 +2380,17 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:playingEntity/ccda:name)">
-          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>" -->
           ,"name": "<xsl:call-template name="string-trim">
                     <xsl:with-param name="text" select="ccda:playingEntity/ccda:name"/>
                   </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": 
+            <xsl:call-template name="build-address-object-only">
+              <xsl:with-param name="addresses" select="ccda:addr"/>
+            </xsl:call-template>
+
+            <!-- , "address": 
                     {
                         <xsl:if test="string(ccda:addr/@use)">
                             "use": "<xsl:choose>
@@ -2482,7 +2448,7 @@
                                 </xsl:if>
                             }
                         </xsl:if>
-                    } 
+                    }  -->
         </xsl:if>
       },
       "request" : {
@@ -2519,34 +2485,54 @@
   </xsl:template>
 
   <!-- Template to format an address -->
-  <xsl:template name="format-address">
+  <!-- <xsl:template name="format-address">
       <xsl:param name="addr"/>
-
-      <!-- Extract components -->
+      
       <xsl:variable name="street">
-          <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-              <xsl:value-of select="normalize-space(.)"/>
-              <xsl:if test="position() != last()">, </xsl:if>
-          </xsl:for-each>
+        <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+          <xsl:variable name="line">
+            <xsl:call-template name="string-trim">
+              <xsl:with-param name="text" select="."/>
+            </xsl:call-template>
+          </xsl:variable>
+
+          <xsl:if test="string($line)">
+            <xsl:value-of select="$line"/>
+            <xsl:if test="position()!=last()">, </xsl:if>
+          </xsl:if>
+        </xsl:for-each>
       </xsl:variable>
 
-      <xsl:variable name="city"  select="normalize-space($addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''])"/>
-      <xsl:variable name="state" select="normalize-space($addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''])"/>
-      <xsl:variable name="zip"   select="normalize-space($addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != ''])"/>
+      <xsl:variable name="city">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
 
-      <!-- Build the final string -->
+      <xsl:variable name="state">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="zip">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
       <xsl:variable name="fullAddress">
-          <xsl:if test="string-length(normalize-space($street)) &gt; 0">
+          <xsl:if test="string-length($street) &gt; 0">
               <xsl:value-of select="$street"/>
           </xsl:if>
 
           <xsl:if test="$city != ''">
-              <xsl:if test="normalize-space($street) != ''">, </xsl:if>
+              <xsl:if test="$street != ''">, </xsl:if>
               <xsl:value-of select="$city"/>
           </xsl:if>
 
           <xsl:if test="$state != ''">
-              <xsl:if test="$city != '' or normalize-space($street) != ''">, </xsl:if>
+              <xsl:if test="$city != '' or $street != ''">, </xsl:if>
               <xsl:value-of select="$state"/>
           </xsl:if>
 
@@ -2556,9 +2542,8 @@
           </xsl:if>
       </xsl:variable>
 
-      <!-- Output trimmed -->
-      <xsl:value-of select="normalize-space($fullAddress)"/>
-  </xsl:template>
+      <xsl:value-of select="$fullAddress"/>
+  </xsl:template> -->
 
   <!-- ========================== -->
   <!-- "Function" to trim leading and trailing spaces -->  
@@ -2647,4 +2632,186 @@
 
     </xsl:choose>
   </xsl:template>
+
+  <!-- Render address array if there are any addresses without nullFlavor -->
+  <xsl:template name="build-address-object">
+    <xsl:param name="addr"/>
+    {
+      <!-- Pre-calculate trimmed values -->
+      <xsl:variable name="street">
+        <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+          <xsl:variable name="line">
+            <xsl:call-template name="string-trim">
+              <xsl:with-param name="text" select="."/>
+            </xsl:call-template>
+          </xsl:variable>
+
+          <xsl:if test="string($line)">
+            <xsl:value-of select="$line"/>
+            <xsl:if test="position()!=last()">, </xsl:if>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:variable name="city">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="district">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:county"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="state">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="zip">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="country">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:country"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <!-- Build the final string -->
+      <xsl:variable name="formattedAddress">
+          <xsl:if test="string-length($street) &gt; 0">
+              <xsl:value-of select="$street"/>
+          </xsl:if>
+
+          <xsl:if test="$city != ''">
+              <xsl:if test="$street != ''">, </xsl:if>
+              <xsl:value-of select="$city"/>
+          </xsl:if>
+
+          <xsl:if test="$state != ''">
+              <xsl:if test="$city != '' or $street != ''">, </xsl:if>
+              <xsl:value-of select="$state"/>
+          </xsl:if>
+
+          <xsl:if test="$zip != ''">
+              <xsl:text> </xsl:text>
+              <xsl:value-of select="$zip"/>
+          </xsl:if>
+      </xsl:variable>
+
+      <!-- use -->
+      <xsl:if test="$addr/@use">
+        "use": "<xsl:choose>
+          <xsl:when test="$addr/@use='HP' or $addr/@use='H'">home</xsl:when>
+          <xsl:when test="$addr/@use='WP'">work</xsl:when>
+          <xsl:when test="$addr/@use='TMP'">temp</xsl:when>
+          <xsl:when test="$addr/@use='OLD' or $addr/@use='BAD'">old</xsl:when>
+          <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise>
+        </xsl:choose>"
+        <xsl:if test="string($formattedAddress) or $addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- text -->
+      <xsl:if test="string($formattedAddress)">
+        "text": "<xsl:value-of select="$formattedAddress"/>"
+        <xsl:if test="$addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- line -->
+      <xsl:if test="$addr/ccda:streetAddressLine[not(@nullFlavor)]">
+        "line": [
+          <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor)]">
+            "<xsl:call-template name="string-trim">
+                <xsl:with-param name="text" select="."/>
+              </xsl:call-template>"
+            <xsl:if test="position()!=last()">,</xsl:if>
+          </xsl:for-each>
+        ]
+        <xsl:if test="string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- city -->
+      <xsl:if test="string($city)">
+        "city": "<xsl:value-of select="$city"/>"
+        <xsl:if test="string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- district -->
+      <xsl:if test="string($district)">
+        "district": "<xsl:value-of select="$district"/>"
+        <xsl:if test="string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- state -->
+      <xsl:if test="string($state)">
+        "state": "<xsl:value-of select="$state"/>"
+        <xsl:if test="string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- postalCode -->
+      <xsl:if test="string($zip)">
+        "postalCode": "<xsl:value-of select="$zip"/>"
+        <xsl:if test="string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- country -->
+      <xsl:if test="string($country)">
+        "country": "<xsl:value-of select="$country"/>"
+      </xsl:if>
+
+      <!-- period -->
+      <xsl:variable name="periodLow" select="$addr/ccda:useablePeriod/ccda:low/@value"/>
+      <xsl:variable name="periodHigh" select="$addr/ccda:useablePeriod/ccda:high/@value"/>
+
+      <xsl:if test="string($periodLow) or string($periodHigh)">
+        , "period": {
+          <xsl:if test="string($periodLow)">
+            "start": "<xsl:call-template name="formatDateTime">
+                        <xsl:with-param name="dateTime" select="$periodLow"/>
+                      </xsl:call-template>"
+            <xsl:if test="string($periodHigh)">,</xsl:if>
+          </xsl:if>
+
+          <xsl:if test="string($periodHigh)">
+            "end": "<xsl:call-template name="formatDateTime">
+                      <xsl:with-param name="dateTime" select="$periodHigh"/>
+                    </xsl:call-template>"
+          </xsl:if>
+        }
+      </xsl:if>
+    }
+  </xsl:template>
+
+  <!-- Gives an array of address objects if there are any addresses without nullFlavor, used for Patient Address and Organization Address. -->
+  <xsl:template name="build-address-array">
+    <xsl:param name="addresses"/>
+    <xsl:if test="$addresses[not(@nullFlavor)]">
+      , "address": [
+        <xsl:for-each select="$addresses[not(@nullFlavor)]">
+          <xsl:call-template name="build-address-object">
+            <xsl:with-param name="addr" select="."/>
+          </xsl:call-template>
+          <xsl:if test="position() != last()">,</xsl:if>
+        </xsl:for-each>
+      ]
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Gives an address object if there are any addresses without nullFlavor, used for Location address. -->
+  <xsl:template name="build-address-object-only">
+    <xsl:param name="addresses"/>
+    <xsl:if test="$addresses[not(@nullFlavor)]">
+      , "address":        
+          <xsl:call-template name="build-address-object">
+            <xsl:with-param name="addr" select="$addresses[not(@nullFlavor)][1]"/>
+          </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.2 -->
+<!-- Version : 0.1.7 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -18,7 +18,6 @@
   <xsl:param name="encounterType"/>
   <xsl:param name="facilityID"/>
   <xsl:variable name="patientRoleId" select="//ccda:patientRole/ccda:id[not(@assigningAuthorityName)]/@extension"/>
-  <!-- <xsl:variable name="patientResourceName" select="concat(//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:family[1], ' ', //ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1])"/> -->
   <xsl:variable name="given_trimmed">
       <xsl:call-template name="string-trim">
         <xsl:with-param name="text" select="//ccda:patientRole/ccda:patient[1]/ccda:name[1]/ccda:given[1]"/>
@@ -146,7 +145,6 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <!-- <xsl:variable name="organizationName" select="normalize-space(/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name)"/> -->
   <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC']/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
 
   <xsl:template match="/">
@@ -253,68 +251,9 @@
                       </xsl:choose>"
         </xsl:if>
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address": [
-                <xsl:for-each select="ccda:addr[not(@nullFlavor)]">
-                    {
-                        <xsl:if test="@use">
-                            "use": "<xsl:choose>
-                                <xsl:when test="@use='HP' or @use='H'">home</xsl:when>
-                                <xsl:when test="@use='WP'">work</xsl:when>
-                                <xsl:when test="@use='TMP'">temp</xsl:when>
-                                <xsl:when test="@use='OLD' or @use='BAD'">old</xsl:when>
-                                <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
-                            </xsl:choose>"
-                        </xsl:if>
-                        <xsl:variable name="formattedAddress">
-                            <xsl:call-template name="format-address">
-                                <xsl:with-param name="addr" select="../ccda:addr"/>
-                            </xsl:call-template>
-                        </xsl:variable>
-
-                        <xsl:if test="normalize-space($formattedAddress) != ''">
-                            , "text": "<xsl:value-of select="$formattedAddress"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                            , "line": [
-                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                                    "<xsl:value-of select="normalize-space(.)"/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:city)">
-                            , "city": "<xsl:value-of select="normalize-space(ccda:city)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:county)">
-                            , "district": "<xsl:value-of select="normalize-space(ccda:county)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:state)">
-                            , "state": "<xsl:value-of select="normalize-space(ccda:state)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:postalCode)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:country)">
-                            , "country": "<xsl:value-of select="normalize-space(ccda:country)"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    } <xsl:if test="position() != last()">,</xsl:if>
-                </xsl:for-each>
-            ]
+            <xsl:call-template name="build-address-array">
+              <xsl:with-param name="addresses" select="ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>
         </xsl:if>
         <xsl:if test="ccda:telecom[not(@nullFlavor)]">
             , "telecom": [
@@ -513,14 +452,6 @@
                                             translate(concat(substring(@extension,1,3), substring(@extension,5,2), substring(@extension,8,4)), '0123456789', '') = ''
                                           ])[1]/@extension"/>
 
-      <!-- MRN: Take first id element that is NOT SSN -->
-      <!-- <xsl:variable name="mrnId" select="(ccda:id[
-                                          not(@root='2.16.840.1.113883.4.1') and
-                                          not(string-length(@extension) = 11 and 
-                                              substring(@extension,4,1) = '-' and 
-                                              substring(@extension,7,1) = '-' and 
-                                              translate(concat(substring(@extension,1,3), substring(@extension,5,2), substring(@extension,8,4)), '0123456789', '') = '')
-                                        ])[1]/@extension"/> -->
       <xsl:variable name="mrnId" select="$patient-MRN"/>
 
       <xsl:if test="$cinId or $ssnId or $mrnId">
@@ -714,7 +645,6 @@
                     <xsl:if test="string($locationResourceId)"> 
                       "reference": "Location/<xsl:value-of select="$locationResourceId"/>",
                     </xsl:if>
-                    <!-- "display": "<xsl:value-of select="normalize-space(ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name)"/>" -->
                     "display": "<xsl:call-template name="string-trim">
                                   <xsl:with-param name="text" select="ccda:participant/ccda:participantRole/ccda:playingEntity/ccda:name"/>
                                 </xsl:call-template>"
@@ -832,10 +762,8 @@
         "active": true,
         <xsl:if test="$organizationNPI or $organizationTIN">
           "identifier": [
-            <!-- <xsl:choose> -->
 
               <!-- NPI -->
-              <!-- <xsl:when test="$organizationNPI"> -->
               <xsl:if test="$organizationNPI">
                 {
                   "use": "official",
@@ -852,12 +780,10 @@
                   "value": "<xsl:value-of select='$organizationNPI'/>"
                 }
               </xsl:if>
-              <!-- </xsl:when> -->
               
               <xsl:if test="$organizationNPI and $organizationTIN">,</xsl:if> <!-- Comma only if both exist -->
 
               <!-- TAX -->
-              <!-- <xsl:when test="$organizationTIN"> -->
               <xsl:if test="$organizationTIN">
                 {
                   "use": "official",
@@ -874,14 +800,9 @@
                   "value": "<xsl:value-of select='$organizationTIN'/>"
                 }
               </xsl:if>
-              <!-- </xsl:when> -->
-            <!-- </xsl:choose> -->
           ],
         </xsl:if>
-        <!-- "name" : "<xsl:choose>
-                    <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-                    <xsl:otherwise><xsl:value-of select="normalize-space(ccda:assignedAuthor/ccda:representedOrganization/ccda:name)"/></xsl:otherwise>
-                  </xsl:choose>" -->
+
         <xsl:variable name="orgNameRaw">
           <xsl:choose>
             <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
@@ -928,68 +849,9 @@
             ]
         </xsl:if>
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]">
-            , "address": [
-                <xsl:for-each select="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]">
-                    {
-                        <xsl:if test="@use">
-                            "use": "<xsl:choose>
-                                <xsl:when test="@use='HP' or @use='H'">home</xsl:when>
-                                <xsl:when test="@use='WP'">work</xsl:when>
-                                <xsl:when test="@use='TMP'">temp</xsl:when>
-                                <xsl:when test="@use='OLD' or @use='BAD'">old</xsl:when>
-                                <xsl:otherwise><xsl:value-of select="@use"/></xsl:otherwise>
-                            </xsl:choose>"
-                        </xsl:if>
-                        <xsl:variable name="formattedAddress">
-                            <xsl:call-template name="format-address">
-                                <xsl:with-param name="addr" select="../ccda:addr"/>
-                            </xsl:call-template>
-                        </xsl:variable>
-
-                        <xsl:if test="normalize-space($formattedAddress) != ''">
-                            , "text": "<xsl:value-of select="$formattedAddress"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                            , "line": [
-                                <xsl:for-each select="ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                                    "<xsl:value-of select="normalize-space(.)"/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:city)">
-                            , "city": "<xsl:value-of select="normalize-space(ccda:city)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:county)">
-                            , "district": "<xsl:value-of select="normalize-space(ccda:county)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:state)">
-                            , "state": "<xsl:value-of select="normalize-space(ccda:state)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:postalCode)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:country)">
-                            , "country": "<xsl:value-of select="normalize-space(ccda:country)"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    } <xsl:if test="position() != last()">,</xsl:if>
-                </xsl:for-each>
-            ]
+            <xsl:call-template name="build-address-array">
+              <xsl:with-param name="addresses" select="ccda:assignedAuthor/ccda:representedOrganization/ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>
         </xsl:if>
       },
       "request" : {
@@ -1150,16 +1012,6 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
-            <!-- <xsl:variable name="observationPrefix">
-                <xsl:choose>                  
-                  <xsl:when test="ccda:observation/ccda:code/@code = '95614-4'"> Total Safety Score
-                    <xsl:value-of select="concat($facilityID, '-', ccda:observation/ccda:value/@value)"/>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:value-of select="concat($facilityID, '-')"/>
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:variable> -->
             <xsl:variable name="encounterEffectiveTime">
                   <xsl:choose>
                       <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
@@ -1182,7 +1034,6 @@
                 <xsl:choose>
                   <!-- Use extension if present and not empty -->
                   <xsl:when test="ccda:observation/ccda:id/@extension and normalize-space(ccda:observation/ccda:id/@extension) != ''">
-                    <!-- <xsl:value-of select="ccda:observation/ccda:id/@extension"/> -->
                     <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
                   </xsl:when>
 
@@ -1196,11 +1047,7 @@
 
             <xsl:variable name="observationResourceId">
               <xsl:call-template name="generateFixedLengthResourceId">
-                <!-- <xsl:with-param name="prefixString" select="$questionCode"/>
-                <xsl:with-param name="sha256ResourceId" select="$observationResourceSha256Id"/> -->
-                <!-- <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/> -->
                 <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                <!-- <xsl:with-param name="sha256ResourceId" select="ccda:observation/ccda:id/@extension"/> -->
                 <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
               </xsl:call-template>
             </xsl:variable>
@@ -1351,12 +1198,6 @@
                           <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                             "derivedFrom": [
                               <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                                <!-- <xsl:variable name="observationResourceId">
-                                  <xsl:call-template name="generateFixedLengthResourceId">
-                                    <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
-                                  </xsl:call-template>
-                                </xsl:variable> -->
                                 <xsl:variable name="encounterEffectiveTimeDF">
                                     <xsl:choose>
                                         <xsl:when test="ccda:effectiveTime/@value">
@@ -1380,7 +1221,6 @@
                                   <xsl:choose>
                                     <!-- Use extension if present and not empty -->
                                     <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
-                                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
                                       <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
                                     </xsl:when>
 
@@ -1430,21 +1270,6 @@
                     "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                   }
                 </xsl:if>
-                <!-- <xsl:if test="ccda:observation/ccda:effectiveTime/@value or $encounterEffectiveTimeValue or $currentTimestamp">
-                  , "effectiveDateTime": "<xsl:choose>
-                                            <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
-                                                <xsl:call-template name="formatDateTime">
-                                                    <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
-                                                </xsl:call-template>
-                                            </xsl:when>
-                                            <xsl:when test="$encounterEffectiveTimeValue">
-                                                <xsl:value-of select="$encounterEffectiveTimeValue"/>
-                                            </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$currentTimestamp"/>
-                                            </xsl:otherwise>
-                                        </xsl:choose>"
-                </xsl:if> -->
                 , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
                 <xsl:if test="string($organizationResourceId)">
                 , "performer": [{
@@ -1989,72 +1814,15 @@
           "profile" : ["<xsl:value-of select='$locationMetaProfileUrl'/>"]
         }
         <xsl:if test="normalize-space(ccda:playingEntity/ccda:name)">
-          <!-- ,"name": "<xsl:value-of select="normalize-space(ccda:playingEntity/ccda:name)"/>" -->
           ,"name": "<xsl:call-template name="string-trim">
                     <xsl:with-param name="text" select="ccda:playingEntity/ccda:name"/>
                   </xsl:call-template>"
         </xsl:if>
 
         <xsl:if test="ccda:addr[not(@nullFlavor)]">
-            , "address":
-                    {
-                        <xsl:if test="string(ccda:addr/@use)">
-                            "use": "<xsl:choose>
-                                <xsl:when test="ccda:addr/@use='HP' or ccda:addr/@use='H'">home</xsl:when>
-                                <xsl:when test="ccda:addr/@use='WP'">work</xsl:when>
-                                <xsl:when test="ccda:addr/@use='TMP'">temp</xsl:when>
-                                <xsl:when test="ccda:addr/@use='OLD' or ccda:addr/@use='BAD'">old</xsl:when>
-                                <xsl:otherwise><xsl:value-of select="ccda:addr/@use"/></xsl:otherwise>
-                            </xsl:choose>"
-                        </xsl:if>
-                        <xsl:variable name="formattedAddress">
-                            <xsl:call-template name="format-address">
-                                <xsl:with-param name="addr" select="ccda:addr"/>
-                            </xsl:call-template>
-                        </xsl:variable>
-
-                        <xsl:if test="normalize-space($formattedAddress) != ''">
-                            , "text": "<xsl:value-of select="$formattedAddress"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                            , "line": [
-                                <xsl:for-each select="ccda:addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-                                    "<xsl:value-of select="normalize-space(.)"/>"
-                                    <xsl:if test="position() != last()">, </xsl:if>
-                                </xsl:for-each>
-                            ]
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:city)">
-                            , "city": "<xsl:value-of select="normalize-space(ccda:addr/ccda:city)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:county)">
-                            , "district": "<xsl:value-of select="normalize-space(ccda:addr/ccda:county)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:state)">
-                            , "state": "<xsl:value-of select="normalize-space(ccda:addr/ccda:state)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:postalCode)">
-                            , "postalCode": "<xsl:value-of select="normalize-space(ccda:addr/ccda:postalCode)"/>"
-                        </xsl:if>
-                        <xsl:if test="normalize-space(ccda:addr/ccda:country)">
-                            , "country": "<xsl:value-of select="normalize-space(ccda:addr/ccda:country)"/>"
-                        </xsl:if>
-                        <xsl:if test="ccda:addr/ccda:useablePeriod">
-                            ,"period": {
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">
-                                    "start": "<xsl:call-template name="formatDateTime">
-                                                  <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:low/@value"/>
-                                              </xsl:call-template>"
-                                </xsl:if>
-                                <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:high/@value)">
-                                    <xsl:if test="string(ccda:addr/ccda:useablePeriod/ccda:low/@value)">, </xsl:if>
-                                    "end": "<xsl:call-template name="formatDateTime">
-                                                <xsl:with-param name="dateTime" select="ccda:addr/ccda:useablePeriod/ccda:high/@value"/>
-                                            </xsl:call-template>"
-                                </xsl:if>
-                            }
-                        </xsl:if>
-                    }
+            <xsl:call-template name="build-address-object-only">
+              <xsl:with-param name="addresses" select="ccda:addr[not(@nullFlavor)]"/>
+            </xsl:call-template>            
         </xsl:if>
       },
       "request" : {
@@ -2111,7 +1879,6 @@
       <xsl:for-each select="$grouperObs[ccda:code/@code = $screeningCode]"> <!--'96777-8'-->       
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
-            <!-- <xsl:with-param name="prefixString" select="concat(generate-id(ccda:code/@code), position())"/>-->
             <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
             <xsl:with-param name="sha256ResourceId" select="$grouperObservationResourceSha256Id"/>
           </xsl:call-template>
@@ -2229,23 +1996,6 @@
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
                 <xsl:variable name="questionCode" select="ccda:code/@code"/>
-                <!-- <xsl:variable name="observationPrefix">
-                  <xsl:choose>                  
-                    <xsl:when test="ccda:code/@code = '95614-4'"> Total Safety Score
-                      <xsl:value-of select="concat($facilityID, '-', ccda:value/@value)"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:value-of select="concat($facilityID, '-')"/>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </xsl:variable> -->
-
-                <!-- <xsl:variable name="observationResourceId">
-                  <xsl:call-template name="generateFixedLengthResourceId">
-                    <xsl:with-param name="prefixString" select="normalize-space($observationPrefix)"/>
-                    <xsl:with-param name="sha256ResourceId" select="ccda:id/@extension"/>
-                  </xsl:call-template>
-                </xsl:variable> -->
                 <xsl:variable name="encounterEffectiveTime">
                     <xsl:choose>
                         <xsl:when test="ccda:effectiveTime/@value">
@@ -2268,7 +2018,6 @@
                   <xsl:choose>
                     <!-- Use extension if present and not empty -->
                     <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
-                      <!-- <xsl:value-of select="ccda:id/@extension"/> -->
                       <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
                     </xsl:when>
 
@@ -2454,4 +2203,186 @@
 
     </xsl:choose>
   </xsl:template>
+
+  <!-- Render address array if there are any addresses without nullFlavor -->
+  <xsl:template name="build-address-object">
+    <xsl:param name="addr"/>
+    {
+      <!-- Pre-calculate trimmed values -->
+      <xsl:variable name="street">
+        <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
+          <xsl:variable name="line">
+            <xsl:call-template name="string-trim">
+              <xsl:with-param name="text" select="."/>
+            </xsl:call-template>
+          </xsl:variable>
+
+          <xsl:if test="string($line)">
+            <xsl:value-of select="$line"/>
+            <xsl:if test="position()!=last()">, </xsl:if>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:variable name="city">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:city[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="district">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:county"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="state">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:state[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="zip">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != '']"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="country">
+        <xsl:call-template name="string-trim">
+          <xsl:with-param name="text" select="$addr/ccda:country"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <!-- Build the final string -->
+      <xsl:variable name="formattedAddress">
+          <xsl:if test="string-length($street) &gt; 0">
+              <xsl:value-of select="$street"/>
+          </xsl:if>
+
+          <xsl:if test="$city != ''">
+              <xsl:if test="$street != ''">, </xsl:if>
+              <xsl:value-of select="$city"/>
+          </xsl:if>
+
+          <xsl:if test="$state != ''">
+              <xsl:if test="$city != '' or $street != ''">, </xsl:if>
+              <xsl:value-of select="$state"/>
+          </xsl:if>
+
+          <xsl:if test="$zip != ''">
+              <xsl:text> </xsl:text>
+              <xsl:value-of select="$zip"/>
+          </xsl:if>
+      </xsl:variable>
+
+      <!-- use -->
+      <xsl:if test="$addr/@use">
+        "use": "<xsl:choose>
+          <xsl:when test="$addr/@use='HP' or $addr/@use='H'">home</xsl:when>
+          <xsl:when test="$addr/@use='WP'">work</xsl:when>
+          <xsl:when test="$addr/@use='TMP'">temp</xsl:when>
+          <xsl:when test="$addr/@use='OLD' or $addr/@use='BAD'">old</xsl:when>
+          <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise>
+        </xsl:choose>"
+        <xsl:if test="string($formattedAddress) or $addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- text -->
+      <xsl:if test="string($formattedAddress)">
+        "text": "<xsl:value-of select="$formattedAddress"/>"
+        <xsl:if test="$addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- line -->
+      <xsl:if test="$addr/ccda:streetAddressLine[not(@nullFlavor)]">
+        "line": [
+          <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor)]">
+            "<xsl:call-template name="string-trim">
+                <xsl:with-param name="text" select="."/>
+              </xsl:call-template>"
+            <xsl:if test="position()!=last()">,</xsl:if>
+          </xsl:for-each>
+        ]
+        <xsl:if test="string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- city -->
+      <xsl:if test="string($city)">
+        "city": "<xsl:value-of select="$city"/>"
+        <xsl:if test="string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- district -->
+      <xsl:if test="string($district)">
+        "district": "<xsl:value-of select="$district"/>"
+        <xsl:if test="string($state) or string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- state -->
+      <xsl:if test="string($state)">
+        "state": "<xsl:value-of select="$state"/>"
+        <xsl:if test="string($zip) or string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- postalCode -->
+      <xsl:if test="string($zip)">
+        "postalCode": "<xsl:value-of select="$zip"/>"
+        <xsl:if test="string($country)">,</xsl:if>
+      </xsl:if>
+
+      <!-- country -->
+      <xsl:if test="string($country)">
+        "country": "<xsl:value-of select="$country"/>"
+      </xsl:if>
+
+      <!-- period -->
+      <xsl:variable name="periodLow" select="$addr/ccda:useablePeriod/ccda:low/@value"/>
+      <xsl:variable name="periodHigh" select="$addr/ccda:useablePeriod/ccda:high/@value"/>
+
+      <xsl:if test="string($periodLow) or string($periodHigh)">
+        , "period": {
+          <xsl:if test="string($periodLow)">
+            "start": "<xsl:call-template name="formatDateTime">
+                        <xsl:with-param name="dateTime" select="$periodLow"/>
+                      </xsl:call-template>"
+            <xsl:if test="string($periodHigh)">,</xsl:if>
+          </xsl:if>
+
+          <xsl:if test="string($periodHigh)">
+            "end": "<xsl:call-template name="formatDateTime">
+                      <xsl:with-param name="dateTime" select="$periodHigh"/>
+                    </xsl:call-template>"
+          </xsl:if>
+        }
+      </xsl:if>
+    }
+  </xsl:template>
+
+  <!-- Gives an array of address objects if there are any addresses without nullFlavor, used for Patient Address and Organization Address. -->
+  <xsl:template name="build-address-array">
+    <xsl:param name="addresses"/>
+    <xsl:if test="$addresses[not(@nullFlavor)]">
+      , "address": [
+        <xsl:for-each select="$addresses[not(@nullFlavor)]">
+          <xsl:call-template name="build-address-object">
+            <xsl:with-param name="addr" select="."/>
+          </xsl:call-template>
+          <xsl:if test="position() != last()">,</xsl:if>
+        </xsl:for-each>
+      ]
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Gives an address object if there are any addresses without nullFlavor, used for Location address. -->
+  <xsl:template name="build-address-object-only">
+    <xsl:param name="addresses"/>
+    <xsl:if test="$addresses[not(@nullFlavor)]">
+      , "address":        
+          <xsl:call-template name="build-address-object">
+            <xsl:with-param name="addr" select="$addresses[not(@nullFlavor)][1]"/>
+          </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
1. Updated mirth connect channel file to resolve the issue with saving input CCDA XML file - remove header and boundary details before saving.
2. Updated XSLT files to remove leading and trailing spaces in address fields (Patient address, Location address and Organization address) instead of using normalize-space function in the XSLT file for CCDA (Epic/Medent/AthenaHealth)