### PR TITLE
feat: add feature flag to control NTE segment inclusion in HL7 ACK responses #2861

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/FeatureEnum.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/feature/FeatureEnum.java
@@ -11,7 +11,9 @@ public enum FeatureEnum implements Feature {
     @Label("Ignore SOAP MustUnderstand Headers")
     IGNORE_MUST_UNDERSTAND_HEADERS,
     @Label("Log Incoming Message")
-    LOG_INCOMING_MESSAGE;
+    LOG_INCOMING_MESSAGE,
+    @Label("Include NTE Segment in HL7 ACK Response")
+    ADD_NTE_SEGMENT_TO_HL7_ACK;
     public static boolean isEnabled(Feature feature) {
         return FeatureContext.getFeatureManager().isActive(feature);
     }

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/listener/NettyTcpServer.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/listener/NettyTcpServer.java
@@ -1460,7 +1460,9 @@ public class NettyTcpServer implements MessageSourceProvider {
                 GenericParser parser = context.getGenericParser();
                 hl7Message = parser.parse(cleanMsg);
                 Message ack = hl7Message.generateACK();
-                ackMessage = addNteWithInteractionId(ack, interactionId.toString(), appConfig.getVersion());
+              if (FeatureEnum.isEnabled(FeatureEnum.ADD_NTE_SEGMENT_TO_HL7_ACK)) {
+                   ackMessage = addNteWithInteractionId(ack, interactionId.toString(), appConfig.getVersion());
+                 }
                 ackMessage = new PipeParser().encode(ack);
                 logger.info("HL7_ACK_GENERATED [sessionId={}] [interactionId={}] [haproxyDetails={}]",
                         sessionId, interactionId, haproxyDetails(ctx));
@@ -2075,31 +2077,4 @@ public class NettyTcpServer implements MessageSourceProvider {
 
     @Override
     public String getDestinationPort(Map<String, String> headers) { return headers.get("DestinationPort"); }
-
-   private void logHttpHeaders(io.netty.handler.codec.http.HttpRequest request,
-                            String sessionId,
-                            UUID interactionId) {
-
-        request.headers().forEach(header -> {
-            logger.info("HTTP_HEADER [sessionId={}] [interactionId={}] {}={}",
-                    sessionId,
-                    interactionId,
-                    header.getKey(),
-                    header.getValue());
-        });
-}
-
-    private void logTcpConnectionDetails(ChannelHandlerContext ctx,
-                                        String sessionId,
-                                        UUID interactionId) {
-
-        String remoteIp = ctx.channel().remoteAddress().toString();
-        String localIp = ctx.channel().localAddress().toString();
-
-        logger.info("TCP_CONNECTION_METADATA [sessionId={}] [interactionId={}] remoteAddress={} localAddress={}",
-                sessionId,
-                interactionId,
-                remoteIp,
-                localIp);
-    }
 }

--- a/nexus-ingestion-api/src/main/resources/application.yml
+++ b/nexus-ingestion-api/src/main/resources/application.yml
@@ -59,6 +59,8 @@ togglz:
       enabled: true
     LOG_INCOMING_MESSAGE:
       enabled: false
+    ADD_NTE_SEGMENT_TO_HL7_ACK:
+      enabled: true  
 logging:
   level:
     root: INFO

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1057.0</revision>
+        <revision>0.1058.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Summary
-------
Introduced a Togglz feature flag to control the inclusion of the NTE segment
in generated HL7 ACK responses. 

Changes
-------
- Added new Togglz feature flag: ADD_NTE_SEGMENT_TO_HL7_ACK
- Updated FeatureEnum to include the new flag
- Added configuration entry under togglz.features
- Updated ACK generation logic to conditionally include the NTE segment
- When enabled, ACK responses include InteractionID and API version in NTE #2861 