### PR TITLE
fix: default ig version in lookup manager (#2380)

### DIFF
--- a/integration-artifacts/lookup-manager/nexus/lookup_group_config_export.json
+++ b/integration-artifacts/lookup-manager/nexus/lookup_group_config_export.json
@@ -13,7 +13,7 @@
     "extra" : null
   },
   "values" : {
-    "BASE_FHIR_URL" : "http://test.shinny.org/us/ny/hrsn",
+    "BASE_FHIR_URL" : "http://shinny.org/us/ny/hrsn",
     "BL_FHIR_BUNDLE_VALIDATION_API_URL" : "https://nexus.fhir.sandbox.techbd.org",
     "DATA_LEDGER_API_URL" : "https://gbp2obo8d0.execute-api.us-east-1.amazonaws.com/development/DataLedger",
     "DATA_LEDGER_TRACKING" : "false",

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -74,8 +74,8 @@
       "type": "Lookup Manager",
       "channel": "lookup_group_config_export.json",
       "version": "",
-      "editedby": "jewelbonnie",
-      "date": "2026-02-18"
+      "editedby": "abhiramisanthosh90",
+      "date": "2026-02-25"
     },
     {
       "type": "Lookup Manager",


### PR DESCRIPTION
Fixed default ig version as shinny in lookup manger