### PR TITLE
fix: update the address use PST in the AthenaHealth CCDA files to remove the FHIR validation error #2756

### DIFF
--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -2355,7 +2355,8 @@
           <xsl:when test="$addr/@use='WP'">work</xsl:when>
           <xsl:when test="$addr/@use='TMP'">temp</xsl:when>
           <xsl:when test="$addr/@use='OLD' or $addr/@use='BAD'">old</xsl:when>
-          <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise>
+          <!-- <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise> -->
+          <xsl:otherwise>home</xsl:otherwise>
         </xsl:choose>"
         <xsl:if test="string($formattedAddress) or $addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
       </xsl:if>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -2722,7 +2722,8 @@
           <xsl:when test="$addr/@use='WP'">work</xsl:when>
           <xsl:when test="$addr/@use='TMP'">temp</xsl:when>
           <xsl:when test="$addr/@use='OLD' or $addr/@use='BAD'">old</xsl:when>
-          <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise>
+          <!-- <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise> -->
+          <xsl:otherwise>home</xsl:otherwise>
         </xsl:choose>"
         <xsl:if test="string($formattedAddress) or $addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
       </xsl:if>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -2293,7 +2293,8 @@
           <xsl:when test="$addr/@use='WP'">work</xsl:when>
           <xsl:when test="$addr/@use='TMP'">temp</xsl:when>
           <xsl:when test="$addr/@use='OLD' or $addr/@use='BAD'">old</xsl:when>
-          <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise>
+          <!-- <xsl:otherwise><xsl:value-of select="$addr/@use"/></xsl:otherwise>. -->
+          <xsl:otherwise>home</xsl:otherwise>
         </xsl:choose>"
         <xsl:if test="string($formattedAddress) or $addr/ccda:streetAddressLine or string($city) or string($district) or string($state) or string($zip) or string($country)">,</xsl:if>
       </xsl:if>


### PR DESCRIPTION
Updated XSLT file to set the address use as 'home' for all the use codes other than H, HP, WP, TMP, OLD and BAD