### PR TITLE
feat: add support for a new route /xds/XDSbRepositoryWS #2846

### DIFF
--- a/nexus-ingestion-api/.envrc.example
+++ b/nexus-ingestion-api/.envrc.example
@@ -16,3 +16,4 @@ export UNDERSTOOD_NAMESPACES="http://www.w3.org/2005/08/addressing"
 export PORT_CONFIG_S3_BUCKET=s3-bucket-name
 export PORT_CONFIG_S3_KEY=full-s3-path-of-portConfig.json
 export AWS_REGION=us-east-1
+export ALLOWED_WS_ROUTES="/xds/XDSbRepositoryWS"

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/commons/Constants.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/commons/Constants.java
@@ -48,4 +48,4 @@ public class Constants {
     public static final String HEADER_INTERACTION_ID = "X-Interaction-ID";
     public static final String ERROR_TRACE_ID = "errorTraceId";
     public static final String ACK_CONTENT_TYPE = "ackContentType";
-}
+    public static final String ALLOWED_ROUTES = "allowedRoutes";}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
@@ -109,11 +109,12 @@ public class DataIngestionController extends AbstractMessageSourceProvider {
             HttpServletResponse response) throws Exception {
 
         String interactionId = (String) request.getAttribute(Constants.INTERACTION_ID);
+        Boolean isAllowedRoute = (Boolean) request.getAttribute(Constants.ALLOWED_ROUTES);
         LOG.info("Received ingest request. interactionId={} sourceId={} msgType={}",
                 interactionId, sourceId, msgType);
 
         // Check if this is a SOAP request
-        boolean isSoapReq = isSoapRequest(msgType);
+        boolean isSoapReq = isSoapRequest(msgType) || Boolean.TRUE.equals(isAllowedRoute);
 
         // Validate that request contains data
         if ((file == null || file.isEmpty()) && (body == null || body.isBlank())) {

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
@@ -69,7 +69,7 @@ public class InteractionsFilter extends OncePerRequestFilter {
     private final Cache<String, X509Certificate[]> caCache;
     private final SoapFaultUtil soapFaultUtil;
     private static final Pattern PATH_PATTERN = Pattern.compile("^/(?:ingest/)?([^/]+)/([^/]+)(?:/.*)?$");
-
+    private static final List<String> ALLOWED_ROUTES_LIST = Optional.ofNullable(System.getenv("ALLOWED_ROUTES")).map(r -> Arrays.stream(r.split(",")).map(String::trim).collect(Collectors.toList())).orElse(Collections.emptyList());
     public InteractionsFilter(AppLogger appLogger, PortConfig portConfig, 
                              PortResolverService portResolverService, S3Client s3Client, SoapFaultUtil soapFaultUtil) {
         this.LOG = appLogger.getLogger(InteractionsFilter.class);
@@ -177,8 +177,12 @@ public class InteractionsFilter extends OncePerRequestFilter {
                 PortConfig.PortEntry portEntry = portEntryOpt.get();
                 LOG.info("InteractionsFilter: resolved PortConfig entry for port {} -> sourceId={}, msgType={}, route={}", 
                         requestPort, portEntry.sourceId, portEntry.msgType, portEntry.route);
-
-                // 3) If this port config requires mtls via mtls field, client must supply
+                        String route = portEntry.route;
+                       if (route != null && !route.isBlank() && !ALLOWED_ROUTES_LIST.isEmpty() && !ALLOWED_ROUTES_LIST.contains(route)) {
+                            origRequest.setAttribute(Constants.ALLOWED_ROUTES, true);
+                            LOG.info("InteractionsFilter: route {} is NOT in allowed routes list, setting ALLOWED_ROUTES attribute to true", route);
+                          }
+                    // 3) If this port config requires mtls via mtls field, client must supply
                 // header
                 String mtlsName = portEntry.mtls;
                 String mtlsBucket = System.getenv(Constants.MTLS_BUCKET_NAME);

--- a/nexus-ingestion-api/src/main/resources/list.json
+++ b/nexus-ingestion-api/src/main/resources/list.json
@@ -24,6 +24,16 @@
          "keepAliveTimeout": 20
     },
     {
+        "port": 5556,
+        "responseType": "pnr",
+        "protocol": "http",
+        "route": "/xds/XDSbRepositoryWS",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "queue": "test.fifo",
+         "keepAliveTimeout": 20
+    },
+    {
         "sourceId":"netspective",
         "msgType":"pix",
         "protocol": "TCP",
@@ -94,6 +104,7 @@
         "whitelistIps": [
             "0.0.0.0/0"
         ],
+        
         "execType": "sync",
         "trafficTo": "util"
     },

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1051.0</revision>
+        <revision>0.1052.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Changes:
- Added route handling for `/xds/XDSbRepositoryWS`.
- Ensured the route behaves identically to the existing `/ws` endpoint.
- Updated InteractionsFilter logic to allow configured routes via ALLOWED_ROUTES.
- Added null-safe handling for route validation. #2846