### PR TITLE
feat: update markdown files that describes the CCDA and HL7 to FHIR converion process #2652

### DIFF
--- a/support/specifications/ccda/README.md
+++ b/support/specifications/ccda/README.md
@@ -53,12 +53,13 @@ These headers are required for correct routing, validation, and FHIR bundle gene
 |--------------|----------------|--------------|
 | **X-TechBD-Tenant-ID** | `QE-CR` | Identifies the tenant for which the CCDA message belongs. |
 | **X-TechBD-CIN** | `AB12345C` | Customer identification number. |
-| **X-TechBD-OrgNPI** | `NPI123456` | Organization’s NPI (National Provider Identifier). |
-| **X-TechBD-OrgTIN** | `TIN1231423` | Organization’s Tax Identification Number. |
+| **X-TechBD-OrgNPI** | `NPI123456` | Organization’s NPI (National Provider Identifier). Either **X-TechBD-OrgNPI** or **X-TechBD-OrgTIN** is required. |
+| **X-TechBD-OrgTIN** | `TIN1231423` | Organization’s Tax Identification Number. Either **X-TechBD-OrgNPI** or **X-TechBD-OrgTIN** is required. |
 | **X-TechBD-Facility-ID** | `FacilityID-123` | The ID of the submitting facility. |
 | **X-TechBD-Encounter-Type** | `405672008` | Encounter type code. |
 | **X-TechBD-Validation-Severity-Level** | `error` | Determines how validation errors are handled. |
 | **X-TechBD-Screening-Code** | `100698-0` | Grouper Screening code linked to the Observation resources. |
+| **X-TechBD-Part2** | `True` | Specifies whether to add the 'security' element to Bundle.meta to flag the Part 2 or sensitive data. |
 
 > **Note:** All these headers must be provided in every CCDA submission request. Missing or incorrect headers may cause the transformation to fail or produce incomplete FHIR bundles.
 
