### PR TITLE
fix: add authProvider attribute to user attributes in OAuth2 user services #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
@@ -51,6 +51,7 @@ public class FusionAuthUsersService {
             //    enrichedAttributes.put("groupNames", user.groups()); 
                enrichedAttributes.put("role", user.roles());              
                enrichedAttributes.put("avatar_url", createAvatarUrl(oAuth2User));
+               enrichedAttributes.put("authProvider", "fusionauth");
 
              
                DefaultOAuth2User enrichedOAuth2User = new DefaultOAuth2User(

--- a/hub-prime/src/main/java/org/techbd/service/http/GitHubUserAuthorizationFilter.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/GitHubUserAuthorizationFilter.java
@@ -2,6 +2,8 @@ package org.techbd.service.http;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.jetbrains.annotations.NotNull;
@@ -90,7 +92,16 @@ public class GitHubUserAuthorizationFilter extends OncePerRequestFilter {
                             + supportEmailDisplayName + "\">" + supportEmail + "</a>>.");
                     return;
                 }
-                setAuthenticatedUser(request, new AuthenticatedUser(gitHubPrincipal, gitHubAuthnUser.orElseThrow()));
+                Map<String, Object> attributes = new HashMap<>(gitHubPrincipal.getAttributes());
+                    // Add auth provider
+                    attributes.put("authProvider", "github");
+                    // Create updated principal
+                    DefaultOAuth2User updatedUser = new DefaultOAuth2User(
+                            gitHubPrincipal.getAuthorities(),
+                            attributes,
+                            "login" // GitHub username field
+                    );
+                setAuthenticatedUser(request, new AuthenticatedUser(updatedUser, gitHubAuthnUser.orElseThrow()));
             }
         }
 

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/PrimeController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/PrimeController.java
@@ -71,7 +71,6 @@ public class PrimeController {
     @GetMapping("/home")
     @RouteMapping(label = "Home", siblingOrder = 0)
     public String home(final Model model, final HttpServletRequest request) {
-        model.addAttribute("authProvider", authProvider);
         return presentation.populateModel("page/home", model, request);
     }
 

--- a/hub-prime/src/main/resources/templates/fragments/nav.html
+++ b/hub-prime/src/main/resources/templates/fragments/nav.html
@@ -86,7 +86,7 @@
                               <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
                                 id="user-menu-item-0">
                                 <span class="font-bold"
-                                        th:text="${authProvider == 'fusionauth'} ? ${#authentication.principal.attributes['name']} : ${#authentication.principal.attributes['login']}">
+                                        th:text="${#authentication.principal.attributes['authProvider'] == 'fusionauth'} ? ${#authentication.principal.attributes['name']} : ${#authentication.principal.attributes['login']}">
                                 </span>
                                 </a>
                                 <!-- <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
@@ -97,7 +97,7 @@
                                     id="user-menu-item-0">My Profile</a>
                                 <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
                                     id="user-menu-item-1">Settings</a> -->
-                               <form th:if="${authProvider == 'fusionauth'}" action="/logout" method="get">
+                               <form th:if="${#authentication.principal.attributes['authProvider'] == 'fusionauth'}" action="/logout" method="get">
                                 <button type="submit"
                                     class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                                     role="menuitem" tabindex="-1" id="user-menu-item-2">

--- a/hub-prime/src/main/resources/templates/page/home.html
+++ b/hub-prime/src/main/resources/templates/page/home.html
@@ -57,12 +57,12 @@
                     <div>
                         You're logged in as 
                         <span class="font-bold"
-                            th:text="${authProvider == 'fusionauth' ? 
+                            th:text="${#authentication.principal.attributes['authProvider'] == 'fusionauth' ? 
                                         #authentication.principal.attributes['name'] : 
                                         #authentication.principal.attributes['login']}">
                         </span>
                         with role 
-                        <code th:text="${authProvider == 'fusionauth' ? 
+                        <code th:text="${#authentication.principal.attributes['authProvider'] == 'fusionauth' ? 
                                         #strings.listJoin(#authentication.principal.attributes['role'], ', ') : 
                                         'admin'}">
                         </code>.


### PR DESCRIPTION
- Refactor authentication logic to use principal.attributes['authProvider'] as the source of truth instead of authProvider. This resolves issues with missing logout button, incorrect username, and inconsistent behavior across pages. #1687 