### PR TITLE
fix: update authentication provider options and enhance user login display #1687

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -68,3 +68,5 @@ export SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_FUSIONAUTH_TOKEN_URI=http://localh
 export SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_FUSIONAUTH_USER_INFO_URI=http://localhost:9011/oauth2/userinfo
 export SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_FUSIONAUTH_JWK_SET_URI=http://localhost:9011/.well-known/jwks.json
 export SPRING_SECURITY_OAUTH2_FUSIONAUTH_REDIRECT_URI=http://localhost:8080/login/oauth2/code/fusionauth
+
+export AUTH_PROVIDER=github # github or fusionauth

--- a/hub-prime/src/main/resources/templates/login/login.html
+++ b/hub-prime/src/main/resources/templates/login/login.html
@@ -36,7 +36,8 @@
                             </svg>
                         </div>
                         <div class="py-1">
-                           <span th:text="'Login with ' + ${authProvider}"></span>
+                        <span th:text="${authProvider == 'fusionauth'} ? 
+                        'Login with Fusion Gateway' : 'Login with GitHub'"> </span>                        
                         </div>
                     </a>
                 </div>

--- a/hub-prime/src/main/resources/templates/page/home.html
+++ b/hub-prime/src/main/resources/templates/page/home.html
@@ -52,16 +52,23 @@
                 </ul>
             </div>
         </div>
-            <div sec:authorize="isAuthenticated()">
-                <div>
-                    You're logged in as 
-                    <span th:text="${authProvider == 'fusionauth' ? 'Fusion Gateway User' : 'GitHub User'}"></span>
-                    <span class="font-bold"
-                    th:text="${authProvider == 'fusionauth'} ? ${#authentication.principal.attributes['name']} : ${#authentication.principal.attributes['login']}"> </span> 
-                with
-                role <code>TODO</code>.</div>
-        </div>
-        <div sec:authorize="isAnonymous()">
+                <div sec:authorize="isAuthenticated()" 
+                    class="flex justify-center items-center h-full text-center">
+                    <div>
+                        You're logged in as 
+                        <span class="font-bold"
+                            th:text="${authProvider == 'fusionauth' ? 
+                                        #authentication.principal.attributes['name'] : 
+                                        #authentication.principal.attributes['login']}">
+                        </span>
+                        with role 
+                        <code th:text="${authProvider == 'fusionauth' ? 
+                                        #strings.listJoin(#authentication.principal.attributes['role'], ', ') : 
+                                        'admin'}">
+                        </code>.
+                    </div>
+                </div>
+      <div sec:authorize="isAnonymous()">
             <div>You're not logged in so you only have guest privileges.</div>
         </div>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1081.0</revision>
+        <revision>0.1082.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
**Description:**

- Implemented role handling with comma-separated display for FusionAuth and default role for GitHub #1687 
- Center-aligned authenticated user information for better UI presentation
- Improved login page text to show proper provider labels (Fusion Gateway / GitHub)