### PR TITLE
feat: enhance session management for dynamic timeout per auth provider #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
@@ -89,10 +89,18 @@ public class SecurityConfig {
                                 .logoutSuccessHandler(customLogoutSuccessHandler())
                                 .permitAll())
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(
-                        sessionManagement -> sessionManagement
-                                .invalidSessionUrl(Constant.SESSION_TIMEOUT_URL)
-                                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+                .sessionManagement(sessionManagement -> {
+            // Dynamically adjust session timeout behavior based on the authentication provider
+                        if ("github".equalsIgnoreCase(authProvider)) {
+                            sessionManagement
+                                    .invalidSessionUrl(Constant.SESSION_TIMEOUT_URL)
+                                    .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED);
+                        } else if ("fusionauth".equalsIgnoreCase(authProvider)) {
+                            sessionManagement
+                                    .invalidSessionUrl(fusionAuthLogoutUUrl())  // Use custom logout handler for FusionAuth
+                                    .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED);
+                        }
+                    });
                   if (fusionAuthAuthorizationFilter != null) {
                         http.addFilterAfter(fusionAuthAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
                     }
@@ -161,13 +169,14 @@ public class SecurityConfig {
                 if (authentication != null) {
                     new SecurityContextLogoutHandler().logout(request, response, authentication);
                 }
-
-                String fusionAuthLogoutUrl = fusionAuthBaseUrl + "/oauth2/logout"
-                        + "?client_id=" + clientId
-                        + "&post_logout_redirect_uri=" + logoutRedirectUrl;
-
-                response.sendRedirect(fusionAuthLogoutUrl);
+                response.sendRedirect(fusionAuthLogoutUUrl());
             };
+        }
+
+        private String fusionAuthLogoutUUrl() {
+            return fusionAuthBaseUrl + "/oauth2/logout"
+                    + "?client_id=" + clientId
+                    + "&post_logout_redirect_uri=" + logoutRedirectUrl;
         }
 
     /**

--- a/hub-prime/src/main/resources/application.yml
+++ b/hub-prime/src/main/resources/application.yml
@@ -109,7 +109,7 @@ server:
         secure: true
         http-only: true
         same-site: LAX
-      timeout: 60m
+      timeout: 5m
 
 org:
   techbd:

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1086.0</revision>
+        <revision>0.1087.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
### Summary
Enhances session management to dynamically set session timeout and invalid session handling based on the active authentication provider. #1687 

### Changes
- Configured `sessionManagement` to redirect to GitHub timeout URL or FusionAuth logout URL based on `AUTH_PROVIDER`.
