### PR TITLE
feat: implement multi-provider authentication support with GitHub and FusionAuth #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/InteractionService.java
+++ b/hub-prime/src/main/java/org/techbd/service/InteractionService.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jooq.DSLContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,6 +18,7 @@ import org.techbd.conf.Configuration;
 import org.techbd.config.CoreAppConfig;
 import org.techbd.service.constants.SourceType;
 import org.techbd.service.http.FusionAuthUserAuthorizationFilter;
+import org.techbd.service.http.GitHubUserAuthorizationFilter;
 import org.techbd.service.http.Interactions.RequestResponseEncountered;
 import org.techbd.udi.auto.jooq.ingress.routines.RegisterUserInteraction;
 import org.techbd.util.AppLogger;
@@ -48,6 +47,9 @@ public class InteractionService {
     @Value("${org.techbd.service.http.interactions.saveUserDataToInteractions:true}")
     private boolean saveUserDataToInteractions;
 
+    @Value("${AUTH_PROVIDER:fusionauth}")
+    private String authProvider;
+
     @Transactional
     public void saveInteractionToDatabase(RequestResponseEncountered rre, String requestURI, 
             OffsetDateTime createdAt, String provenance, HttpServletRequest origRequest) {
@@ -70,28 +72,58 @@ public class InteractionService {
                 rihr.setPProvenance(provenance);
                 // User details
                 if (saveUserDataToInteractions) {
-                        var curUserName = "API_USER";
-                        var fusionAuthUserId = "N/A";
-                        final var sessionId = origRequest.getRequestedSessionId();
-                        var userRole = "API_ROLE";
+                    var curUserName = "API_USER";
+                    var userId = "N/A";
+                    final var sessionId = origRequest.getRequestedSessionId();
+                    var userRole = "API_ROLE";
 
-                         final var curUser = FusionAuthUserAuthorizationFilter.getAuthenticatedUser(origRequest);
-                        if (curUser.isPresent()) {
-                            final var faUser = curUser.get().faUser();
-                            if (null != faUser) {
+                    Optional<?> curUser = Optional.empty();
+
+                    if ("fusionauth".equalsIgnoreCase(authProvider)) {
+                        curUser = FusionAuthUserAuthorizationFilter.getAuthenticatedUser(origRequest);
+                    } else if ("github".equalsIgnoreCase(authProvider)) {
+                        curUser = GitHubUserAuthorizationFilter.getAuthenticatedUser(origRequest);
+                    }
+
+                    if (curUser.isPresent()) {
+                        Object user = curUser.get();
+
+                        if ("fusionauth".equalsIgnoreCase(authProvider)) {
+                            final var faUser = ((FusionAuthUserAuthorizationFilter.AuthenticatedUser) user).faUser();
+                            if (faUser != null) {
                                 curUserName = Optional.ofNullable(faUser.name()).orElse("NO_DATA");
-                                fusionAuthUserId = Optional.ofNullable(faUser.fusionAuthId()).orElse("NO_DATA");
-                                userRole = curUser.get().principal().getAuthorities().stream()
-                                        .map(GrantedAuthority::getAuthority)
-                                        .collect(Collectors.joining(","));
-                                LOG.info("userRole: " + userRole);
-                                userRole = "DEFAULT_ROLE"; // TODO: Remove this when role is implemented as part of Auth
+                                userId = Optional.ofNullable(faUser.fusionAuthId()).orElse("NO_DATA");
                             }
+
+                            userRole = ((FusionAuthUserAuthorizationFilter.AuthenticatedUser) user)
+                                    .principal()
+                                    .getAuthorities()
+                                    .stream()
+                                    .map(GrantedAuthority::getAuthority)
+                                    .collect(Collectors.joining(","));
+
+                        } else if ("github".equalsIgnoreCase(authProvider)) {
+                            final var ghUser = ((GitHubUserAuthorizationFilter.AuthenticatedUser) user).ghUser();
+                            if (ghUser != null) {
+                                curUserName = Optional.ofNullable(ghUser.name()).orElse("NO_DATA");
+                                userId = Optional.ofNullable(ghUser.gitHubId()).orElse("NO_DATA");
+                            }
+
+                            userRole = ((GitHubUserAuthorizationFilter.AuthenticatedUser) user)
+                                    .principal()
+                                    .getAuthorities()
+                                    .stream()
+                                    .map(GrantedAuthority::getAuthority)
+                                    .collect(Collectors.joining(","));
                         }
-                        rihr.setPUserName(curUserName);
-                        rihr.setPUserId(fusionAuthUserId);
-                        rihr.setPUserSession(sessionId);
-                        rihr.setPUserRole(userRole);
+
+                        LOG.info("userRole: " + userRole);
+                        userRole = "DEFAULT_ROLE"; // TODO: remove when real role mapping is implemented
+                    }
+                    rihr.setPUserName(curUserName);
+                    rihr.setPUserId(userId);
+                    rihr.setPUserSession(sessionId);
+                    rihr.setPUserRole(userRole);
                 } else {
                     LOG.info("User details are not saved with Interaction as saveUserDataToInteractions: "
                             + saveUserDataToInteractions);

--- a/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUserAuthorizationFilter.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUserAuthorizationFilter.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -21,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @Component
+@ConditionalOnProperty(name = "AUTH_PROVIDER", havingValue = "fusionauth", matchIfMissing = true)
 public class FusionAuthUserAuthorizationFilter extends OncePerRequestFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(FusionAuthUserAuthorizationFilter.class);

--- a/hub-prime/src/main/java/org/techbd/service/http/GitHubUserAuthorizationFilter.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/GitHubUserAuthorizationFilter.java
@@ -1,113 +1,115 @@
-// package org.techbd.service.http;
+package org.techbd.service.http;
 
-// import java.io.IOException;
-// import java.io.Serializable;
-// import java.util.Optional;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Optional;
 
-// import org.jetbrains.annotations.NotNull;
-// import org.springframework.lang.NonNull;
-// import org.springframework.security.core.context.SecurityContextHolder;
-// import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-// import org.springframework.security.oauth2.core.user.OAuth2User;
-// import org.springframework.stereotype.Component;
-// import org.springframework.web.filter.OncePerRequestFilter;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
-// import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-// import jakarta.servlet.FilterChain;
-// import jakarta.servlet.ServletException;
-// import jakarta.servlet.http.HttpServletRequest;
-// import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-// @Component
-// public class GitHubUserAuthorizationFilter extends OncePerRequestFilter {
+@Component
+@ConditionalOnProperty(name = "AUTH_PROVIDER", havingValue = "github")
+public class GitHubUserAuthorizationFilter extends OncePerRequestFilter {
 
-//     private static final String AUTH_USER_SESSION_ATTR_NAME = "authenticatedUser";
-//     private static final String supportEmail = "help@techbd.org";
-//     private static final String supportEmailDisplayName = "Tech by Design Support <" + supportEmail + ">";
+    private static final String AUTH_USER_SESSION_ATTR_NAME = "authenticatedUser";
+    private static final String supportEmail = "help@techbd.org";
+    private static final String supportEmailDisplayName = "Tech by Design Support <" + supportEmail + ">";
 
-//     @JsonIgnoreProperties(ignoreUnknown = true)
-//     public record AuthenticatedUser(OAuth2User principal, GitHubUsersService.AuthorizedUser ghUser)
-//             implements Serializable {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AuthenticatedUser(OAuth2User principal, GitHubUsersService.AuthorizedUser ghUser)
+            implements Serializable {
 
-//     }
+    }
 
-//     public static final Optional<AuthenticatedUser> getAuthenticatedUser(
-//             final @NonNull HttpServletRequest request) {
-//         return Optional.ofNullable(request.getSession(false))
-//                 .map(session -> (AuthenticatedUser) session.getAttribute(AUTH_USER_SESSION_ATTR_NAME));
-//     }
+    public static final Optional<AuthenticatedUser> getAuthenticatedUser(
+            final @NonNull HttpServletRequest request) {
+        return Optional.ofNullable(request.getSession(false))
+                .map(session -> (AuthenticatedUser) session.getAttribute(AUTH_USER_SESSION_ATTR_NAME));
+    }
 
-//     protected static final void setAuthenticatedUser(final @NonNull HttpServletRequest request,
-//             final @NonNull AuthenticatedUser authUser) {
-//         request.getSession(true).setAttribute(AUTH_USER_SESSION_ATTR_NAME, authUser);
-//     }
+    protected static final void setAuthenticatedUser(final @NonNull HttpServletRequest request,
+            final @NonNull AuthenticatedUser authUser) {
+        request.getSession(true).setAttribute(AUTH_USER_SESSION_ATTR_NAME, authUser);
+    }
 
-//     private final GitHubUsersService gitHubUsers;
+    private final GitHubUsersService gitHubUsers;
 
-//     public GitHubUserAuthorizationFilter(final GitHubUsersService gitHubUsers) {
-//         this.gitHubUsers = gitHubUsers;
-//     }
+    public GitHubUserAuthorizationFilter(final GitHubUsersService gitHubUsers) {
+        this.gitHubUsers = gitHubUsers;
+    }
 
-//     @Override
-//     protected void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response,
-//             @NotNull FilterChain filterChain)
-//             throws ServletException, IOException {
-//         final var sessionUser = getAuthenticatedUser(request);
-//         if (sessionUser.isEmpty()) {
-//             final var authentication = SecurityContextHolder.getContext().getAuthentication();
-//             if (authentication != null && authentication.isAuthenticated()
-//                     && !"anonymousUser".equals(authentication.getPrincipal().toString())) {
-//                 final var gitHubPrincipal = (DefaultOAuth2User) authentication.getPrincipal();
-//                 final var gitHubLoginId = Optional.ofNullable(gitHubPrincipal.getAttribute("login")).orElseThrow();
+    @Override
+    protected void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response,
+            @NotNull FilterChain filterChain)
+            throws ServletException, IOException {
+        final var sessionUser = getAuthenticatedUser(request);
+        if (sessionUser.isEmpty()) {
+            final var authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.isAuthenticated()
+                    && !"anonymousUser".equals(authentication.getPrincipal().toString())) {
+                final var gitHubPrincipal = (DefaultOAuth2User) authentication.getPrincipal();
+                final var gitHubLoginId = Optional.ofNullable(gitHubPrincipal.getAttribute("login")).orElseThrow();
                 
-//                 // Check for sandbox profile - bypass GitHub repo fetch completely
-//                 String activeProfile = System.getenv("SPRING_PROFILES_ACTIVE");
-//                 Optional<GitHubUsersService.AuthorizedUser> gitHubAuthnUser = Optional.empty();
-//                 boolean useDummyUser = Boolean.parseBoolean(System.getenv("SANDBOX_USE_DUMMY_USER"));
-//                 if (useDummyUser && "sandbox".equals(activeProfile)) {
-//                     // In sandbox mode, create dummy user without calling GitHub API
-//                     String sandboxGitHubId = System.getenv("SANDBOX_GITHUB_ID");
-//                     String sandboxUserName = System.getenv("SANDBOX_USER_NAME");
-//                     String sandboxTenantId = System.getenv("SANDBOX_TENANT_ID");
-//                     gitHubAuthnUser = Optional.of(
-//                             gitHubUsers.createDummyAuthorizedUser(
-//                                     sandboxGitHubId,
-//                                     sandboxUserName != null ? sandboxUserName : gitHubLoginId.toString(),
-//                                     sandboxTenantId != null ? sandboxTenantId : "Netspective"));
-//                 } else {
-//                     // Production mode - use normal authorization (reads from GitHub repo)
-//                     gitHubAuthnUser = gitHubUsers.isAuthorizedUser(gitHubLoginId.toString());
-//                 }
+                // Check for sandbox profile - bypass GitHub repo fetch completely
+                String activeProfile = System.getenv("SPRING_PROFILES_ACTIVE");
+                Optional<GitHubUsersService.AuthorizedUser> gitHubAuthnUser = Optional.empty();
+                boolean useDummyUser = Boolean.parseBoolean(System.getenv("SANDBOX_USE_DUMMY_USER"));
+                if (useDummyUser && "sandbox".equals(activeProfile)) {
+                    // In sandbox mode, create dummy user without calling GitHub API
+                    String sandboxGitHubId = System.getenv("SANDBOX_GITHUB_ID");
+                    String sandboxUserName = System.getenv("SANDBOX_USER_NAME");
+                    String sandboxTenantId = System.getenv("SANDBOX_TENANT_ID");
+                    gitHubAuthnUser = Optional.of(
+                            gitHubUsers.createDummyAuthorizedUser(
+                                    sandboxGitHubId,
+                                    sandboxUserName != null ? sandboxUserName : gitHubLoginId.toString(),
+                                    sandboxTenantId != null ? sandboxTenantId : "Netspective"));
+                } else {
+                    // Production mode - use normal authorization (reads from GitHub repo)
+                    gitHubAuthnUser = gitHubUsers.isAuthorizedUser(gitHubLoginId.toString());
+                }
                 
-//                 if (!gitHubAuthnUser.isPresent()) {
-//                     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-//                     response.setContentType("text/html");
-//                     response.getWriter().write("GitHub ID " + gitHubLoginId
-//                             + " does not have permission to access this resource. Please fill out the <a href=\"https://techbd.org/submit-form/access-request\" target=\"_blank\"> Access Request Form </a> to request access. Once submitted, Tech by Design Support will review your request. For further assistance, contact Tech by Design Support at <<a href=\"mailto:"
-//                             + supportEmailDisplayName + "\">" + supportEmail + "</a>>.");
-//                     return;
-//                 }
-//                 setAuthenticatedUser(request, new AuthenticatedUser(gitHubPrincipal, gitHubAuthnUser.orElseThrow()));
-//             }
-//         }
+                if (!gitHubAuthnUser.isPresent()) {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    response.setContentType("text/html");
+                    response.getWriter().write("GitHub ID " + gitHubLoginId
+                            + " does not have permission to access this resource. Please fill out the <a href=\"https://techbd.org/submit-form/access-request\" target=\"_blank\"> Access Request Form </a> to request access. Once submitted, Tech by Design Support will review your request. For further assistance, contact Tech by Design Support at <<a href=\"mailto:"
+                            + supportEmailDisplayName + "\">" + supportEmail + "</a>>.");
+                    return;
+                }
+                setAuthenticatedUser(request, new AuthenticatedUser(gitHubPrincipal, gitHubAuthnUser.orElseThrow()));
+            }
+        }
 
-//         if (request.getRequestURI().startsWith("/actuator")) {
-//             Optional<AuthenticatedUser> userOptional = getAuthenticatedUser(request);
-//             if (userOptional.isPresent()) {
-//                 if (!userOptional.get().ghUser.isUserHasActuatorAccess()) {
-//                     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-//                     response.setContentType("text/plain"); // Ensure content type is set to text/plain
-//                     response.getWriter().write("GitHub ID " + userOptional.get().ghUser.gitHubId()
-//                             + " does not have roles to access actuator. Please send an email to "
-//                             + supportEmailDisplayName
-//                             + " from your manager, to add roles to access actuator from this GitHub ID.");
-//                     response.flushBuffer();
-//                     return; // Stop further processing of the request
-//                 }
-//             }
-//         }
+        if (request.getRequestURI().startsWith("/actuator")) {
+            Optional<AuthenticatedUser> userOptional = getAuthenticatedUser(request);
+            if (userOptional.isPresent()) {
+                if (!userOptional.get().ghUser.isUserHasActuatorAccess()) {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    response.setContentType("text/plain"); // Ensure content type is set to text/plain
+                    response.getWriter().write("GitHub ID " + userOptional.get().ghUser.gitHubId()
+                            + " does not have roles to access actuator. Please send an email to "
+                            + supportEmailDisplayName
+                            + " from your manager, to add roles to access actuator from this GitHub ID.");
+                    response.flushBuffer();
+                    return; // Stop further processing of the request
+                }
+            }
+        }
 
-//         filterChain.doFilter(request, response);
-//     }
-// }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/hub-prime/src/main/java/org/techbd/service/http/GitHubUsersService.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/GitHubUsersService.java
@@ -1,154 +1,154 @@
-// package org.techbd.service.http;
+package org.techbd.service.http;
 
-// import java.io.IOException;
-// import java.time.Duration;
-// import java.util.Collections;
-// import java.util.List;
-// import java.util.Map;
-// import java.util.Optional;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
-// import org.springframework.boot.context.properties.ConfigurationProperties;
-// import org.springframework.stereotype.Service;
-// import org.springframework.web.reactive.function.client.WebClient;
-// import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 
-// import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-// import com.fasterxml.jackson.databind.ObjectMapper;
-// import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-// import reactor.core.publisher.Mono;
-// import reactor.util.retry.Retry;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
-// @ConfigurationProperties(prefix = "org.techbd.service.http.github")
-// @Service
-// public class GitHubUsersService {
-//   private static final Logger LOG = LoggerFactory.getLogger(GitHubUsersService.class);
+@ConfigurationProperties(prefix = "org.techbd.service.http.github")
+@Service
+public class GitHubUsersService {
+  private static final Logger LOG = LoggerFactory.getLogger(GitHubUsersService.class);
 
-//   // @JsonIgnoreProperties(ignoreUnknown = true)
-//   // public record AuthorizedUser(String gitHubId, String name, String tenantId,
-//   // List<String> roles) {
-//   // }
-//   @JsonIgnoreProperties(ignoreUnknown = true)
-//   public record AuthorizedUser(String name, String emailPrimary, String profilePicUrl, String gitHubId,
-//       String tenantId, Map<String, Resource> resources) {
-//     public boolean isUserHasActuatorAccess() {
-//       return Optional.ofNullable(resources().get("actuator"))
-//           .map(actuator -> actuator.roles)
-//           .orElseGet(Collections::emptyList)
-//           .stream()
-//           .anyMatch(role -> role.contains("ADMIN"));
-//     }
-//   }
+  // @JsonIgnoreProperties(ignoreUnknown = true)
+  // public record AuthorizedUser(String gitHubId, String name, String tenantId,
+  // List<String> roles) {
+  // }
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record AuthorizedUser(String name, String emailPrimary, String profilePicUrl, String gitHubId,
+      String tenantId, Map<String, Resource> resources) {
+    public boolean isUserHasActuatorAccess() {
+      return Optional.ofNullable(resources().get("actuator"))
+          .map(actuator -> actuator.roles)
+          .orElseGet(Collections::emptyList)
+          .stream()
+          .anyMatch(role -> role.contains("ADMIN"));
+    }
+  }
 
-//   public record Resource(List<String> roles) {
-//   }
+  public record Resource(List<String> roles) {
+  }
 
-//   // this record must physically match the structure of
-//   // sensitive/oauth2-github-authz.yml
-//   public record AuthorizedUsers(List<AuthorizedUser> users) {
-//     public Optional<AuthorizedUser> isAuthorizedUser(final String gitHubUserID) {
-//       return users.stream().filter(u -> u.gitHubId().equals(gitHubUserID)).findFirst();
-//     }
-//   }
+  // this record must physically match the structure of
+  // sensitive/oauth2-github-authz.yml
+  public record AuthorizedUsers(List<AuthorizedUser> users) {
+    public Optional<AuthorizedUser> isAuthorizedUser(final String gitHubUserID) {
+      return users.stream().filter(u -> u.gitHubId().equals(gitHubUserID)).findFirst();
+    }
+  }
 
-//   private String gitHubApiAuthnToken = System.getenv("ORG_TECHBD_SERVICE_HTTP_GITHUB_API_AUTHN_TOKEN");
-//   private String authzUsersYamlUrl = System.getenv("ORG_TECHBD_SERVICE_HTTP_GITHUB_AUTHZ_USERS_YAML_URL");
+  private String gitHubApiAuthnToken = System.getenv("ORG_TECHBD_SERVICE_HTTP_GITHUB_API_AUTHN_TOKEN");
+  private String authzUsersYamlUrl = System.getenv("ORG_TECHBD_SERVICE_HTTP_GITHUB_AUTHZ_USERS_YAML_URL");
 
-//   private final WebClient gitHubApiClient = WebClient.builder()
-//       .defaultHeader("Authorization", "token " + gitHubApiAuthnToken)
-//       .build();
+  private final WebClient gitHubApiClient = WebClient.builder()
+      .defaultHeader("Authorization", "token " + gitHubApiAuthnToken)
+      .build();
 
-//   /**
-//    * Check GitHub to see if the provided userName is an authorized user. This
-//    * method will always go back to GitHub and load all users before returning
-//    * result. User is responsible for caching to reduce performance hits.
-//    * 
-//    * @param gitHubLoginID the GitHub userName to check
-//    * @return non-empty AuthenticatedUser if found authorized or empty if not
-//    *         authorized
-//    */
-//   public Optional<AuthorizedUser> isAuthorizedUser(final String gitHubLoginID) {
-//     final var result = getAuthorizedUsers().isAuthorizedUser(gitHubLoginID);
-//     LOG.info("isAuthorizedUser %s in %s: %s".formatted(gitHubLoginID, authzUsersYamlUrl, result));
-//     return result;
-//   }
+  /**
+   * Check GitHub to see if the provided userName is an authorized user. This
+   * method will always go back to GitHub and load all users before returning
+   * result. User is responsible for caching to reduce performance hits.
+   * 
+   * @param gitHubLoginID the GitHub userName to check
+   * @return non-empty AuthenticatedUser if found authorized or empty if not
+   *         authorized
+   */
+  public Optional<AuthorizedUser> isAuthorizedUser(final String gitHubLoginID) {
+    final var result = getAuthorizedUsers().isAuthorizedUser(gitHubLoginID);
+    LOG.info("isAuthorizedUser %s in %s: %s".formatted(gitHubLoginID, authzUsersYamlUrl, result));
+    return result;
+  }
 
-//   /**
-//    * Get list of all authorized GitHub users. This method will always go back to
-//    * GitHub and load all users before returning result. User is responsible for
-//    * caching to reduce performance hits.
-//    * 
-//    * @return all authorized users defined in GitHub file authzUsersYamlUrl
-//    */
-//   protected AuthorizedUsers getAuthorizedUsers() {
-//     LOG.info("Downloading users from %s".formatted(authzUsersYamlUrl));
-//     // Make a single request to the URL and get the YAML content directly
-//     final var responseBody = gitHubApiClient.get()
-//         .uri(authzUsersYamlUrl)
-//         .retrieve()
-//         .onStatus(status -> !status.is2xxSuccessful(), clientResponse -> {
-//           LOG.error("Unexpected response code from GitHub API: {} ({})", clientResponse.statusCode(),
-//               authzUsersYamlUrl);
-//           return Mono
-//               .error(new IOException("Unexpected response code from GitHub API: " + clientResponse.statusCode()));
-//         })
-//         .bodyToMono(String.class)
-//         .timeout(Duration.ofSeconds(10))
-//         .retryWhen(
-//             Retry.backoff(3, Duration.ofSeconds(2))
-//                 .filter(throwable -> throwable instanceof IOException || throwable instanceof WebClientRequestException)
-//                 .doBeforeRetry(retrySignal -> LOG.warn("GitHub API retry attempt {} due to {}",
-//                     retrySignal.totalRetries() + 1, retrySignal.failure().toString())) // Log retry attempt
-//                 .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> retrySignal.failure()))
-//         .block();
+  /**
+   * Get list of all authorized GitHub users. This method will always go back to
+   * GitHub and load all users before returning result. User is responsible for
+   * caching to reduce performance hits.
+   * 
+   * @return all authorized users defined in GitHub file authzUsersYamlUrl
+   */
+  protected AuthorizedUsers getAuthorizedUsers() {
+    LOG.info("Downloading users from %s".formatted(authzUsersYamlUrl));
+    // Make a single request to the URL and get the YAML content directly
+    final var responseBody = gitHubApiClient.get()
+        .uri(authzUsersYamlUrl)
+        .retrieve()
+        .onStatus(status -> !status.is2xxSuccessful(), clientResponse -> {
+          LOG.error("Unexpected response code from GitHub API: {} ({})", clientResponse.statusCode(),
+              authzUsersYamlUrl);
+          return Mono
+              .error(new IOException("Unexpected response code from GitHub API: " + clientResponse.statusCode()));
+        })
+        .bodyToMono(String.class)
+        .timeout(Duration.ofSeconds(10))
+        .retryWhen(
+            Retry.backoff(3, Duration.ofSeconds(2))
+                .filter(throwable -> throwable instanceof IOException || throwable instanceof WebClientRequestException)
+                .doBeforeRetry(retrySignal -> LOG.warn("GitHub API retry attempt {} due to {}",
+                    retrySignal.totalRetries() + 1, retrySignal.failure().toString())) // Log retry attempt
+                .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> retrySignal.failure()))
+        .block();
 
-//     if (responseBody == null) {
-//       LOG.error("GitHub API response body is null for " + authzUsersYamlUrl);
-//       return null;
-//     }
+    if (responseBody == null) {
+      LOG.error("GitHub API response body is null for " + authzUsersYamlUrl);
+      return null;
+    }
 
-//     // Parse the YAML content into an AuthorizedUsers object
-//     final var mapper = new ObjectMapper(new YAMLFactory());
-//     AuthorizedUsers users;
-//     try {
-//       users = mapper.readValue(responseBody, AuthorizedUsers.class);
-//       users.users.stream().forEach(item -> LOG.info("Item: {}", item));
-//       return users;
-//     } catch (Exception e) {
-//       LOG.error("Error transforming %s to AuthorizedUsers.class".formatted(authzUsersYamlUrl), e);
-//     }
+    // Parse the YAML content into an AuthorizedUsers object
+    final var mapper = new ObjectMapper(new YAMLFactory());
+    AuthorizedUsers users;
+    try {
+      users = mapper.readValue(responseBody, AuthorizedUsers.class);
+      users.users.stream().forEach(item -> LOG.info("Item: {}", item));
+      return users;
+    } catch (Exception e) {
+      LOG.error("Error transforming %s to AuthorizedUsers.class".formatted(authzUsersYamlUrl), e);
+    }
 
-//     return new AuthorizedUsers(List.of());
-//   }
+    return new AuthorizedUsers(List.of());
+  }
     
-//   /**
-//    * Creates a dummy authorized user for sandbox environments.
-//    * This allows testing without requiring users to be in the authorized users
-//    * list.
-//    * 
-//    * @param gitHubId The GitHub user ID
-//    * @param name     The user's display name
-//    * @param tenantId The tenant ID for the user
-//    * @return An AuthorizedUser instance with basic USER role
-//    */
-//   public AuthorizedUser createDummyAuthorizedUser(String gitHubId, String name, String tenantId) {
-//     // Create resources map with sudomain1.techbd.org having USER role
-//     Map<String, Resource> resources = Map.of(
-//         "sudomain1.techbd.org", new Resource(List.of("USER")));
+  /**
+   * Creates a dummy authorized user for sandbox environments.
+   * This allows testing without requiring users to be in the authorized users
+   * list.
+   * 
+   * @param gitHubId The GitHub user ID
+   * @param name     The user's display name
+   * @param tenantId The tenant ID for the user
+   * @return An AuthorizedUser instance with basic USER role
+   */
+  public AuthorizedUser createDummyAuthorizedUser(String gitHubId, String name, String tenantId) {
+    // Create resources map with sudomain1.techbd.org having USER role
+    Map<String, Resource> resources = Map.of(
+        "sudomain1.techbd.org", new Resource(List.of("USER")));
 
-//     // Note: Not adding actuator resource, so sandbox users won't have actuator
-//     // access
+    // Note: Not adding actuator resource, so sandbox users won't have actuator
+    // access
 
-//     return new AuthorizedUser(
-//         name, // name
-//         gitHubId + "@github.local", // emailPrimary (dummy email)
-//         null, // profilePicUrl (can be null for sandbox)
-//         gitHubId, // gitHubId
-//         tenantId, // tenantId
-//         resources // resources map
-//     );
-//   }
+    return new AuthorizedUser(
+        name, // name
+        gitHubId + "@github.local", // emailPrimary (dummy email)
+        null, // profilePicUrl (can be null for sandbox)
+        gitHubId, // gitHubId
+        tenantId, // tenantId
+        resources // resources map
+    );
+  }
 
-// }
+}

--- a/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
@@ -31,8 +31,11 @@ import jakarta.servlet.http.HttpServletResponse;
 public class SecurityConfig {
   
     
-    @Autowired
+    @Autowired(required = false)
     private FusionAuthUserAuthorizationFilter fusionAuthAuthorizationFilter;
+
+    @Autowired(required = false)
+    private GitHubUserAuthorizationFilter gitHubUserAuthorizationFilter;
 
     @Value("${TECHBD_HUB_PRIME_FHIR_API_BASE_URL:#{null}}")
     private String apiUrl;
@@ -48,6 +51,9 @@ public class SecurityConfig {
 
     @Value("${SPRING_SECURITY_OAUTH2_LOGOUT_REDIRECT_URI}")
     private String logoutRedirectUrl;
+   
+    @Value("${AUTH_PROVIDER:fusionauth}")
+    private String authProvider;
 
     @Bean
     public SecurityFilterChain statelessSecurityFilterChain(final HttpSecurity http) throws Exception {
@@ -86,8 +92,14 @@ public class SecurityConfig {
                 .sessionManagement(
                         sessionManagement -> sessionManagement
                                 .invalidSessionUrl(Constant.SESSION_TIMEOUT_URL)
-                                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
-                .addFilterAfter(fusionAuthAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+                                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+                  if (fusionAuthAuthorizationFilter != null) {
+                        http.addFilterAfter(fusionAuthAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+                    }
+
+                    if (gitHubUserAuthorizationFilter != null) {
+                        http.addFilterAfter(gitHubUserAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+                    }    
         // allow us to show our own content in IFRAMEs (e.g. Swagger, etc.)
         http.headers(headers -> {
             headers.frameOptions(frameOptions -> frameOptions.sameOrigin());

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/Presentation.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/Presentation.java
@@ -9,11 +9,13 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.Model;
 import org.techbd.conf.Configuration;
 import org.techbd.service.http.FusionAuthUserAuthorizationFilter;
+import org.techbd.service.http.GitHubUserAuthorizationFilter;
 import org.techbd.service.http.SandboxHelpers;
 import org.techbd.service.http.hub.prime.AppConfig;
 import org.techbd.service.http.hub.prime.route.RoutesTree;
@@ -24,6 +26,10 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @Service
 public class Presentation {
+
+    @Value("${AUTH_PROVIDER}")
+    private String authProvider;
+    
     @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(Presentation.class.getName());
 
@@ -72,8 +78,13 @@ public class Presentation {
         // make the request, authUser available to templates
         model.addAttribute("appVersion", this.appConfig.getVersion());
         model.addAttribute("req", request);
-        model.addAttribute("authUser", FusionAuthUserAuthorizationFilter.getAuthenticatedUser(request));
-
+        Object authUser;
+        if ("fusionauth".equalsIgnoreCase(authProvider)) {
+            authUser = FusionAuthUserAuthorizationFilter.getAuthenticatedUser(request);
+        } else {
+            authUser = GitHubUserAuthorizationFilter.getAuthenticatedUser(request);
+        }
+        model.addAttribute("authUser", authUser);
         // active route, siblings, ancestors (breadcrumbs) available for navigation
         model.addAttribute("navPrime", navPrimeLinks);
         model.addAttribute("navPrimeTree", navPrimeTree);

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/PrimeController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/PrimeController.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +35,10 @@ import lib.aide.tabular.JooqRowsSupplier;
 @Controller
 @Tag(name = "Tech by Design Hub UX API")
 public class PrimeController {
+
+    @Value("${AUTH_PROVIDER}")
+    private String authProvider;
+
     private static final Logger LOG = LoggerFactory.getLogger(PrimeController.class.getName());
 
     private final DSLContext primaryDslContext;
@@ -66,17 +71,19 @@ public class PrimeController {
     @GetMapping("/home")
     @RouteMapping(label = "Home", siblingOrder = 0)
     public String home(final Model model, final HttpServletRequest request) {
+        model.addAttribute("authProvider", authProvider);
         return presentation.populateModel("page/home", model, request);
     }
 
     @GetMapping("/")
-    public String index() {
+    public String index(Model model) {
+        model.addAttribute("authProvider", authProvider.toLowerCase());
         return "login/login";
     }
 
     @GetMapping("/login")
     public void login(HttpServletResponse response) throws IOException {
-        response.sendRedirect("/oauth2/authorization/fusionauth");
+       response.sendRedirect("/oauth2/authorization/" + authProvider.toLowerCase());
     }
 
     @GetMapping(value = "/admin/cache/tenant-sftp-egress-content/clear")

--- a/hub-prime/src/main/resources/templates/fragments/nav.html
+++ b/hub-prime/src/main/resources/templates/fragments/nav.html
@@ -83,8 +83,12 @@
                                 role="menu" aria-orientation="vertical" aria-labelledby="user-menu-button"
                                 tabindex="-1">
                                 <!-- Active: "bg-gray-100", Not Active: "" -->                         
-                                <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
-                                    id="user-menu-item-0"> <span sec:authentication="principal.attributes['name']" class="font-bold"></span></a>
+                              <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
+                                id="user-menu-item-0">
+                                <span class="font-bold"
+                                        th:text="${authProvider == 'fusionauth'} ? ${#authentication.principal.attributes['name']} : ${#authentication.principal.attributes['login']}">
+                                </span>
+                                </a>
                                 <!-- <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
                                     id="user-menu-item-0"><span sec:authentication="principal.attributes['role']" class="font-bold"></span></a>
                                 <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
@@ -93,13 +97,13 @@
                                     id="user-menu-item-0">My Profile</a>
                                 <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
                                     id="user-menu-item-1">Settings</a> -->
-                                <form action="/logout" method="get">
+                               <form th:if="${authProvider == 'fusionauth'}" action="/logout" method="get">
                                 <button type="submit"
                                     class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                                     role="menuitem" tabindex="-1" id="user-menu-item-2">
                                     Sign out
                                 </button>
-                                </form>
+                            </form>
                             </div>
                              <script>
                         document.addEventListener('DOMContentLoaded', function () { 

--- a/hub-prime/src/main/resources/templates/login/login.html
+++ b/hub-prime/src/main/resources/templates/login/login.html
@@ -28,13 +28,16 @@
             <div class="space-y-4">
                 <!-- FusionAuth Login Button -->
                 <div>
-                    <a th:href="@{/oauth2/authorization/fusionauth}" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-m font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                <a th:href="@{'/oauth2/authorization/' + ${authProvider}}"
+                    class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-m font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700">
                         <div>
                             <svg class="h-8 w-auto mr-2" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                             </svg>
                         </div>
-                        <div class="py-1">Login with Fusion Gateway</div>
+                        <div class="py-1">
+                           <span th:text="'Login with ' + ${authProvider}"></span>
+                        </div>
                     </a>
                 </div>
             </div>

--- a/hub-prime/src/main/resources/templates/page/home.html
+++ b/hub-prime/src/main/resources/templates/page/home.html
@@ -52,9 +52,13 @@
                 </ul>
             </div>
         </div>
-
-        <div sec:authorize="isAuthenticated()">
-            <div>You're logged in as Fusion Gateway User <span sec:authentication="principal.attributes['name']"></span> with
+            <div sec:authorize="isAuthenticated()">
+                <div>
+                    You're logged in as 
+                    <span th:text="${authProvider == 'fusionauth' ? 'Fusion Gateway User' : 'GitHub User'}"></span>
+                    <span class="font-bold"
+                    th:text="${authProvider == 'fusionauth'} ? ${#authentication.principal.attributes['name']} : ${#authentication.principal.attributes['login']}"> </span> 
+                with
                 role <code>TODO</code>.</div>
         </div>
         <div sec:authorize="isAnonymous()">

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1078.0</revision>
+        <revision>0.1079.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
**Title:**
Support dynamic auth provider (FusionAuth/GitHub) with UI and session handling updates  #1687 

**Description:**

- Implemented environment-based auth provider switching using AUTH_PROVIDER
- Updated controller to pass authProvider to UI templates
- Modified login page to dynamically route to selected OAuth provider
- Updated navigation/profile UI to display correct user attributes (name for FusionAuth, login for GitHub)
- Conditional rendering of logout button only for FusionAuth sessions