### PR TITLE
fix: update authentication provider to fallback to GitHub #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/InteractionService.java
+++ b/hub-prime/src/main/java/org/techbd/service/InteractionService.java
@@ -47,7 +47,7 @@ public class InteractionService {
     @Value("${org.techbd.service.http.interactions.saveUserDataToInteractions:true}")
     private boolean saveUserDataToInteractions;
 
-    @Value("${AUTH_PROVIDER:fusionauth}")
+    @Value("${AUTH_PROVIDER:github}")
     private String authProvider;
 
     @Transactional

--- a/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
     @Value("${SPRING_SECURITY_OAUTH2_LOGOUT_REDIRECT_URI}")
     private String logoutRedirectUrl;
    
-    @Value("${AUTH_PROVIDER:fusionauth}")
+    @Value("${AUTH_PROVIDER:github}")
     private String authProvider;
 
     @Bean

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/Presentation.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/Presentation.java
@@ -27,7 +27,7 @@ import jakarta.servlet.http.HttpServletRequest;
 @Service
 public class Presentation {
 
-    @Value("${AUTH_PROVIDER}")
+    @Value("${AUTH_PROVIDER:github}")
     private String authProvider;
     
     @SuppressWarnings("unused")

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/PrimeController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/PrimeController.java
@@ -36,7 +36,7 @@ import lib.aide.tabular.JooqRowsSupplier;
 @Tag(name = "Tech by Design Hub UX API")
 public class PrimeController {
 
-    @Value("${AUTH_PROVIDER}")
+    @Value("${AUTH_PROVIDER:github}")
     private String authProvider;
 
     private static final Logger LOG = LoggerFactory.getLogger(PrimeController.class.getName());

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1082.0</revision>
+        <revision>0.1083.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Updated authentication configuration to handle missing AUTH_PROVIDER environment variable. If the variable is not defined, the application now defaults to using GitHub as the authentication provider without causing any errors. #1687