### PR TITLE
fix: fix ZNT validation to execute only for responseType outbound #2780

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/listener/NettyTcpServer.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/listener/NettyTcpServer.java
@@ -1005,7 +1005,7 @@ public class NettyTcpServer implements MessageSourceProvider {
                     MessageSourceType.MLLP);
 
             // Extract ZNT always if MLLP responseType. If missing, immediately send a NACK.
-            if (detectMllp(portEntryOpt)) {
+            if (detectMllpZNT(portEntryOpt)) {
                 boolean zntPresent = true;
                 if (hl7Message != null) {
                     zntPresent = extractZntSegment(hl7Message, requestContext, interactionId.toString());
@@ -1484,9 +1484,15 @@ public class NettyTcpServer implements MessageSourceProvider {
                         .orElse(false);
     }
 
+     private boolean detectMllpZNT(Optional<PortConfig.PortEntry> portEntryOpt) {
+        return portEntryOpt.isPresent()
+                && Optional.ofNullable(portEntryOpt.get().responseType)
+                        .map(rt -> rt.equalsIgnoreCase("outbound"))
+                        .orElse(false);
+    }
+
     /**
-     * Extract ZNT segment from HL7 message using HAPI parser
-     */
+     * Extract ZNT segment from HL7 message using HAPI parser     */
     private boolean extractZntSegment(Message hapiMsg, RequestContext requestContext, String interactionId) {
         try {
             Terser terser = new Terser(hapiMsg);

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1033.0</revision>
+        <revision>0.1034.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- This PR updates ZNT segment validation logic to ensure it is executed only when responseType = "outbound", and skipped for responseType = "mllp". #2780