@@ -89,7 +90,7 @@ These headers are required for correct routing, validation, and FHIR bundle gene
   ```
 
 ### **Step 5: Mirth Channel Processing**
-- The entire process—PHI exclusion, schema validation, transformation—is performed within the **Mirth Connect channel**:
+- The entire process — PHI exclusion, schema validation, transformation — is performed within the **Mirth Connect channel**:
   ```
   TechBD CCD Workflow
   ```

--- a/support/specifications/ccda/sample-ccda-files/README.md
+++ b/support/specifications/ccda/sample-ccda-files/README.md
@@ -1,1 +1,48 @@
+# CCDA Sample Files
 
+This directory contains **sample CCDA (Consolidated Clinical Document Architecture) files** used for testing, validation, and CCDA → FHIR conversion workflows.
+
+The samples come from different **EHR vendors and testing scenarios** to ensure compatibility with various CCDA formats.
+
+---
+
+# Folder Structure
+
+```
+sample-ccda-files
+│
+├── AthenaHealth
+│ ├── Sample.CCDA.v3.with.screener.consent.txt
+│ └── SamplesPREV.with.Test.Patient.txt
+│
+├── Epic
+│ ├── AHC_Sample_CDA.xml
+│ ├── epic_sample_ccd_noauth_021725.txt
+│ ├── epic_sample_ccd_auth1_021725.txt
+│ ├── epic_sample_ccd_auth2_021725.txt
+│ ├── epic_sample_cda_1_021125.xml
+│ ├── epic_sample_cda_2_021125.xml
+│ └── Sample_CCD_EPIC_via_OBH_via_HEALTHIX.xml
+│
+├── Greenway
+│ └── Test_05368091_Greenway.xml
+│
+└── Medent
+├── JPedAs_11.xml
+├── JPedAs_12.xml
+├── JPedAs_13.xml
+├── JPedAs_14.xml
+├── JPedAs_15.xml
+├── JPedAs_16.xml
+├── JPedAs_17.xml
+├── JPedAs_18.xml
+├── JPedAs_19.xml
+└── JPedAs_20.xml
+```
+
+
+# Notes
+
+- These files represent **real-world CCDA structures from different EHR vendors**.
+- Some files are provided in **`.xml` format**, while others are provided as **`.txt` containing CCDA XML payloads**.
+- The variation helps ensure robust parsing and transformation logic.

--- a/support/specifications/hl7/ReadMe.md
+++ b/support/specifications/hl7/ReadMe.md
@@ -1,8 +1,8 @@
 # HL7v2 to FHIR Conversion Process
 
-This document describes the **step-by-step process** for converting **HL7v2 messages** into **FHIR-compliant bundles** using **Mirth Connect**.  
-It includes schema validation, XML conversion, and transformation based on the **SHINNY Implementation Guide (IG)**.
-
+This document describes the **HL7v2 → FHIR conversion pipeline** implemented using **Mirth Connect** for converting **HL7v2 messages** into **FHIR Bundles** using **Mirth Connect**.  
+The pipeline receives **HL7v2 messages**, performs **XML conversion**, **validation**, and converts them into **FHIR Bundles** compliant with the **SHINNY Implementation Guide (IG)**.
+The entire process is implemented through the **TechBD HL7 Workflow** Mirth Connect channel.
 
 
 ## Overview
@@ -34,6 +34,26 @@ integration-artifacts/
 ### **Step 1: Receive HL7v2 Message**
 - The process begins when an **HL7v2 message** is received through the **TechBD HL7 Workflow** Mirth Connect channel.
 - Mirth triggers the pipeline for transformation and validation.
+
+
+#### Required HTTP Headers
+
+When sending the HL7v2 file to the conversion endpoint, include the following **HTTP headers** in the request.  
+These headers are required for correct routing, validation, and FHIR bundle generation.
+
+| Header Name | Example Value | Description |
+|--------------|----------------|--------------|
+| **X-TechBD-Tenant-ID** | `QE-CR` | Identifies the tenant for which the HL7 message belongs. |
+| **X-TechBD-CIN** | `AB12345C` | Customer identification number. |
+| **X-TechBD-OrgNPI** | `NPI123456` | Organization’s NPI (National Provider Identifier). Either **X-TechBD-OrgNPI** or **X-TechBD-OrgTIN** is required. |
+| **X-TechBD-OrgTIN** | `TIN1231423` | Organization’s Tax Identification Number. Either **X-TechBD-OrgNPI** or **X-TechBD-OrgTIN** is required. |
+| **X-TechBD-Facility-ID** | `FacilityID-123` | The ID of the submitting facility. |
+| **X-TechBD-Encounter-Type** | `405672008` | Encounter type code. |
+| **X-TechBD-Validation-Severity-Level** | `error` | Determines how validation errors are handled. |
+| **X-TechBD-Organization-Name** | `Abc Corporation` | Name of the Organization. |
+| **X-TechBD-Part2** | `True` | Specifies whether to add the 'security' element to Bundle.meta to flag the Part 2 or sensitive data. |
+
+> **Note:** All these headers must be provided in every HL7 submission request. Missing or incorrect headers may cause the transformation to fail or produce incomplete FHIR bundles.
 
 
 
@@ -77,12 +97,14 @@ integration-artifacts/
 
 
 ### **Step 6: Generate FHIR Bundle**
-- The transformation produces a **FHIR Bundle** containing:
+- The transformation produces a **FHIR Bundle** containing the following resources:
   - `Patient`
   - `Encounter`
   - `Consent`
   - `Organization`
   - `Observation`
+  - `Sexual Orientation`
+  - `Grouper Observation`
 
 - The final output is a **FHIR-compliant JSON bundle**, ready for downstream systems.
 
@@ -106,21 +128,3 @@ integration-artifacts/
 - Future versions may include mappings for **HL7v2.4**, **v2.5**, and beyond.
 - Ensure Mirth Connect has read/write access to the `integration-artifacts` directory.
 - Logging and error handling are managed within the Mirth Connect channel.
-
-## Required HTTP Headers
-
-When sending the HL7v2 file to the conversion endpoint, include the following **HTTP headers** in the request.  
-These headers are required for correct routing, validation, and FHIR bundle generation.
-
-| Header Name | Example Value | Description |
-|--------------|----------------|--------------|
-| **X-TechBD-Tenant-ID** | `QE-CR` | Identifies the tenant for which the HL7 message belongs. |
-| **X-TechBD-CIN** | `AB12345C` | Customer identification number. |
-| **X-TechBD-OrgNPI** | `NPI123456` | Organization’s NPI (National Provider Identifier). |
-| **X-TechBD-OrgTIN** | `TIN1231423` | Organization’s Tax Identification Number. |
-| **X-TechBD-Facility-ID** | `FacilityID-123` | The ID of the submitting facility. |
-| **X-TechBD-Encounter-Type** | `405672008` | Encounter type code. |
-| **X-TechBD-Validation-Severity-Level** | `error` | Determines how validation errors are handled. |
-| **X-TechBD-Organization-Name** | `Abc Corporation` | Name of the Organization. |
-
-> **Note:** All these headers must be provided in every HL7 submission request. Missing or incorrect headers may cause the transformation to fail or produce incomplete FHIR bundles.

--- a/support/specifications/hl7/sample-hl7-files/README.md
+++ b/support/specifications/hl7/sample-hl7-files/README.md
@@ -1,0 +1,25 @@
+# HL7 Sample Files
+
+This directory contains **sample HL7v2 messages** used for testing, validation, and HL7 → FHIR conversion workflows.
+
+The samples come from different **EHR vendors and testing scenarios** to ensure compatibility with various CCDA formats.
+
+---
+
+# Folder Structure
+
+```
+sample-hl7-files
+│
+├── KHS_AHCTRN_05212025_2318.hl7
+├── KHS_AHCTRN_05212025_2326.hl7
+├── KHS_AHCTRN_05212025_2330.hl7
+└── KHS_HRSN_HL7v2.hl7
+```
+
+
+# Notes
+
+- HL7 messages use the **pipe-delimited format** (`|`).
+- Segments are separated by **carriage returns**.
+- These samples are intended for **testing and development purposes only**.


### PR DESCRIPTION
- Updated the following markdown files 

1. `support/specifications/hl7/ReadMe.md` -> HL7 to FHIR Bundle conversion process through Mirth Connect channel
2. `support/specifications/ccda/README.md` -> CCDA to FHIR Bundle conversion process through Mirth Connect channel
3. `support/specifications/ccda/sample-ccda-files/README.md` -> describe the sample files used for testing the CCDA to FHIR conversion.

- Added new markdown file `support/specifications/hl7/sample-hl7-files/README.md` to describe the sample files used for testing the HL7 to FHIR conversion.