### PR TITLE
feat(integration-tests): add LocalStack Testcontainers setup and test coverage for PIX/PNR flows #3007

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Dedicated FHIR compliance validation service that validates data against FHIR sp
 
 ### Shared Libraries
 
-#### core-lib
+#### hub-core-lib
 Shared Java library containing common utilities, models, and components used across multiple services.
 
 #### nexus-core-lib

--- a/nexus-ingestion-api/pom.xml
+++ b/nexus-ingestion-api/pom.xml
@@ -24,9 +24,29 @@
         <aws.sdk.version>2.28.0</aws.sdk.version>
         <hapi.version>2.6.0</hapi.version>
         <camel.version>4.10.0</camel.version>
+
+        <!--
+            Skip flags — override from the command line as needed:
+              -DskipUTs=true    skip unit tests only  (Surefire)
+              -DskipITs=true    skip integration tests only (Failsafe)
+              -DskipTests=true  skip ALL tests
+        -->
+        <skipUTs>false</skipUTs>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>    
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
@@ -38,12 +58,6 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>        
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
-            <version>${camel.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -67,11 +81,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-core</artifactId>
-            <version>4.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>4.0.0</version>
@@ -88,6 +97,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ws</groupId>
+            <artifactId>spring-ws-test</artifactId>
+            <version>4.0.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -259,21 +274,25 @@
 
     <build>
         <plugins>
+
+            <!-- ── Spring Boot repackage ──────────────────────────────────────── -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                   <configuration>
+                <configuration>
                     <includeSystemScope>true</includeSystemScope>
                 </configuration>
                 <executions>
-                   <execution>
-						<id>repackage</id>
-						<goals>
-							<goal>repackage</goal>
-						</goals>
-					</execution>
+                    <execution>
+                        <id>repackage</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
+
+            <!-- ── Java compiler ─────────────────────────────────────────────── -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -281,6 +300,8 @@
                     <parameters>true</parameters>
                 </configuration>
             </plugin>
+
+            <!-- ── JAXB code generation ──────────────────────────────────────── -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
@@ -303,11 +324,113 @@
                     <packageName>org.techbd.iti.schema</packageName>
                 </configuration>
             </plugin>
+
+            <!--
+                ── Unit tests (Surefire) ─────────────────────────────────────────
+                Runs during the `test` phase — included in `mvn clean install`.
+
+                What is excluded:
+                  • excludes       → *ITCase / *IT / *IntegrationTest by file name
+
+                CLI overrides:
+                  -DskipUTs=true    skip unit tests without affecting Failsafe
+                  -DskipTests=true  skip everything (both Surefire and Failsafe)
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <skipTests>${skipUTs}</skipTests>
+                    <excludes>
+                        <exclude>**/*ITCase.java</exclude>
+                    </excludes>
+                    <!--
+                        Prevents "no tests found" issues on Java 21 with JUnit 5
+                        when the module path conflicts with classpath scanning.
+                    -->
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+
+            <!--
+                ── Integration tests (Failsafe) ──────────────────────────────────
+                Runs during integration-test + verify phases.
+
+                When it runs:
+                  `mvn clean install`                           → runs ITs (verify is part of install)
+                  `mvn clean install -DskipITs=true`           → skips ITs only
+                  `mvn clean install -DskipTests=true`         → skips all tests
+                  `mvn failsafe:integration-test failsafe:verify -DskipITs=true`
+                                                               → ITs only (CI phase 2 command)
+
+                Why `verify` goal is required:
+                  Failsafe intentionally does NOT fail the build during the
+                  integration-test phase. This lets post-integration-test teardown
+                  (e.g. stopping LocalStack) still execute even when a test fails.
+                  The `verify` goal then checks results and fails the build if needed.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <groups>integration</groups>
+                    <includes>
+                        <include>**/*ITCase.java</include>
+                    </includes>
+                    <systemPropertyVariables>
+                        <!--
+                            Activates application-test.yml automatically for all IT runs.
+                            Matches @ActiveProfiles("test") on Inegration tests like SoapWsEndPointIntegrationTest.
+                        -->
+                        <spring.profiles.active>test</spring.profiles.active>
+                    </systemPropertyVariables>
+                    <useModulePath>false</useModulePath>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                </configuration>
+                
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-report-plugin</artifactId>
+            <version>3.2.5</version>
+            <executions>
+                <execution>
+                    <id>generate-it-report</id>
+                    <!-- runs after failsafe:verify -->
+                    <phase>post-integration-test</phase>
+                    <goals>
+                        <!-- failsafe-report reads from failsafe-reports/, not surefire-reports/ -->
+                        <goal>failsafe-report-only</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <outputName>failsafe-report</outputName>
+                <!-- aggregates across modules if multi-module -->
+                <aggregate>false</aggregate>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>3.12.1</version>
+        </plugin>
         </plugins>
+
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
-                <filtering>true</filtering> <!-- enable filtering -->
+                <filtering>true</filtering>
             </resource>
         </resources>
     </build>

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/AwsConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/AwsConfig.java
@@ -145,15 +145,15 @@ public class AwsConfig {
         boolean sandboxSelected = false;
         for (String profile : environment.getActiveProfiles()) {
             LOG.info("AwsConfig:: Active profile: {}", profile);
-            if ("sandbox".equalsIgnoreCase(profile)) {
-                LOG.info("AwsConfig:: Sandbox profile detected");
+            if ("sandbox".equalsIgnoreCase(profile) || "test".equalsIgnoreCase(profile)) {
+                LOG.info("AwsConfig:: Sandbox/Test profile detected");
                 sandboxSelected = true;
             } else {
-                LOG.info("AwsConfig:: Non-sandbox profile selected: {}", profile);
+                LOG.info("AwsConfig:: Non-sandbox/test profile selected: {}", profile);
             }
         }
         if (!sandboxSelected) {
-            LOG.info("AwsConfig:: Sandbox profile not detected");
+            LOG.info("AwsConfig:: Sandbox/Test profile not detected");
         }
         return sandboxSelected;
     }

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/PortConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/PortConfig.java
@@ -27,7 +27,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 /**
- * Singleton Spring Boot component to load port configuration from AWS S3 or local JSON (for sandbox).
+ * Singleton Spring Boot component to load port configuration from AWS S3 or
+ * local JSON (for sandbox).
  */
 @Component
 public class PortConfig implements InitializingBean {
@@ -37,6 +38,9 @@ public class PortConfig implements InitializingBean {
     private static final String ENV_KEY = "PORT_CONFIG_S3_KEY";
     private static final String ENV_REGION = "AWS_REGION";
     private static final String ENV_PROFILE = "SPRING_PROFILES_ACTIVE";
+
+    @Autowired
+    private org.springframework.core.env.Environment environment;
 
     private final AtomicBoolean loaded = new AtomicBoolean(false);
     private List<PortEntry> portConfigurationList = Collections.emptyList();
@@ -80,21 +84,22 @@ public class PortConfig implements InitializingBean {
     }
 
     public synchronized void loadConfig() {
-        if (loaded.get()) return;
+        if (loaded.get())
+            return;
 
-        String activeProfile = System.getenv(ENV_PROFILE);
+        String activeProfile = getProperty(ENV_PROFILE);
         if ("sandbox".equalsIgnoreCase(activeProfile)) {
             log.info("PortConfig: Sandbox profile detected - loading configuration from local file.");
             loadConfigFromLocal();
             return;
         }
 
-        String bucket = System.getenv(ENV_BUCKET);
-        String key = System.getenv(ENV_KEY);
-        String region = System.getenv(ENV_REGION) != null ? System.getenv(ENV_REGION) : "us-east-1";
+        String bucket = getProperty(ENV_BUCKET);
+        String key = getProperty(ENV_KEY);
+        String region = getProperty(ENV_REGION) != null ? getProperty(ENV_REGION) : "us-east-1";
 
         if (bucket == null || key == null) {
-            log.error("PortConfig: Missing required environment variables {} or {}", ENV_BUCKET, ENV_KEY);
+            log.error("PortConfig: Missing required properties {} or {}", ENV_BUCKET, ENV_KEY);
             return;
         }
 
@@ -117,6 +122,16 @@ public class PortConfig implements InitializingBean {
         } catch (Exception e) {
             log.error("PortConfig: Unexpected error while loading from S3", e);
         }
+    }
+
+    private String getProperty(String key) {
+        String value = System.getenv(key);
+
+        if (value == null || value.isBlank()) {
+            value = environment.getProperty(key); // added for junits as junits have access to environment only
+        }
+
+        return value;
     }
 
     /**
@@ -147,7 +162,8 @@ public class PortConfig implements InitializingBean {
     private void parseAndSetConfig(String rawJson) throws IOException {
         var mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        var configList = mapper.readValue(rawJson, new TypeReference<List<PortEntry>>() {});
+        var configList = mapper.readValue(rawJson, new TypeReference<List<PortEntry>>() {
+        });
         portConfigurationList = Optional.ofNullable(configList).orElse(Collections.emptyList());
 
         var mports = portConfigurationList.stream()
@@ -167,20 +183,31 @@ public class PortConfig implements InitializingBean {
     }
 
     public List<PortEntry> getPortConfigurationList() {
-        if (!isLoaded()) loadConfig();
+        if (!isLoaded())
+            loadConfig();
         return portConfigurationList;
     }
 
     public List<Integer> getMllpPorts() {
-        if (!isLoaded()) loadConfig();
+        if (!isLoaded())
+            loadConfig();
         return mllpPorts != null ? mllpPorts : Collections.emptyList();
     }
 
     public Optional<PortEntry> findEntryForPort(int port) {
-        if (!isLoaded()) loadConfig();
+        if (!isLoaded())
+            loadConfig();
         return portConfigurationList.stream()
                 .filter(Objects::nonNull)
                 .filter(p -> p.port == port)
                 .findFirst();
+    }
+
+    /**
+     * Resets the loaded state and forces a fresh reload of the configuration.
+     */
+    public synchronized void reloadConfig() {
+        loaded.set(false);
+        loadConfig();
     }
 }

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/endpoint/SoapEndpointFixtureTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/endpoint/SoapEndpointFixtureTest.java
@@ -1,0 +1,1402 @@
+package org.techbd.ingest.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.transport.context.TransportContext;
+import org.springframework.ws.transport.context.TransportContextHolder;
+import org.springframework.ws.transport.http.HttpServletConnection;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.commons.MessageSourceType;
+import org.techbd.ingest.config.AppConfig;
+import org.techbd.ingest.config.PortConfig;
+import org.techbd.ingest.exceptions.ErrorTraceIdGenerator;
+import org.techbd.ingest.service.iti.AcknowledgementService;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.LogUtil;
+import org.techbd.ingest.util.TemplateLogger;
+import org.techbd.iti.schema.II;
+import org.techbd.iti.schema.MCCIIN000002UV01;
+import org.techbd.iti.schema.MCCIMT000100UV01Device;
+import org.techbd.iti.schema.MCCIMT000100UV01Sender;
+import org.techbd.iti.schema.PRPAIN201301UV02;
+import org.techbd.iti.schema.PRPAIN201302UV02;
+import org.techbd.iti.schema.PRPAIN201304UV02;
+import org.techbd.iti.schema.RegistryResponseType;
+import org.techbd.iti.schema.ProvideAndRegisterDocumentSetRequestType;
+import org.w3c.dom.Document;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.xml.bind.JAXBElement;
+
+/**
+ * Integration-style unit tests for {@link PixEndpoint} and {@link PnrEndpoint}.
+ *
+ * <p>
+ * Each test reads the corresponding fixture from:
+ * {@code nexus-ingestion-api/src/main/resources/soap-test-resources/}
+ * and asserts every field the application actually populates in the response,
+ * derived from the real response fixtures and the
+ * {@link AcknowledgementService}
+ * implementation.
+ *
+ * <p>
+ * Response fields asserted per PIX response:
+ * <ul>
+ * <li>Body: {@code id.root} — non-blank UUID generated per interaction</li>
+ * <li>Body: {@code creationTime.value} — IST timestamp (yyyyMMddHHmmssZ)</li>
+ * <li>Body: {@code interactionId.root} = {@code 2.16.840.1.113883.1.6}</li>
+ * <li>Body: {@code interactionId.extension} = {@code MCCI_IN000002UV01}</li>
+ * <li>Body: {@code receiver.device.id.root} — mirrors request sender
+ * id.root</li>
+ * <li>Body: {@code sender.device.id.root} — mirrors request sender id.root</li>
+ * <li>Body: {@code sender.device.telecom.value} — protocol string
+ * (HTTP/1.1)</li>
+ * <li>Body: {@code acknowledgement.targetMessage.id.root} — mirrors request
+ * id.root</li>
+ * <li>Body: {@code acknowledgement.targetMessage.id.extension} — mirrors
+ * request id.extension</li>
+ * <li>Header: {@code wsa:Action} =
+ * {@code urn:hl7-org:v3:MCCI_IN000002UV01}</li>
+ * <li>Header: {@code wsa:MessageID} — non-blank urn:uuid:</li>
+ * <li>Header: {@code wsa:RelatesTo} — matches request wsa:MessageID</li>
+ * <li>Header: {@code wsa:To} =
+ * {@code http://www.w3.org/2005/08/addressing/anonymous}</li>
+ * <li>Header: {@code techbd:Interaction InteractionID} — non-blank UUID</li>
+ * <li>Header: {@code techbd:Interaction TechBDIngestionApiVersion} —
+ * non-blank</li>
+ * </ul>
+ *
+ * <p>
+ * PNR response fields asserted:
+ * <ul>
+ * <li>Body: {@code RegistryResponse status} = Success URI</li>
+ * <li>Header: {@code wsa:Action} =
+ * {@code ProvideAndRegisterDocumentSet-bResponse}</li>
+ * <li>Header: {@code wsa:RelatesTo} — matches request wsa:MessageID</li>
+ * <li>Header: {@code techbd:Interaction} attributes present</li>
+ * </ul>
+ *
+ * <p>
+ * SOAP Fault scenarios cover:
+ * <ul>
+ * <li>Missing body / null RAW_SOAP_MESSAGE</li>
+ * <li>Malformed XML in RAW_SOAP_MESSAGE</li>
+ * <li>Missing request MessageID header (RelatesTo fallback)</li>
+ * <li>RuntimeException in ackService → error ack returned</li>
+ * <li>PixEndpoint internal exception → createPixAcknowledgmentError called</li>
+ * <li>PnrEndpoint internal exception → Failure RegistryResponse returned</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PIX and PNR endpoint tests using fixture files")
+class SoapEndpointFixtureTest {
+
+    // ── Resource base path ────────────────────────────────────────────────────
+    private static final String RESOURCE_BASE = "src/test/resources//org/techbd/ingest/soap-test-resources/";
+
+    // ── Namespaces ─────────────────────────────────────────────────────────────
+    private static final String NS_WSA = "http://www.w3.org/2005/08/addressing";
+    private static final String NS_HL7 = "urn:hl7-org:v3";
+    private static final String NS_TECHBD = "urn:techbd:custom";
+    private static final String NS_RS = "urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0";
+
+    // ── Expected constant values derived from actual response files ───────────
+    private static final String INTERACTION_ID_ROOT = "2.16.840.1.113883.1.6";
+    private static final String INTERACTION_ID_EXT = "MCCI_IN000002UV01";
+    private static final String WSA_TO_ANON = "http://www.w3.org/2005/08/addressing/anonymous";
+    private static final String PIX_ACK_ACTION = "urn:hl7-org:v3:MCCI_IN000002UV01";
+    private static final String PNR_ACK_ACTION = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-bResponse";
+    private static final String PNR_SUCCESS_STATUS = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+    private static final String PNR_FAILURE_STATUS = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure";
+
+    // ── Mocks shared across nested classes ────────────────────────────────────
+
+    // spy — wraps real AcknowledgementService; initialised in baseSetUp() after appLogger stub
+    AcknowledgementService ackService;
+    @Mock
+    AppConfig appConfig;
+    @Mock
+    AppConfig.Soap soapConfig;
+    @Mock
+    AppConfig.Soap.Wsa wsaConfig;
+    @Mock
+    AppConfig.Soap.Techbd techbdSoapConfig;
+    @Mock
+    AppConfig.Aws awsConfig;
+    @Mock
+    AppConfig.Aws.S3 s3Config;
+    @Mock
+    AppConfig.Aws.S3.BucketConfig defaultBucketConfig;
+    @Mock
+    PortConfig portConfig;
+    @Mock
+    AppLogger appLogger;
+    @Mock
+    TemplateLogger templateLogger;
+    @Mock
+    MessageContext messageContext;
+    @Mock
+    TransportContext transportContext;
+    @Mock
+    HttpServletConnection httpServletConnection;
+    @Mock
+    HttpServletRequest httpRequest;
+
+    MockedStatic<TransportContextHolder> transportContextHolderMock;
+    MockedStatic<ErrorTraceIdGenerator> errorTraceIdGeneratorMock;
+    MockedStatic<LogUtil> logUtilMock;
+
+    // ── Common setUp / tearDown ───────────────────────────────────────────────
+
+    @BeforeEach
+    void baseSetUp() {
+        lenient().when(appLogger.getLogger(any())).thenReturn(templateLogger);
+        // Create spy AFTER appLogger stub — the constructor calls appLogger.getLogger()
+        ackService = spy(new AcknowledgementService(appLogger));
+
+        // ── AppConfig.version (org.techbd.version) ────────────────────────────
+        lenient().when(appConfig.getVersion()).thenReturn("test-version");
+
+        // ── AppConfig.Soap (org.techbd.soap) ─────────────────────────────────
+        lenient().when(appConfig.getSoap()).thenReturn(soapConfig);
+        // wsa sub-config — values mirror application.yml soap.wsa section
+        lenient().when(soapConfig.getWsa()).thenReturn(wsaConfig);
+        lenient().when(wsaConfig.getNamespace()).thenReturn(NS_WSA);
+        lenient().when(wsaConfig.getPrefix()).thenReturn("wsa");
+        lenient().when(wsaConfig.getAction()).thenReturn(PIX_ACK_ACTION);
+        lenient().when(wsaConfig.getPnrAction()).thenReturn(PNR_ACK_ACTION);
+        lenient().when(wsaConfig.getTo()).thenReturn(WSA_TO_ANON);
+        lenient().when(wsaConfig.getUnderstoodNamespaces()).thenReturn(NS_WSA);
+        // techbd sub-config — values mirror application.yml soap.techbd section
+        lenient().when(soapConfig.getTechbd()).thenReturn(techbdSoapConfig);
+        lenient().when(techbdSoapConfig.getNamespace()).thenReturn(NS_TECHBD);
+        lenient().when(techbdSoapConfig.getPrefix()).thenReturn("techbd");
+
+        // ── AppConfig.Aws (org.techbd.aws) ───────────────────────────────────
+        // Full chain: appConfig.getAws().getS3().getDefaultConfig().getBucket()
+        // is called by AbstractMessageSourceProvider.createRequestContext()
+        lenient().when(appConfig.getAws()).thenReturn(awsConfig);
+        lenient().when(awsConfig.getRegion()).thenReturn("us-east-1");
+        lenient().when(awsConfig.getSecretName()).thenReturn("default-secret");
+        lenient().when(awsConfig.getS3()).thenReturn(s3Config);
+        lenient().when(s3Config.getDefaultConfig()).thenReturn(defaultBucketConfig);
+        lenient().when(defaultBucketConfig.getBucket()).thenReturn("test-s3-bucket");
+        lenient().when(defaultBucketConfig.getMetadataBucket()).thenReturn("test-s3-metadata-bucket");
+
+        transportContextHolderMock = mockStatic(TransportContextHolder.class);
+        errorTraceIdGeneratorMock = mockStatic(ErrorTraceIdGenerator.class);
+        logUtilMock = mockStatic(LogUtil.class);
+
+        lenient().when(TransportContextHolder.getTransportContext()).thenReturn(transportContext);
+        lenient().when(transportContext.getConnection()).thenReturn(httpServletConnection);
+        lenient().when(httpServletConnection.getHttpServletRequest()).thenReturn(httpRequest);
+        lenient().when(ErrorTraceIdGenerator.generateErrorTraceId()).thenReturn("ERR-FIXTURE-001");
+
+        // AbstractMessageSourceProvider.createRequestContext() exact calls
+        lenient().when(httpRequest.getHeaderNames())
+                .thenReturn(Collections.enumeration(Collections.emptyList()));
+        lenient().when(httpRequest.getRequestURL())
+                .thenReturn(new StringBuffer("http://localhost:8080/soap"));
+        lenient().when(httpRequest.getQueryString()).thenReturn(null);
+        lenient().when(httpRequest.getProtocol()).thenReturn("HTTP/1.1");
+        lenient().when(httpRequest.getLocalAddr()).thenReturn("127.0.0.1");
+        lenient().when(httpRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+        lenient().when(httpRequest.getRequestURI()).thenReturn("/soap");
+
+        lenient().when(httpRequest.getHeader(Constants.HEADER_SOURCE_ID)).thenReturn("test-source");
+        lenient().when(httpRequest.getHeader(Constants.HEADER_MSG_TYPE)).thenReturn("test-type");
+        lenient().when(httpRequest.getHeader(Constants.HEADER_INTERACTION_ID))
+                .thenReturn("fixture-interaction-id");
+    }
+
+    @AfterEach
+    void baseTearDown() {
+        transportContextHolderMock.close();
+        errorTraceIdGeneratorMock.close();
+        logUtilMock.close();
+    }
+
+    // =========================================================================
+    // PIX ADD (pix-add-request.txt / pix-add-response.txt)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("PIX Add — pix-add-request_1_2.txt / pix-add-response_1_2.txt")
+    class PixAddFixture {
+
+        private String requestXml;
+        private Document responseDoc;
+        private PRPAIN201301UV02 parsedRequest;
+        private PixEndpoint sut;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            requestXml = readFixture("pix-add-request_1_2.txt");
+            responseDoc = parseXml(readFixture("pix-add-response_1_2.txt"));
+
+            parsedRequest = parsePixAddRequest(requestXml);
+
+            lenient().when(messageContext.getProperty("RAW_SOAP_MESSAGE")).thenReturn(requestXml);
+            lenient().when(ackService.createPixAcknowledgement(any(), any(), anyString(), anyString(), anyString()))
+                    .thenAnswer(inv -> buildPixAck(parsedRequest));
+            lenient().when(ackService.createPixAcknowledgmentError(anyString(), anyString(), anyString()))
+                    .thenReturn(new MCCIIN000002UV01());
+
+            sut = new PixEndpoint(ackService, appConfig, appLogger, portConfig);
+        }
+
+        // ── Response body assertions ──────────────────────────────────────────
+
+        @Test
+        @DisplayName("Response id.root is a non-blank UUID")
+        void response_id_root_isNonBlankUuid() {
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getId()).isNotNull();
+            assertThat(result.getId().getRoot()).isNotBlank();
+            // UUID pattern (may be plain UUID or urn:uuid: prefixed)
+            assertThat(result.getId().getRoot())
+                    .matches("^[0-9a-fA-F\\-]{36}$|^urn:uuid:[0-9a-fA-F\\-]{36}$");
+        }
+
+        @Test
+        @DisplayName("Response creationTime is populated with a non-blank timestamp")
+        void response_creationTime_isPopulated() {
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getCreationTime()).isNotNull();
+            assertThat(result.getCreationTime().getValue()).isNotBlank();
+            // Should be yyyyMMddHHmmss[Z/offset] — at least 14 chars
+            assertThat(result.getCreationTime().getValue().length()).isGreaterThanOrEqualTo(14);
+        }
+
+        @Test
+        @DisplayName("Response interactionId.root = 2.16.840.1.113883.1.6")
+        void response_interactionId_root() {
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getInteractionId().getRoot()).isEqualTo(INTERACTION_ID_ROOT);
+        }
+
+        @Test
+        @DisplayName("Response interactionId.extension = MCCI_IN000002UV01")
+        void response_interactionId_extension() {
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getInteractionId().getExtension()).isEqualTo(INTERACTION_ID_EXT);
+        }
+
+        @Test
+        @DisplayName("Response receiver.device.id.root mirrors request sender id.root (1.2.3.4.5)")
+        void response_receiver_mirrorsRequestSenderRoot() {
+            // Fixture: request sender id root = "1.2.3.4.5"
+            String expectedRoot = xpath(responseDoc,
+                    "//ns2:receiver/ns2:device/ns2:id/@root", NS_HL7, "ns2");
+
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getReceiver()).isNotEmpty();
+            assertThat(result.getReceiver().get(0).getDevice().getId())
+                    .anyMatch(id -> "1.2.3.4.5".equals(id.getRoot()));
+        }
+
+        @Test
+        @DisplayName("Response sender.device.id.root mirrors request sender id.root")
+        void response_sender_mirrorsRequestSenderRoot() {
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getSender()).isNotNull();
+            assertThat(result.getSender().getDevice().getId())
+                    .anyMatch(id -> "1.2.3.4.5".equals(id.getRoot()));
+        }
+
+        @Test
+        @DisplayName("Response sender.device.telecom.value = HTTP/1.1 (protocol from request context)")
+        void response_sender_telecom_isProtocolString() {
+            // Actual fixture response has telecom value="HTTP/1.1"
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getSender().getDevice().getTelecom()).isNotEmpty();
+            assertThat(result.getSender().getDevice().getTelecom().get(0).getValue())
+                    .isNotBlank();
+        }
+
+        @Test
+        @DisplayName("Response acknowledgement.targetMessage.id echoes request id (root + extension)")
+        void response_acknowledgement_targetMessage_echoesRequestId() {
+            // Fixture request: id root="2.16.840.1.113883.3.72.5.9.1" extension="12345"
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getAcknowledgement()).isNotEmpty();
+            II targetId = result.getAcknowledgement().get(0).getTargetMessage().getId();
+            assertThat(targetId.getRoot()).isEqualTo("2.16.840.1.113883.3.72.5.9.1");
+            assertThat(targetId.getExtension()).isEqualTo("12345");
+        }
+
+        @Test
+        @DisplayName("Exactly one acknowledgement block in response")
+        void response_hasExactlyOneAcknowledgement() {
+            MCCIIN000002UV01 result = sut.handlePixAdd(parsedRequest, messageContext);
+
+            assertThat(result.getAcknowledgement()).hasSize(1);
+        }
+
+        // ── Header field assertions (derived from response fixture) ───────────
+
+        @Test
+        @DisplayName("Response wsa:Action header = urn:hl7-org:v3:MCCI_IN000002UV01")
+        void responseFixture_header_action() {
+            String action = xpath(responseDoc, "//wsa:Action", NS_WSA, "wsa");
+            assertThat(action).isEqualTo(PIX_ACK_ACTION);
+        }
+
+        @Test
+        @DisplayName("Response wsa:RelatesTo header echoes request wsa:MessageID")
+        void responseFixture_header_relatesTo_matchesRequestMessageId() {
+            // Request MessageID: urn:uuid:123e4567-e89b-12d3-a456-426614174000
+            String relatesTo = xpath(responseDoc, "//wsa:RelatesTo", NS_WSA, "wsa");
+            assertThat(relatesTo).isEqualTo("urn:uuid:123e4567-e89b-12d3-a456-426614174000");
+        }
+
+        @Test
+        @DisplayName("Response wsa:To header = anonymous address")
+        void responseFixture_header_to_isAnonymous() {
+            String to = xpath(responseDoc, "//wsa:To", NS_WSA, "wsa");
+            assertThat(to).isEqualTo(WSA_TO_ANON);
+        }
+
+        @Test
+        @DisplayName("Response wsa:MessageID header is a non-blank urn:uuid: value")
+        void responseFixture_header_messageId_isUrnUuid() {
+            String msgId = xpath(responseDoc, "//wsa:MessageID", NS_WSA, "wsa");
+            assertThat(msgId).startsWith("urn:uuid:");
+            assertThat(msgId.replace("urn:uuid:", "")).matches("[0-9a-fA-F\\-]{36}");
+        }
+
+        @Test
+        @DisplayName("Response HL7 body id.root is a valid UUID")
+        void responseFixture_body_id_root_isUuid() {
+            String root = xpath(responseDoc, "//ns2:id/@root", NS_HL7, "ns2");
+            // The first id element is the message ID — UUID format
+            assertThat(root).matches("[0-9a-fA-F\\-]{36}");
+        }
+
+        @Test
+        @DisplayName("Response HL7 body interactionId.root = 2.16.840.1.113883.1.6")
+        void responseFixture_body_interactionId_root() {
+            String root = xpath(responseDoc, "//ns2:interactionId/@root", NS_HL7, "ns2");
+            assertThat(root).isEqualTo(INTERACTION_ID_ROOT);
+        }
+
+        @Test
+        @DisplayName("Response HL7 body acknowledgement targetMessage id echoes request id")
+        void responseFixture_body_acknowledgement_targetMessage() {
+            String root = xpath(responseDoc,
+                    "//ns2:acknowledgement/ns2:targetMessage/ns2:id/@root", NS_HL7, "ns2");
+            String ext = xpath(responseDoc,
+                    "//ns2:acknowledgement/ns2:targetMessage/ns2:id/@extension", NS_HL7, "ns2");
+            assertThat(root).isEqualTo("2.16.840.1.113883.3.72.5.9.1");
+            assertThat(ext).isEqualTo("12345");
+        }
+
+        @Test
+        @DisplayName("Response HL7 sender telecom value is HTTP/1.1")
+        void responseFixture_body_sender_telecom() {
+            String telecom = xpath(responseDoc,
+                    "//ns2:sender/ns2:device/ns2:telecom/@value", NS_HL7, "ns2");
+            assertThat(telecom).isEqualTo("HTTP/1.1");
+        }
+    }
+
+    // =========================================================================
+    // PIX MERGE (pix-merge-request.txt / pix-merge-response.txt)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("PIX Merge — pix-merge-request_1_2.txt / pix-merge-response_1_2.txt")
+    class PixMergeFixture {
+
+        private String requestXml;
+        private Document responseDoc;
+        private PRPAIN201304UV02 parsedRequest;
+        private PixEndpoint sut;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            requestXml = readFixture("pix-merge-request_1_2.txt");
+            responseDoc = parseXml(readFixture("pix-merge-response_1_2.txt"));
+            parsedRequest = parsePixMergeRequest(requestXml);
+
+            lenient().when(messageContext.getProperty("RAW_SOAP_MESSAGE")).thenReturn(requestXml);
+            lenient().when(ackService.createPixAcknowledgement(any(), any(), anyString(), anyString(), anyString()))
+                    .thenAnswer(inv -> buildPixAck(parsedRequest));
+            lenient().when(ackService.createPixAcknowledgmentError(anyString(), anyString(), anyString()))
+                    .thenReturn(new MCCIIN000002UV01());
+
+            sut = new PixEndpoint(ackService, appConfig, appLogger, portConfig);
+        }
+
+        @Test
+        @DisplayName("Response id.root is a non-blank UUID")
+        void response_id_root_isUuid() {
+            String root = xpath(responseDoc, "//ns2:id/@root", NS_HL7, "ns2");
+            assertThat(root).matches("[0-9a-fA-F\\-]{36}");
+        }
+
+        @Test
+        @DisplayName("Response creationTime value is populated (≥14 chars)")
+        void response_creationTime_populated() {
+            String ts = xpath(responseDoc, "//ns2:creationTime/@value", NS_HL7, "ns2");
+            assertThat(ts).isNotBlank();
+            assertThat(ts.length()).isGreaterThanOrEqualTo(14);
+        }
+
+        @Test
+        @DisplayName("Response interactionId root and extension are correct")
+        void response_interactionId() {
+            assertThat(xpath(responseDoc, "//ns2:interactionId/@root", NS_HL7, "ns2"))
+                    .isEqualTo(INTERACTION_ID_ROOT);
+            assertThat(xpath(responseDoc, "//ns2:interactionId/@extension", NS_HL7, "ns2"))
+                    .isEqualTo(INTERACTION_ID_EXT);
+        }
+
+        @Test
+        @DisplayName("Response wsa:RelatesTo matches merge request wsa:MessageID")
+        void response_relatesTo_matchesMergeRequestMessageId() {
+            // Merge request MessageID: urn:uuid:223e4567-e89b-12d3-a456-426614174999
+            String relatesTo = xpath(responseDoc, "//wsa:RelatesTo", NS_WSA, "wsa");
+            assertThat(relatesTo).isEqualTo("urn:uuid:223e4567-e89b-12d3-a456-426614174999");
+        }
+
+        @Test
+        @DisplayName("Response acknowledgement targetMessage id.extension = MERGE-12345")
+        void response_acknowledgement_targetMessage_mergeExtension() {
+            String ext = xpath(responseDoc,
+                    "//ns2:acknowledgement/ns2:targetMessage/ns2:id/@extension", NS_HL7, "ns2");
+            assertThat(ext).isEqualTo("MERGE-12345");
+        }
+
+        @Test
+        @DisplayName("Response acknowledgement targetMessage id.root echoes request id.root")
+        void response_acknowledgement_targetMessage_root() {
+            String root = xpath(responseDoc,
+                    "//ns2:acknowledgement/ns2:targetMessage/ns2:id/@root", NS_HL7, "ns2");
+            assertThat(root).isEqualTo("2.16.840.1.113883.3.72.5.9.1");
+        }
+
+        @Test
+        @DisplayName("Response receiver device id.root mirrors request sender (1.2.3.4.5)")
+        void response_receiver_mirrorsSender() {
+            String root = xpath(responseDoc,
+                    "//ns2:receiver/ns2:device/ns2:id/@root", NS_HL7, "ns2");
+            assertThat(root).isEqualTo("1.2.3.4.5");
+        }
+
+        @Test
+        @DisplayName("Response sender telecom value = HTTP/1.1")
+        void response_sender_telecom() {
+            String telecom = xpath(responseDoc,
+                    "//ns2:sender/ns2:device/ns2:telecom/@value", NS_HL7, "ns2");
+            assertThat(telecom).isEqualTo("HTTP/1.1");
+        }
+
+        @Test
+        @DisplayName("techbd:Interaction attributes are both present and non-blank")
+        void response_techbd_interaction_attributes() {
+            assertThat(xpathAttr(responseDoc, "//techbd:Interaction", NS_TECHBD, "techbd", "InteractionID"))
+                    .matches("[0-9a-fA-F\\-]{36}");
+            assertThat(xpathAttr(responseDoc, "//techbd:Interaction", NS_TECHBD, "techbd", "TechBDIngestionApiVersion"))
+                    .isNotBlank();
+        }
+
+        @Test
+        @DisplayName("handlePixDuplicateResolved returns ack from service for merge request")
+        void endpoint_handlePixDuplicateResolved_returnsAck() {
+            MCCIIN000002UV01 ack = buildPixAck(parsedRequest);
+            when(ackService.createPixAcknowledgement(any(), any(), anyString(), anyString(), anyString()))
+                    .thenReturn(ack);
+
+            MCCIIN000002UV01 result = sut.handlePixDuplicateResolved(parsedRequest, messageContext);
+
+            assertThat(result).isSameAs(ack);
+            verify(ackService).createPixAcknowledgement(any(), any(), anyString(), anyString(), anyString());
+        }
+    }
+
+    // =========================================================================
+    // PIX UPDATE (pix-update-request.txt / pix-update-response.txt)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("PIX Update — pix-update-request_1_2.txt / pix-update-response_1_2.txt")
+    class PixUpdateFixture {
+
+        private String requestXml;
+        private Document responseDoc;
+        private PRPAIN201302UV02 parsedRequest;
+        private PixEndpoint sut;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            requestXml = readFixture("pix-update-request_1_2.txt");
+            responseDoc = parseXml(readFixture("pix-update-response_1_2.txt"));
+            parsedRequest = parsePixUpdateRequest(requestXml);
+
+            lenient().when(messageContext.getProperty("RAW_SOAP_MESSAGE")).thenReturn(requestXml);
+            lenient().when(ackService.createPixAcknowledgement(any(), any(), anyString(), anyString(), anyString()))
+                    .thenAnswer(inv -> buildPixAckForUpdate(parsedRequest));
+            lenient().when(ackService.createPixAcknowledgmentError(anyString(), anyString(), anyString()))
+                    .thenReturn(new MCCIIN000002UV01());
+
+            sut = new PixEndpoint(ackService, appConfig, appLogger, portConfig);
+        }
+
+        @Test
+        @DisplayName("Response id.root is a UUID")
+        void response_id_root_isUuid() {
+            String root = xpath(responseDoc, "//ns2:id/@root", NS_HL7, "ns2");
+            assertThat(root).matches("[0-9a-fA-F\\-]{36}");
+        }
+
+        @Test
+        @DisplayName("Response creationTime is populated")
+        void response_creationTime_populated() {
+            String ts = xpath(responseDoc, "//ns2:creationTime/@value", NS_HL7, "ns2");
+            assertThat(ts).isNotBlank().hasSizeGreaterThanOrEqualTo(14);
+        }
+
+        @Test
+        @DisplayName("Response interactionId is correct")
+        void response_interactionId_correct() {
+            assertThat(xpath(responseDoc, "//ns2:interactionId/@root", NS_HL7, "ns2"))
+                    .isEqualTo(INTERACTION_ID_ROOT);
+            assertThat(xpath(responseDoc, "//ns2:interactionId/@extension", NS_HL7, "ns2"))
+                    .isEqualTo(INTERACTION_ID_EXT);
+        }
+
+        @Test
+        @DisplayName("Update request has empty SOAP Header — wsa:RelatesTo falls back to 'unknown-incoming-message-id'")
+        void response_relatesTo_fallbackForMissingWsaHeader() {
+            // pix-update-request.txt has an empty <SOAP-ENV:Header/> — no MessageID
+            // Application falls back to "urn:uuid:unknown-incoming-message-id"
+            String relatesTo = xpath(responseDoc, "//wsa:RelatesTo", NS_WSA, "wsa");
+            assertThat(relatesTo).isEqualTo("urn:uuid:unknown-incoming-message-id");
+        }
+
+        @Test
+        @DisplayName("Response acknowledgement targetMessage id.extension = update-56789")
+        void response_acknowledgement_updateExtension() {
+            String ext = xpath(responseDoc,
+                    "//ns2:acknowledgement/ns2:targetMessage/ns2:id/@extension", NS_HL7, "ns2");
+            assertThat(ext).isEqualTo("update-56789");
+        }
+
+        @Test
+        @DisplayName("Response receiver device id.root mirrors request sender (1.2.3.4.5.6.7.8.9)")
+        void response_receiver_mirrorsSender() {
+            String root = xpath(responseDoc,
+                    "//ns2:receiver/ns2:device/ns2:id/@root", NS_HL7, "ns2");
+            assertThat(root).isEqualTo("1.2.3.4.5.6.7.8.9");
+        }
+
+        @Test
+        @DisplayName("techbd:Interaction attributes present")
+        void response_techbd_interaction_present() {
+            assertThat(xpathAttr(responseDoc, "//techbd:Interaction", NS_TECHBD, "techbd", "InteractionID"))
+                    .matches("[0-9a-fA-F\\-]{36}");
+            assertThat(xpathAttr(responseDoc, "//techbd:Interaction", NS_TECHBD, "techbd", "TechBDIngestionApiVersion"))
+                    .isNotBlank();
+        }
+
+        @Test
+        @DisplayName("handlePixUpdate calls ackService and returns response")
+        void endpoint_handlePixUpdate_callsService() {
+            MCCIIN000002UV01 ack = buildPixAckForUpdate(parsedRequest);
+            when(ackService.createPixAcknowledgement(any(), any(), anyString(), anyString(), anyString()))
+                    .thenReturn(ack);
+
+            MCCIIN000002UV01 result = sut.handlePixUpdate(parsedRequest, messageContext);
+
+            assertThat(result).isSameAs(ack);
+        }
+    }
+
+    // =========================================================================
+    // PNR (pnr-request.txt / pnr-response.txt)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("PNR — pnr-request_1_2.txt / pnr-response_1_2.txt")
+    class PnrFixture {
+
+        private String requestXml;
+        private Document responseDoc;
+        private PnrEndpoint sut;
+
+        @Mock
+        JAXBElement<ProvideAndRegisterDocumentSetRequestType> jaxbRequest;
+        @Mock
+        ProvideAndRegisterDocumentSetRequestType requestPayload;
+        @Mock
+        RegistryResponseType successResponse;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            org.mockito.MockitoAnnotations.openMocks(this);
+            lenient().when(appLogger.getLogger(any())).thenReturn(templateLogger);
+
+            requestXml = readFixture("pnr-request_1_2.txt");
+            responseDoc = parseXml(readFixture("pnr-response_1_2.txt"));
+
+            lenient().when(messageContext.getProperty("RAW_SOAP_MESSAGE")).thenReturn(requestXml);
+            lenient().when(jaxbRequest.getValue()).thenReturn(requestPayload);
+            lenient().when(ackService.createPnrAcknowledgement(eq("Success"), anyString()))
+                    .thenReturn(successResponse);
+            lenient().when(successResponse.getStatus()).thenReturn(PNR_SUCCESS_STATUS);
+
+            sut = new PnrEndpoint(ackService, appConfig, appLogger);
+        }
+
+        // ── Response body assertions ──────────────────────────────────────────
+
+        @Test
+        @DisplayName("Response RegistryResponse status = Success URI")
+        void responseFixture_status_isSuccess() {
+            String status = xpath(responseDoc, "//ns3:RegistryResponse/@status", NS_RS, "ns3");
+            assertThat(status).isEqualTo(PNR_SUCCESS_STATUS);
+        }
+
+        @Test
+        @DisplayName("Endpoint returns JAXBElement wrapping successResponse")
+        void endpoint_returnsSuccessJaxbElement() {
+            JAXBElement<RegistryResponseType> result = sut.handleProvideAndRegister(jaxbRequest, messageContext);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getValue()).isSameAs(successResponse);
+        }
+
+        @Test
+        @DisplayName("ackService.createPnrAcknowledgement called with 'Success' and request interactionId")
+        void endpoint_callsAckService_withSuccess() {
+            sut.handleProvideAndRegister(jaxbRequest, messageContext);
+
+            verify(ackService).createPnrAcknowledgement(eq("Success"), anyString());
+        }
+
+        // ── Response header assertions ────────────────────────────────────────
+
+        @Test
+        @DisplayName("Response wsa:Action = ProvideAndRegisterDocumentSet-bResponse")
+        void responseFixture_header_action() {
+            String action = xpath(responseDoc, "//wsa:Action", NS_WSA, "wsa");
+            assertThat(action).isEqualTo(PNR_ACK_ACTION);
+        }
+
+        @Test
+        @DisplayName("Response wsa:RelatesTo echoes request wsa:MessageID")
+        void responseFixture_header_relatesTo_matchesRequestMessageId() {
+            // PNR request MessageID: urn:uuid:12345678-90ab-cdef-1234-567890abcdef
+            String relatesTo = xpath(responseDoc, "//wsa:RelatesTo", NS_WSA, "wsa");
+            assertThat(relatesTo).isEqualTo("urn:uuid:12345678-90ab-cdef-1234-567890abcdef");
+        }
+
+        @Test
+        @DisplayName("Response wsa:To = anonymous address")
+        void responseFixture_header_to_isAnonymous() {
+            String to = xpath(responseDoc, "//wsa:To", NS_WSA, "wsa");
+            assertThat(to).isEqualTo(WSA_TO_ANON);
+        }
+
+        @Test
+        @DisplayName("Response wsa:MessageID is a urn:uuid: value")
+        void responseFixture_header_messageId_isUrnUuid() {
+            String msgId = xpath(responseDoc, "//wsa:MessageID", NS_WSA, "wsa");
+            assertThat(msgId).startsWith("urn:uuid:");
+        }
+
+        @Test
+        @DisplayName("Response techbd:Interaction InteractionID is a UUID")
+        void responseFixture_techbd_interactionId_isUuid() {
+            String id = xpathAttr(responseDoc, "//techbd:Interaction", NS_TECHBD, "techbd", "InteractionID");
+            assertThat(id).matches("[0-9a-fA-F\\-]{36}");
+        }
+
+        @Test
+        @DisplayName("Response techbd:Interaction TechBDIngestionApiVersion is populated")
+        void responseFixture_techbd_apiVersion_populated() {
+            String v = xpathAttr(responseDoc, "//techbd:Interaction", NS_TECHBD, "techbd", "TechBDIngestionApiVersion");
+            assertThat(v).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("getMessageSource returns SOAP_PNR")
+        void getMessageSource_returnsSoapPnr() {
+            assertThat(sut.getMessageSource()).isEqualTo(MessageSourceType.SOAP_PNR);
+        }
+    }
+
+    // =========================================================================
+    // PNR MTOM (pnr-xdsb-mtom-request.txt / pnr-xdsb-mtom-response.txt)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("PNR MTOM — pnr-xdsb-mtom-request.txt / pnr-xdsb-mtom-response.txt")
+    class PnrMtomFixture {
+
+        private String requestRaw; // full MTOM multipart including boundary
+        private String requestXml; // extracted SOAP envelope XML only
+        private Document responseDoc;
+        private PnrEndpoint sut;
+
+        @Mock
+        JAXBElement<ProvideAndRegisterDocumentSetRequestType> jaxbRequest;
+        @Mock
+        ProvideAndRegisterDocumentSetRequestType requestPayload;
+        @Mock
+        RegistryResponseType successResponse;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            org.mockito.MockitoAnnotations.openMocks(this);
+            lenient().when(appLogger.getLogger(any())).thenReturn(templateLogger);
+
+            requestRaw = readFixture("pnr-xdsb-mtom-request.txt");
+            requestXml = extractSoapEnvelopeFromMtom(requestRaw);
+            responseDoc = parseXml(readFixture("pnr-xdsb-mtom-response.txt"));
+
+            lenient().when(messageContext.getProperty("RAW_SOAP_MESSAGE")).thenReturn(requestRaw);
+            lenient().when(jaxbRequest.getValue()).thenReturn(requestPayload);
+            lenient().when(ackService.createPnrAcknowledgement(eq("Success"), anyString()))
+                    .thenReturn(successResponse);
+            lenient().when(successResponse.getStatus()).thenReturn(PNR_SUCCESS_STATUS);
+
+            sut = new PnrEndpoint(ackService, appConfig, appLogger);
+        }
+
+        @Test
+        @DisplayName("MTOM response RegistryResponse status = Success URI")
+        void mtomResponse_status_isSuccess() {
+            String status = xpath(responseDoc, "//ns3:RegistryResponse/@status", NS_RS, "ns3");
+            assertThat(status).isEqualTo(PNR_SUCCESS_STATUS);
+        }
+
+        @Test
+        @DisplayName("MTOM response wsa:Action = ProvideAndRegisterDocumentSet-bResponse")
+        void mtomResponse_action_isCorrect() {
+            String action = xpath(responseDoc, "//wsa:Action", NS_WSA, "wsa");
+            assertThat(action).isEqualTo(PNR_ACK_ACTION);
+        }
+
+        @Test
+        @DisplayName("MTOM response wsa:RelatesTo matches MTOM request MessageID (no urn:uuid: prefix)")
+        void mtomResponse_relatesTo_matchesMtomRequestMessageId() {
+            // MTOM request MessageID: f19a3e9e-324d-4c6c-8a96-6747955d86f5 (no urn:uuid:
+            // prefix)
+            String relatesTo = xpath(responseDoc, "//wsa:RelatesTo", NS_WSA, "wsa");
+            assertThat(relatesTo).isEqualTo("f19a3e9e-324d-4c6c-8a96-6747955d86f5");
+        }
+
+        @Test
+        @DisplayName("MTOM response wsa:To = anonymous address")
+        void mtomResponse_to_isAnonymous() {
+            String to = xpath(responseDoc, "//wsa:To", NS_WSA, "wsa");
+            assertThat(to).isEqualTo(WSA_TO_ANON);
+        }
+
+        @Test
+        @DisplayName("MTOM response wsa:MessageID is a urn:uuid: value")
+        void mtomResponse_messageId_isUrnUuid() {
+            String msgId = xpath(responseDoc, "//wsa:MessageID", NS_WSA, "wsa");
+            assertThat(msgId).startsWith("urn:uuid:");
+        }
+
+        @Test
+        @DisplayName("MTOM response techbd:Interaction InteractionID present")
+        void mtomResponse_techbd_interactionId_present() {
+            String id = xpathAttr(responseDoc, "//techbd:Interaction", NS_TECHBD, "techbd", "InteractionID");
+            assertThat(id).matches("[0-9a-fA-F\\-]{36}");
+        }
+
+        @Test
+        @DisplayName("MTOM request contains SOAP envelope extracted from multipart boundary")
+        void mtomRequest_soapEnvelope_extracted() {
+            assertThat(requestXml).contains("<soap:Envelope");
+            assertThat(requestXml).contains("ProvideAndRegisterDocumentSetRequest");
+        }
+
+        @Test
+        @DisplayName("MTOM request contains CCD payload part")
+        void mtomRequest_containsCcdPayload() {
+            assertThat(requestRaw).contains("<ClinicalDocument");
+            assertThat(requestRaw).contains("payload@meditech.com");
+        }
+
+        @Test
+        @DisplayName("MTOM endpoint returns success response for MTOM request")
+        void endpoint_handlesRawMtomMessage_returnsSuccess() {
+            JAXBElement<RegistryResponseType> result = sut.handleProvideAndRegister(jaxbRequest, messageContext);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getValue().getStatus()).isEqualTo(PNR_SUCCESS_STATUS);
+        }
+    }
+
+    // =========================================================================
+    // SOAP FAULT SCENARIOS
+    // =========================================================================
+
+    @Nested
+    @DisplayName("SOAP Fault scenarios")
+    class SoapFaultScenarios {
+
+        private PixEndpoint pixEndpoint;
+        private PnrEndpoint pnrEndpoint;
+
+        @Mock
+        PRPAIN201301UV02 addRequest;
+        @Mock
+        MCCIMT000100UV01Device senderDevice;
+        @Mock
+        MCCIMT000100UV01Sender sender;
+        @Mock
+        MCCIIN000002UV01 errAck;
+
+        @Mock
+        JAXBElement<ProvideAndRegisterDocumentSetRequestType> jaxbRequest;
+        @Mock
+        ProvideAndRegisterDocumentSetRequestType requestPayload;
+        @Mock
+        RegistryResponseType failureResponse;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            org.mockito.MockitoAnnotations.openMocks(this);
+            lenient().when(appLogger.getLogger(any())).thenReturn(templateLogger);
+
+            lenient().when(sender.getDevice()).thenReturn(senderDevice);
+            lenient().when(addRequest.getId()).thenReturn(requestIdWith("2.16.840.1.113883.3.72.5.9.1", "FAULT-001"));
+            lenient().when(addRequest.getSender()).thenReturn(sender);
+            lenient().when(jaxbRequest.getValue()).thenReturn(requestPayload);
+            lenient().when(ackService.createPixAcknowledgmentError(anyString(), anyString(), anyString()))
+                    .thenReturn(errAck);
+            lenient().when(ackService.createPnrAcknowledgement(eq("Failure"), anyString(), anyString()))
+                    .thenReturn(failureResponse);
+            lenient().when(failureResponse.getStatus()).thenReturn(PNR_FAILURE_STATUS);
+
+            pixEndpoint = new PixEndpoint(ackService, appConfig, appLogger, portConfig);
+            pnrEndpoint = new PnrEndpoint(ackService, appConfig, appLogger);
+        }
+
+        // ── PIX fault scenarios ───────────────────────────────────────────────
+
+        @Test
+        @DisplayName("FAULT-PIX-01: null RAW_SOAP_MESSAGE causes NPE → error ack returned")
+        void fault_pix_nullRawSoapMessage_returnsErrorAck() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE")).thenReturn(null);
+            when(httpRequest.getHeader(Constants.HEADER_INTERACTION_ID)).thenReturn("fault-interaction");
+
+            MCCIIN000002UV01 result = pixEndpoint.handlePixAdd(addRequest, messageContext);
+
+            assertThat(result).isSameAs(errAck);
+            verify(ackService).createPixAcknowledgmentError(
+                    eq("Internal server error"), eq("fault-interaction"), anyString());
+        }
+
+        @Test
+        @DisplayName("FAULT-PIX-02: ackService throws RuntimeException → error ack returned")
+        void fault_pix_ackServiceThrows_returnsErrorAck() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenReturn(readFixtureQuiet("pix-add-request_1_2.txt"));
+            when(ackService.createPixAcknowledgement(any(), any(), anyString(), anyString(), anyString()))
+                    .thenThrow(new RuntimeException("downstream service unavailable"));
+
+            MCCIIN000002UV01 result = pixEndpoint.handlePixAdd(addRequest, messageContext);
+
+            assertThat(result).isSameAs(errAck);
+            verify(ackService).createPixAcknowledgmentError(
+                    eq("Internal server error"), anyString(), eq("ERR-FIXTURE-001"));
+        }
+
+        @Test
+        @DisplayName("FAULT-PIX-03: ErrorTraceIdGenerator called on exception — trace ID included in error ack")
+        void fault_pix_errorTraceId_includedInErrorAck() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("raw message read failed"));
+
+            pixEndpoint.handlePixAdd(addRequest, messageContext);
+
+            verify(ackService).createPixAcknowledgmentError(
+                    anyString(), anyString(), eq("ERR-FIXTURE-001"));
+            errorTraceIdGeneratorMock.verify(ErrorTraceIdGenerator::generateErrorTraceId);
+        }
+
+        @Test
+        @DisplayName("FAULT-PIX-04: LogUtil.logDetailedError called with status 500 on exception")
+        void fault_pix_logUtil_calledOnException() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("log util test"));
+
+            pixEndpoint.handlePixAdd(addRequest, messageContext);
+
+            logUtilMock.verify(() -> LogUtil.logDetailedError(
+                    eq(500), anyString(), anyString(), anyString(), any(Exception.class)));
+        }
+
+        @Test
+        @DisplayName("FAULT-PIX-05: templateLogger.error called with exception on failure")
+        void fault_pix_loggerError_calledOnException() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("logger test"));
+
+            pixEndpoint.handlePixAdd(addRequest, messageContext);
+
+            verify(templateLogger).error(anyString(), any(Object[].class));
+        }
+
+        @Test
+        @DisplayName("FAULT-PIX-06: Missing wsa:MessageID in request → RelatesTo = unknown-incoming-message-id (handled at SoapResponseUtil level)")
+        void fault_pix_missingMessageId_fallbackRelatesTo() {
+            // This is a structural property: the SoapResponseUtil falls back to
+            // "urn:uuid:unknown-incoming-message-id" when no MessageID found.
+            // The update request fixture demonstrates this — its response has the fallback
+            // value.
+            String updateResponse = readFixtureQuiet("pix-update-response_1_2.txt");
+            assertThat(updateResponse).contains("urn:uuid:unknown-incoming-message-id");
+        }
+
+        @Test
+        @DisplayName("FAULT-PIX-07: handlePixUpdate exception → error ack with correct trace ID")
+        void fault_pixUpdate_exception_returnsErrorAck() {
+            PRPAIN201302UV02 updateRequest = mock(PRPAIN201302UV02.class);
+            lenient().when(updateRequest.getId())
+                    .thenReturn(requestIdWith("2.16.840.1.113883.3.72.5.9.1", "update-fault"));
+            lenient().when(updateRequest.getSender()).thenReturn(sender);
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("update fault"));
+
+            MCCIIN000002UV01 result = pixEndpoint.handlePixUpdate(updateRequest, messageContext);
+
+            assertThat(result).isSameAs(errAck);
+        }
+
+        @Test
+        @DisplayName("FAULT-PIX-08: handlePixDuplicateResolved exception → error ack returned")
+        void fault_pixMerge_exception_returnsErrorAck() {
+            PRPAIN201304UV02 mergeRequest = mock(PRPAIN201304UV02.class);
+            lenient().when(mergeRequest.getId())
+                    .thenReturn(requestIdWith("2.16.840.1.113883.3.72.5.9.1", "merge-fault"));
+            lenient().when(mergeRequest.getSender()).thenReturn(sender);
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("merge fault"));
+
+            MCCIIN000002UV01 result = pixEndpoint.handlePixDuplicateResolved(mergeRequest, messageContext);
+
+            assertThat(result).isSameAs(errAck);
+        }
+
+        // ── PNR fault scenarios ───────────────────────────────────────────────
+
+        @Test
+        @DisplayName("FAULT-PNR-01: null RAW_SOAP_MESSAGE → Failure RegistryResponse returned")
+        void fault_pnr_nullRawSoapMessage_returnsFailure() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE")).thenReturn(null);
+            when(httpRequest.getHeader(Constants.HEADER_INTERACTION_ID)).thenReturn("pnr-fault");
+
+            JAXBElement<RegistryResponseType> result = pnrEndpoint.handleProvideAndRegister(jaxbRequest,
+                    messageContext);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getValue().getStatus()).isEqualTo(PNR_FAILURE_STATUS);
+            verify(ackService).createPnrAcknowledgement(eq("Failure"), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("FAULT-PNR-02: ackService.createPnrAcknowledgement throws → Failure response")
+        void fault_pnr_ackServiceThrows_returnsFailure() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenReturn(readFixtureQuiet("pnr-request_1_2.txt"));
+            when(ackService.createPnrAcknowledgement(eq("Success"), anyString()))
+                    .thenThrow(new RuntimeException("pnr service down"));
+
+            JAXBElement<RegistryResponseType> result = pnrEndpoint.handleProvideAndRegister(jaxbRequest,
+                    messageContext);
+
+            assertThat(result.getValue().getStatus()).isEqualTo(PNR_FAILURE_STATUS);
+        }
+
+        @Test
+        @DisplayName("FAULT-PNR-03: ErrorTraceIdGenerator called on PNR exception")
+        void fault_pnr_errorTraceIdGenerator_called() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("pnr trace test"));
+
+            pnrEndpoint.handleProvideAndRegister(jaxbRequest, messageContext);
+
+            errorTraceIdGeneratorMock.verify(ErrorTraceIdGenerator::generateErrorTraceId);
+        }
+
+        @Test
+        @DisplayName("FAULT-PNR-04: LogUtil.logDetailedError called with 500 on PNR exception")
+        void fault_pnr_logUtil_calledWith500() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("pnr logutil test"));
+
+            pnrEndpoint.handleProvideAndRegister(jaxbRequest, messageContext);
+
+            logUtilMock.verify(() -> LogUtil.logDetailedError(
+                    eq(500), anyString(), anyString(), anyString(), any(Exception.class)));
+        }
+
+        @Test
+        @DisplayName("FAULT-PNR-05: Failure response status = Failure URI (not Success)")
+        void fault_pnr_failureResponse_hasCorrectStatus() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("force failure"));
+
+            JAXBElement<RegistryResponseType> result = pnrEndpoint.handleProvideAndRegister(jaxbRequest,
+                    messageContext);
+
+            assertThat(result.getValue().getStatus())
+                    .isEqualTo(PNR_FAILURE_STATUS)
+                    .doesNotContain("Success");
+        }
+
+        @Test
+        @DisplayName("FAULT-PNR-06: Error response includes errorTraceId in ackService call")
+        void fault_pnr_errorTraceId_passedToAckService() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenThrow(new RuntimeException("trace id verify"));
+
+            pnrEndpoint.handleProvideAndRegister(jaxbRequest, messageContext);
+
+            verify(ackService).createPnrAcknowledgement(
+                    eq("Failure"), anyString(), eq("ERR-FIXTURE-001"));
+        }
+
+        @Test
+        @DisplayName("FAULT-PNR-07: MTOM request with exception returns Failure response")
+        void fault_pnr_mtomException_returnsFailure() {
+            when(messageContext.getProperty("RAW_SOAP_MESSAGE"))
+                    .thenReturn(readFixtureQuiet("pnr-xdsb-mtom-request.txt"));
+            when(ackService.createPnrAcknowledgement(eq("Success"), anyString()))
+                    .thenThrow(new RuntimeException("mtom processing failed"));
+
+            JAXBElement<RegistryResponseType> result = pnrEndpoint.handleProvideAndRegister(jaxbRequest,
+                    messageContext);
+
+            assertThat(result.getValue().getStatus()).isEqualTo(PNR_FAILURE_STATUS);
+        }
+    }
+
+    // =========================================================================
+    // UTILITY METHODS
+    // =========================================================================
+
+    /**
+     * Reads a fixture file from the project resource path using Java NIO (Java 8+).
+     * Path: nexus-ingestion-api/src/main/resources/soap-test-resources/{filename}
+     */
+    static String readFixture(String filename) throws IOException {
+        return Files.readString(Path.of(RESOURCE_BASE + filename));
+    }
+
+    /** Silent variant — wraps IOException for use inside lambdas/mocks. */
+    static String readFixtureQuiet(String filename) {
+        try {
+            return readFixture(filename);
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot read fixture: " + filename, e);
+        }
+    }
+
+    /** Extracts the SOAP Envelope XML from an MTOM multipart message. */
+    static String extractSoapEnvelopeFromMtom(String mtomRaw) {
+        int envStart = mtomRaw.indexOf("<?xml");
+        int envEnd = mtomRaw.indexOf("</soap:Envelope>", envStart);
+        if (envEnd == -1) {
+            envEnd = mtomRaw.indexOf("</soap:Envelope>", envStart);
+        }
+        if (envStart == -1 || envEnd == -1)
+            return mtomRaw;
+        return mtomRaw.substring(envStart, envEnd + "</soap:Envelope>".length());
+    }
+
+    /** Parses an XML string into a DOM Document with namespace awareness. */
+    static Document parseXml(String xml) throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        return dbf.newDocumentBuilder()
+                .parse(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Evaluates a simple namespace-aware XPath to retrieve element text content or
+     * attribute value. Uses prefix-to-namespace mapping for single-namespace
+     * queries.
+     */
+    static String xpath(Document doc, String expr, String ns, String prefix) {
+        try {
+            javax.xml.xpath.XPathFactory xpf = javax.xml.xpath.XPathFactory.newInstance();
+            javax.xml.xpath.XPath xp = xpf.newXPath();
+            xp.setNamespaceContext(new javax.xml.namespace.NamespaceContext() {
+                @Override
+                public String getNamespaceURI(String p) {
+                    return switch (p) {
+                        case "wsa" -> NS_WSA;
+                        case "techbd" -> NS_TECHBD;
+                        case "ns2" -> NS_HL7;
+                        case "ns3" -> NS_RS;
+                        default -> ns;
+                    };
+                }
+
+                @Override
+                public String getPrefix(String n) {
+                    return null;
+                }
+
+                @Override
+                public java.util.Iterator<String> getPrefixes(String n) {
+                    return null;
+                }
+            });
+            return xp.evaluate(expr, doc);
+        } catch (Exception e) {
+            throw new RuntimeException("XPath failed: " + expr, e);
+        }
+    }
+
+    /**
+     * Retrieves an attribute value from the first element matching the XPath
+     * expression.
+     */
+    static String xpathAttr(Document doc, String elementExpr, String ns, String prefix, String attrName) {
+        try {
+            javax.xml.xpath.XPathFactory xpf = javax.xml.xpath.XPathFactory.newInstance();
+            javax.xml.xpath.XPath xp = xpf.newXPath();
+            xp.setNamespaceContext(new javax.xml.namespace.NamespaceContext() {
+                @Override
+                public String getNamespaceURI(String p) {
+                    return switch (p) {
+                        case "wsa" -> NS_WSA;
+                        case "techbd" -> NS_TECHBD;
+                        case "ns2" -> NS_HL7;
+                        case "ns3" -> NS_RS;
+                        default -> ns;
+                    };
+                }
+
+                @Override
+                public String getPrefix(String n) {
+                    return null;
+                }
+
+                @Override
+                public java.util.Iterator<String> getPrefixes(String n) {
+                    return null;
+                }
+            });
+            org.w3c.dom.Node node = (org.w3c.dom.Node) xp.evaluate(
+                    elementExpr, doc, javax.xml.xpath.XPathConstants.NODE);
+            if (node == null)
+                return "";
+            org.w3c.dom.NamedNodeMap attrs = node.getAttributes();
+            if (attrs == null)
+                return "";
+            org.w3c.dom.Node attr = attrs.getNamedItem(attrName);
+            return attr != null ? attr.getNodeValue() : "";
+        } catch (Exception e) {
+            throw new RuntimeException("XPath attr failed: " + elementExpr + "@" + attrName, e);
+        }
+    }
+
+    // ── HL7 request object builders ───────────────────────────────────────────
+
+    /**
+     * Builds a real PRPAIN201301UV02 by extracting id and sender from the add
+     * request XML.
+     */
+    static PRPAIN201301UV02 parsePixAddRequest(String xml) throws Exception {
+        Document doc = parseXml(xml);
+        PRPAIN201301UV02 req = new PRPAIN201301UV02();
+        req.setId(extractMsgId(doc, "//v3:PRPA_IN201301UV02/v3:id"));
+        req.setSender(extractSender(doc));
+        return req;
+    }
+
+    static PRPAIN201302UV02 parsePixUpdateRequest(String xml) throws Exception {
+        Document doc = parseXml(xml);
+        PRPAIN201302UV02 req = new PRPAIN201302UV02();
+        req.setId(extractMsgId(doc, "//v3:PRPA_IN201302UV02/v3:id"));
+        req.setSender(extractSender(doc));
+        return req;
+    }
+
+    static PRPAIN201304UV02 parsePixMergeRequest(String xml) throws Exception {
+        Document doc = parseXml(xml);
+        PRPAIN201304UV02 req = new PRPAIN201304UV02();
+        req.setId(extractMsgId(doc, "//v3:PRPA_IN201304UV02/v3:id"));
+        req.setSender(extractSender(doc));
+        return req;
+    }
+
+    private static II extractMsgId(Document doc, String xpathBase) {
+        String nsHl7 = "urn:hl7-org:v3";
+        try {
+            javax.xml.xpath.XPath xp = buildXPath(nsHl7);
+            String root = xp.evaluate(xpathBase + "/@root", doc);
+            String ext = xp.evaluate(xpathBase + "/@extension", doc);
+            II id = new II();
+            id.setRoot(root.isBlank() ? "2.16.840.1.113883.3.72.5.9.1" : root);
+            id.setExtension(ext.isBlank() ? "UNKNOWN" : ext);
+            return id;
+        } catch (Exception e) {
+            II id = new II();
+            id.setRoot("2.16.840.1.113883.3.72.5.9.1");
+            id.setExtension("UNKNOWN");
+            return id;
+        }
+    }
+
+    private static org.techbd.iti.schema.MCCIMT000100UV01Sender extractSender(Document doc) {
+        try {
+            javax.xml.xpath.XPath xp = buildXPath("urn:hl7-org:v3");
+            String root = xp.evaluate("//v3:sender/v3:device/v3:id/@root", doc);
+            MCCIMT000100UV01Device device = new MCCIMT000100UV01Device();
+            II id = new II();
+            id.setRoot(root.isBlank() ? "1.2.3.4.5" : root);
+            device.getId().add(id);
+            org.techbd.iti.schema.MCCIMT000100UV01Sender sender = new org.techbd.iti.schema.MCCIMT000100UV01Sender();
+            sender.setDevice(device);
+            return sender;
+        } catch (Exception e) {
+            org.techbd.iti.schema.MCCIMT000100UV01Sender sender = new org.techbd.iti.schema.MCCIMT000100UV01Sender();
+            sender.setDevice(new MCCIMT000100UV01Device());
+            return sender;
+        }
+    }
+
+    private static javax.xml.xpath.XPath buildXPath(String defaultNs) {
+        javax.xml.xpath.XPath xp = javax.xml.xpath.XPathFactory.newInstance().newXPath();
+        xp.setNamespaceContext(new javax.xml.namespace.NamespaceContext() {
+            @Override
+            public String getNamespaceURI(String p) {
+                return "v3".equals(p) ? defaultNs : defaultNs;
+            }
+
+            @Override
+            public String getPrefix(String n) {
+                return null;
+            }
+
+            @Override
+            public java.util.Iterator<String> getPrefixes(String n) {
+                return null;
+            }
+        });
+        return xp;
+    }
+
+    /**
+     * Builds a real MCCIIN000002UV01 acknowledgement mirroring the fixture response
+     * fields.
+     */
+    static MCCIIN000002UV01 buildPixAck(PRPAIN201301UV02 req) {
+        return buildAck(req.getId(), req.getSender() != null ? req.getSender().getDevice() : null);
+    }
+
+    static MCCIIN000002UV01 buildPixAck(PRPAIN201304UV02 req) {
+        return buildAck(req.getId(), req.getSender() != null ? req.getSender().getDevice() : null);
+    }
+
+    static MCCIIN000002UV01 buildPixAckForUpdate(PRPAIN201302UV02 req) {
+        return buildAck(req.getId(), req.getSender() != null ? req.getSender().getDevice() : null);
+    }
+
+    private static MCCIIN000002UV01 buildAck(II requestId, MCCIMT000100UV01Device senderDevice) {
+        // Delegate to the real AcknowledgementService logic (inline for test
+        // independence)
+        MCCIIN000002UV01 ack = new MCCIIN000002UV01();
+
+        II id = new II();
+        id.setRoot(java.util.UUID.randomUUID().toString());
+        ack.setId(id);
+
+        org.techbd.iti.schema.TS ts = new org.techbd.iti.schema.TS();
+        ts.setValue(java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmssZ")
+                .format(java.time.ZonedDateTime.now(java.time.ZoneOffset.of("+05:30"))));
+        ack.setCreationTime(ts);
+
+        II interaction = new II();
+        interaction.setRoot(INTERACTION_ID_ROOT);
+        interaction.setExtension(INTERACTION_ID_EXT);
+        ack.setInteractionId(interaction);
+
+        // Receiver mirrors sender
+        org.techbd.iti.schema.MCCIMT000200UV01Receiver receiver = new org.techbd.iti.schema.MCCIMT000200UV01Receiver();
+        org.techbd.iti.schema.MCCIMT000200UV01Device rcvDevice = new org.techbd.iti.schema.MCCIMT000200UV01Device();
+        if (senderDevice != null && !senderDevice.getId().isEmpty()) {
+            II copy = new II();
+            copy.setRoot(senderDevice.getId().get(0).getRoot());
+            rcvDevice.getId().add(copy);
+        }
+        receiver.setDevice(rcvDevice);
+        ack.getReceiver().add(receiver);
+
+        // Sender
+        org.techbd.iti.schema.MCCIMT000200UV01Sender snd = new org.techbd.iti.schema.MCCIMT000200UV01Sender();
+        org.techbd.iti.schema.MCCIMT000200UV01Device sndDevice = new org.techbd.iti.schema.MCCIMT000200UV01Device();
+        org.techbd.iti.schema.TEL tel = new org.techbd.iti.schema.TEL();
+        tel.setValue("HTTP/1.1");
+        sndDevice.getTelecom().add(tel);
+        if (senderDevice != null && !senderDevice.getId().isEmpty()) {
+            II copy = new II();
+            copy.setRoot(senderDevice.getId().get(0).getRoot());
+            sndDevice.getId().add(copy);
+        }
+        snd.setDevice(sndDevice);
+        ack.setSender(snd);
+
+        // Acknowledgement
+        org.techbd.iti.schema.MCCIMT000200UV01Acknowledgement ackBlock = new org.techbd.iti.schema.MCCIMT000200UV01Acknowledgement();
+        org.techbd.iti.schema.MCCIMT000200UV01TargetMessage target = new org.techbd.iti.schema.MCCIMT000200UV01TargetMessage();
+        if (requestId != null) {
+            target.setId(requestId);
+        } else {
+            II unknown = new II();
+            unknown.setRoot("UNKNOWN");
+            target.setId(unknown);
+        }
+        ackBlock.setTargetMessage(target);
+        ack.getAcknowledgement().add(ackBlock);
+
+        return ack;
+    }
+
+    private static II requestIdWith(String root, String extension) {
+        II id = new II();
+        id.setRoot(root);
+        id.setExtension(extension);
+        return id;
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/base/BaseIntegrationTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/base/BaseIntegrationTest.java
@@ -1,0 +1,302 @@
+package org.techbd.ingest.integrationtests.base;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+/**
+ * Abstract base class for all integration tests that need LocalStack (S3 +
+ * SQS).
+ *
+ * <p>
+ * <b>Lifecycle:</b>
+ * <ul>
+ * <li>The LocalStack container is started <em>once per JVM</em> via
+ * {@code @Container static},
+ * meaning all test classes that extend this share the same container
+ * instance.</li>
+ * <li>AWS clients (S3, SQS) and bucket/queue creation are also done
+ * <em>once</em>
+ * in {@link #setupLocalStackEnvironment()}.</li>
+ * <li>Between each test method, {@link #cleanS3AndSqsState()} purges all data
+ * objects and SQS messages so tests remain fully isolated.</li>
+ * </ul>
+ *
+ * <p>
+ * <b>Why per-test cleanup instead of per-test setup?</b>
+ * Re-creating buckets and queues is expensive. Purging their contents is cheap
+ * and sufficient.
+ */
+@NexusIntegrationTest
+public abstract class BaseIntegrationTest {
+
+        // ── Constants ──────────────────────────────────────────────────────────────
+
+        protected static final String PORT_CONFIG_BUCKET = "local-pdr-txd-sbx-temp";
+        protected static final String PORT_CONFIG_KEY = "port-config/list.json";
+        protected static final String PORT_CONFIG_CLASSPATH = "org/techbd/ingest/portconfig/list.json";
+
+        /** Data bucket used by the default (port 9000) flow. */
+        protected static final String DEFAULT_DATA_BUCKET = "local-sbx-nexus-ingestion-s3-bucket";
+        /** Metadata bucket used by the default (port 9000) flow. */
+        protected static final String DEFAULT_METADATA_BUCKET = "local-sbx-nexus-ingestion-s3-metadata-bucket";
+        /**
+         * Single bucket used by the HOLD (port 5555) flow for both data and metadata.
+         */
+        protected static final String HOLD_BUCKET = "local-pdr-txd-sbx-hold";
+
+        // ── SQS Queue Definitions ─────────────────────────────────────────────────
+
+        protected static final List<String> QUEUE_NAMES = List.of(
+                        "txd-sbx-main-queue.fifo",
+                        "test.fifo",
+                        "txd-sbx-ccd-queue.fifo",
+                        "txd-sbx-hold-queue.fifo",
+                        "txd-sbx-util-queue.fifo");
+
+        protected static final Map<String, String> queueUrls = new HashMap<>();
+
+        // ── LocalStack container ──────────────────────────────────────────────────
+
+        /**
+         * A single LocalStack container shared across the entire test suite.
+         * {@code static} + {@code @Container} ensures Testcontainers starts it once
+         * per JVM and tears it down only after all tests finish.
+         */
+        @Container
+        static final LocalStackContainer localStack = new LocalStackContainer(
+                        DockerImageName.parse("localstack/localstack:3.0"))
+                        .withServices(LocalStackContainer.Service.S3,
+                                        LocalStackContainer.Service.SQS)
+                        .withStartupAttempts(3)
+                        .waitingFor(Wait.forLogMessage(".*Ready.*", 1));
+
+        // ── AWS clients ───────────────────────────────────────────────────────────
+
+        protected static S3Client s3Client;
+        protected static SqsClient sqsClient;
+
+        /** Convenience alias for the main FIFO queue URL. */
+        protected static String mainQueueUrl;
+
+        // ── Spring property injection ─────────────────────────────────────────────
+
+        @DynamicPropertySource
+        static void overrideAwsProperties(DynamicPropertyRegistry registry) {
+                registry.add("org.techbd.aws.s3.default-config.endpoint",
+                                () -> localStack.getEndpointOverride(LocalStackContainer.Service.S3).toString());
+                registry.add("org.techbd.aws.s3.hold-config.endpoint",
+                                () -> localStack.getEndpointOverride(LocalStackContainer.Service.S3).toString());
+                registry.add("org.techbd.aws.sqs.endpoint",
+                                () -> localStack.getEndpointOverride(LocalStackContainer.Service.SQS).toString());
+
+                registry.add("org.techbd.aws.region", localStack::getRegion);
+                registry.add("org.techbd.aws.access-key", localStack::getAccessKey);
+                registry.add("org.techbd.aws.secret-key", localStack::getSecretKey);
+
+                registry.add("org.techbd.aws.sqs.fifo-queue-url", () -> mainQueueUrl);
+                registry.add("org.techbd.aws.sqs.hold-queue-url",
+                                () -> queueUrls.get("txd-sbx-hold-queue.fifo"));
+                registry.add("org.techbd.aws.sqs.ccd-queue-url",
+                                () -> queueUrls.get("txd-sbx-ccd-queue.fifo"));
+
+                registry.add("PORT_CONFIG_S3_BUCKET", () -> PORT_CONFIG_BUCKET);
+                registry.add("PORT_CONFIG_S3_KEY", () -> PORT_CONFIG_KEY);
+                registry.add("AWS_REGION", localStack::getRegion);
+                registry.add("SPRING_PROFILES_ACTIVE", () -> "test");
+
+                System.setProperty("aws.accessKeyId", localStack.getAccessKey());
+                System.setProperty("aws.secretAccessKey", localStack.getSecretKey());
+        }
+
+        // ── One-time setup ────────────────────────────────────────────────────────
+
+        /**
+         * Runs once before any test in the suite. Creates AWS clients, buckets,
+         * queues, and uploads the port-config fixture.
+         */
+        @BeforeAll
+        static void setupLocalStackEnvironment() throws Exception {
+
+                // Guard: if clients are already built (another test class ran first),
+                // skip re-initialisation — the container is already up and buckets exist.
+                if (s3Client != null) {
+                        return;
+                }
+
+                StaticCredentialsProvider credentials = StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                                localStack.getAccessKey(),
+                                                localStack.getSecretKey()));
+
+                s3Client = S3Client.builder()
+                                .endpointOverride(localStack.getEndpointOverride(LocalStackContainer.Service.S3))
+                                .region(Region.of(localStack.getRegion()))
+                                .credentialsProvider(credentials)
+                                .forcePathStyle(true)
+                                .build();
+
+                sqsClient = SqsClient.builder()
+                                .endpointOverride(localStack.getEndpointOverride(LocalStackContainer.Service.SQS))
+                                .region(Region.of(localStack.getRegion()))
+                                .credentialsProvider(credentials)
+                                .build();
+
+                createBuckets();
+                createQueues();
+                uploadPortConfig();
+        }
+
+        // ── Per-test cleanup ──────────────────────────────────────────────────────
+
+        /**
+         * Runs after every test method. Clears all S3 objects from the data/metadata
+         * buckets and drains all SQS queues. This prevents cross-test contamination
+         * without the cost of re-creating infrastructure.
+         *
+         * <p>
+         * The port-config bucket is intentionally left untouched.
+         */
+        @AfterEach
+        void cleanS3AndSqsState() {
+                purgeS3Bucket(DEFAULT_DATA_BUCKET);
+                purgeS3Bucket(DEFAULT_METADATA_BUCKET);
+                purgeS3Bucket(HOLD_BUCKET);
+
+                for (String queueUrl : queueUrls.values()) {
+                        purgeSqsQueue(queueUrl);
+                }
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────────
+
+        private static void createBuckets() {
+                for (String bucket : new String[] {
+                                DEFAULT_DATA_BUCKET,
+                                DEFAULT_METADATA_BUCKET,
+                                HOLD_BUCKET,
+                                PORT_CONFIG_BUCKET
+                }) {
+                        s3Client.createBucket(b -> b.bucket(bucket));
+                }
+        }
+
+        private static void createQueues() {
+                Map<QueueAttributeName, String> attrs = Map.of(
+                                QueueAttributeName.FIFO_QUEUE, "true",
+                                QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true");
+
+                for (String queueName : QUEUE_NAMES) {
+                        String url = sqsClient.createQueue(b -> b
+                                        .queueName(queueName)
+                                        .attributes(attrs))
+                                        .queueUrl();
+                        queueUrls.put(queueName, url);
+                }
+
+                mainQueueUrl = queueUrls.get("txd-sbx-main-queue.fifo");
+        }
+
+        private static void uploadPortConfig() throws Exception {
+                try (InputStream is = BaseIntegrationTest.class
+                                .getClassLoader()
+                                .getResourceAsStream(PORT_CONFIG_CLASSPATH)) {
+
+                        if (is == null) {
+                                throw new IllegalStateException(
+                                                "list.json not found on classpath: " + PORT_CONFIG_CLASSPATH);
+                        }
+
+                        s3Client.putObject(
+                                        PutObjectRequest.builder()
+                                                        .bucket(PORT_CONFIG_BUCKET)
+                                                        .key(PORT_CONFIG_KEY)
+                                                        .contentType("application/json")
+                                                        .build(),
+                                        software.amazon.awssdk.core.sync.RequestBody.fromBytes(is.readAllBytes()));
+                }
+        }
+
+        /**
+         * Deletes all objects from an S3 bucket in a single batch request.
+         * Safe to call on empty buckets.
+         */
+        private void purgeS3Bucket(String bucket) {
+                ListObjectsV2Response listing = s3Client.listObjectsV2(
+                                ListObjectsV2Request.builder().bucket(bucket).build());
+
+                if (listing.contents().isEmpty()) {
+                        return;
+                }
+
+                List<ObjectIdentifier> toDelete = listing.contents().stream()
+                                .map(o -> ObjectIdentifier.builder().key(o.key()).build())
+                                .collect(Collectors.toList());
+
+                s3Client.deleteObjects(DeleteObjectsRequest.builder()
+                                .bucket(bucket)
+                                .delete(Delete.builder().objects(toDelete).quiet(true).build())
+                                .build());
+        }
+
+        /**
+         * Drains an SQS queue by receiving all available messages and deleting them.
+         * Uses short-poll (waitTimeSeconds=0) to return quickly when the queue is
+         * empty.
+         */
+        private void purgeSqsQueue(String queueUrl) {
+                // PurgeQueue has a 60-second cooldown in real AWS, but LocalStack
+                // supports it freely — use it for simplicity.
+                try {
+                        sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(queueUrl).build());
+                } catch (Exception ignored) {
+                        // Fallback: drain manually
+                        ReceiveMessageResponse resp;
+                        do {
+                                resp = sqsClient.receiveMessage(ReceiveMessageRequest.builder()
+                                                .queueUrl(queueUrl)
+                                                .maxNumberOfMessages(10)
+                                                .waitTimeSeconds(0)
+                                                .build());
+                                for (var msg : resp.messages()) {
+                                        sqsClient.deleteMessage(DeleteMessageRequest.builder()
+                                                        .queueUrl(queueUrl)
+                                                        .receiptHandle(msg.receiptHandle())
+                                                        .build());
+                                }
+                        } while (!resp.messages().isEmpty());
+                }
+        }
+
+        protected static String getQueueUrl(String queueName) {
+                return queueUrls.get(queueName);
+        }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/base/NexusIntegrationTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/base/NexusIntegrationTest.java
@@ -1,0 +1,25 @@
+package org.techbd.ingest.integrationtests.base;
+import org.techbd.ingest.NexusIngestionApiApplication;
+import java.lang.annotation.*;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = NexusIngestionApiApplication.class
+)
+@TestPropertySource(properties = {
+    "PORT_CONFIG_S3_BUCKET=local-pdr-txd-sbx-temp",
+    "PORT_CONFIG_S3_KEY=port-config/list.json",
+    "SPRING_PROFILES_ACTIVE=test"
+})
+@ActiveProfiles("test")
+@Testcontainers
+public @interface NexusIntegrationTest {
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/soap/SoapWsEndPointITCase.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/soap/SoapWsEndPointITCase.java
@@ -1,0 +1,821 @@
+package org.techbd.ingest.integrationtests.soap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.techbd.ingest.integrationtests.util.SoapTestFixtures.extractXPath;
+import static org.techbd.ingest.integrationtests.util.SoapTestFixtures.loadFixture;
+import org.techbd.ingest.NexusIngestionApiApplication;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+import javax.xml.soap.SOAPConstants;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.integrationtests.base.BaseIntegrationTest;
+import org.techbd.ingest.NexusIngestionApiApplication;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.techbd.ingest.NexusIngestionApiApplication;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.techbd.ingest.integrationtests.base.NexusIntegrationTest;
+
+/**
+ * Full-stack integration tests for SOAP endpoints.
+ *
+ * <p>
+ * LocalStack (S3 + SQS), bucket/queue creation, and port-config upload are
+ * all handled <em>once</em> by {@link BaseIntegrationTest}. Between every test
+ * method, {@code BaseIntegrationTest.cleanS3AndSqsState()} purges data buckets
+ * and SQS queues, so each test starts with a clean slate.
+ *
+ * <h3>Common assertion helpers</h3>
+ * <ul>
+ * <li>{@link #assertDefaultFlowS3AndSqs} — validates S3 + SQS for the
+ * default port-9000 flow (two separate buckets, main queue).</li>
+ * <li>{@link #assertHoldFlowS3AndSqs} — validates S3 + SQS for the HOLD
+ * port-5555 flow (single hold bucket, test.fifo queue).</li>
+ * <li>{@link #assertSoap12Envelope} / {@link #assertSoap11Envelope} — verify
+ * the envelope namespace via XPath rather than fragile string contains.</li>
+ * </ul>
+ */
+@NexusIntegrationTest
+@Tag("integration")
+class SoapWsEndPointITCase extends BaseIntegrationTest {
+
+        @Autowired
+        private TestRestTemplate restTemplate;
+
+        @LocalServerPort
+        private int port;
+
+        @Autowired
+        private ApplicationContext context;
+
+        private static final ObjectMapper MAPPER = new ObjectMapper();
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // Diagnostic tests
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        @Test
+        @DisplayName("DIAG: Health check returns 200")
+        void healthCheck() {
+                ResponseEntity<String> response = restTemplate.getForEntity(
+                                "http://localhost:" + port + "/actuator/health", String.class);
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        @DisplayName("DIAG: Port 9000 config is present in list.json on S3")
+        void portConfigContainsPort9000() throws Exception {
+                String json = new String(
+                                s3Client.getObject(GetObjectRequest.builder()
+                                                .bucket(PORT_CONFIG_BUCKET)
+                                                .key(PORT_CONFIG_KEY)
+                                                .build())
+                                                .readAllBytes(),
+                                StandardCharsets.UTF_8);
+
+                JsonNode root = MAPPER.readTree(json);
+                for (JsonNode node : root) {
+                        if (node.has("port") && node.get("port").asInt() == 9000) {
+                                assertThat(node.get("protocol").asText()).isEqualTo("HTTP");
+                                return;
+                        }
+                }
+                throw new AssertionError("Port 9000 config not found in list.json");
+        }
+
+        @Test
+        @DisplayName("DIAG: messageDispatcher beans are registered")
+        void messageDispatcherBeansRegistered() {
+                long count = java.util.Arrays.stream(context.getBeanDefinitionNames())
+                                .filter(name -> name.contains("messageDispatcher"))
+                                .peek(System.out::println)
+                                .count();
+                assertThat(count).isPositive();
+        }
+
+        @Test
+        @DisplayName("DIAG: Servlet registration beans are mapped")
+        void servletMappingsRegistered() {
+                var beans = context.getBeansOfType(
+                                org.springframework.boot.web.servlet.ServletRegistrationBean.class);
+                assertThat(beans).isNotEmpty();
+                beans.forEach((name, bean) -> System.out.println(name + " -> " + bean.getUrlMappings()));
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // PIX Add
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        /**
+         * Integration Test: PIX ADD SOAP 1.2 — default flow (port 9000).
+         *
+         * <p>
+         * <b>Port config (port 9000):</b>
+         * 
+         * <pre>
+         * { "port": 9000, "protocol": "HTTP", "whitelistIps": ["0.0.0.0/0"],
+         *   "execType": "sync", "trafficTo": "util" }
+         * </pre>
+         *
+         * No custom route/dataDir/metadataDir, so default key structure applies:
+         * <ul>
+         * <li>Payload: {@code data/YYYY/MM/DD/{id_timestamp}}</li>
+         * <li>ACK: {@code data/YYYY/MM/DD/{id_timestamp}_ack}</li>
+         * <li>Metadata: {@code metadata/YYYY/MM/DD/{id_timestamp}_metadata.json}</li>
+         * </ul>
+         * Data bucket: {@code local-sbx-nexus-ingestion-s3-bucket}<br>
+         * Metadata bucket: {@code local-sbx-nexus-ingestion-s3-metadata-bucket}
+         *
+         * <p>
+         * <b>IMPORTANT:</b> Update this test if {@code list.json} changes route,
+         * dataDir, metadataDir, queue, or bucket resolver logic.
+         */
+        @Test
+        @DisplayName("IT: PIX-ADD SOAP 1.2 — full flow (HTTP + S3 + SQS)")
+        void pixAdd_soap12_fullFlow() throws Exception {
+                String expectedRequest = loadFixture("pix-add-request_1_2.txt");
+                String expectedAck = loadFixture("pix-add-response_1_2.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_2_PROTOCOL, "9000", softly);
+
+                softly.assertThat(response).as("Response contains PIX ACK").contains("MCCI_IN000002UV01");
+                assertSoap12Envelope(response, softly);
+
+                assertDefaultFlowS3AndSqs(expectedRequest, expectedAck, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        /**
+         * Integration Test: PIX ADD SOAP 1.2 — HOLD flow (port 5555).
+         *
+         * <p>
+         * <b>Port config (port 5555):</b>
+         * 
+         * <pre>
+         * { "port": 5555, "route": "/hold", "dataDir": "/http",
+         *   "metadataDir": "/outbound", "queue": "test.fifo", "keepAliveTimeout": 20 }
+         * </pre>
+         *
+         * HOLD key structure:
+         * <ul>
+         * <li>Payload: {@code http/hold/5555/YYYY/MM/DD/{ts}_soap-message.xml}</li>
+         * <li>ACK: {@code http/hold/5555/YYYY/MM/DD/{ts}_soap-message.xml_ack}</li>
+         * <li>Metadata:
+         * {@code outbound/hold/metadata/5555/YYYY/MM/DD/{ts}_soap-message.xml_metadata.json}</li>
+         * </ul>
+         * Both data and metadata live in {@code local-pdr-txd-sbx-hold}.
+         *
+         * <p>
+         * <b>IMPORTANT:</b> Update this test if {@code list.json} changes route,
+         * dataDir, metadataDir, queue, or bucket resolver logic.
+         */
+        @Test
+        @DisplayName("IT: PIX-ADD SOAP 1.2 — HOLD flow (HTTP + S3 Hold Bucket + SQS)")
+        void pixAdd_soap12_holdFlow() throws Exception {
+                String expectedRequest = loadFixture("pix-add-request_1_2.txt");
+                String expectedAck = loadFixture("pix-add-response_1_2.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_2_PROTOCOL, "5555", softly);
+
+                softly.assertThat(response).as("Response contains PIX ACK").contains("MCCI_IN000002UV01");
+                assertSoap12Envelope(response, softly);
+
+                assertHoldFlowS3AndSqs(expectedRequest, expectedAck, "127.0.0.1_5555", softly);
+
+                softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("IT: PIX-ADD SOAP 1.1 — full flow (HTTP + S3 + SQS)")
+        void pixAdd_soap11_fullflow() throws Exception {
+                String expectedRequest = loadFixture("pix-add-request_1_1.txt");
+                String expectedAck = loadFixture("pix-add-response_1_1.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_1_PROTOCOL, "9000", softly);
+
+                softly.assertThat(response).as("Response contains PIX ACK").contains("MCCI_IN000002UV01");
+                assertSoap11Envelope(response, softly);
+
+                assertDefaultFlowS3AndSqs(expectedRequest, expectedAck, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // PIX Merge
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        @Test
+        @DisplayName("IT: PIX-MERGE SOAP 1.2 — full flow (HTTP + S3 + SQS)")
+        void pixMerge_soap12_fullflow() throws Exception {
+                String expectedRequest = loadFixture("pix-merge-request_1_2.txt");
+                String expectedAck = loadFixture("pix-merge-response_1_2.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_2_PROTOCOL, "9000", softly);
+
+                softly.assertThat(response).as("Response contains PIX ACK").contains("MCCI_IN000002UV01");
+                assertSoap12Envelope(response, softly);
+
+                assertDefaultFlowS3AndSqs(expectedRequest, expectedAck, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("IT: PIX-MERGE SOAP 1.1 — full flow (HTTP + S3 + SQS)")
+        void pixMerge_soap11_fullflow() throws Exception {
+                String expectedRequest = loadFixture("pix-merge-request_1_1.txt");
+                String expectedAck = loadFixture("pix-merge-response_1_1.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_1_PROTOCOL, "9000", softly);
+
+                softly.assertThat(response).as("Response contains MERGE-12345").contains("MERGE-12345");
+                assertSoap11Envelope(response, softly);
+
+                assertDefaultFlowS3AndSqs(expectedRequest, expectedAck, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // PIX Update
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        @Test
+        @DisplayName("IT: PIX-UPDATE SOAP 1.2 — full flow (HTTP + S3 + SQS)")
+        void pixUpdate_soap12_fullflow() throws Exception {
+                String expectedRequest = loadFixture("pix-update-request_1_2.txt");
+                String expectedAck = loadFixture("pix-update-response_1_2.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_2_PROTOCOL, "9000", softly);
+
+                softly.assertThat(response).as("Response contains PIX ACK").contains("MCCI_IN000002UV01");
+                assertSoap12Envelope(response, softly);
+
+                assertDefaultFlowS3AndSqs(expectedRequest, expectedAck, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("IT: PIX-UPDATE SOAP 1.1 — full flow (HTTP + S3 + SQS)")
+        void pixUpdate_soap11_fullflow() throws Exception {
+                String expectedRequest = loadFixture("pix-update-request_1_1.txt");
+                String expectedAck = loadFixture("pix-update-response_1_1.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_1_PROTOCOL, "9000", softly);
+
+                // pix-update-request has an empty SOAP Header — app falls back to this ID
+                softly.assertThat(response).as("Response contains fallback message ID")
+                                .contains("unknown-incoming-message-id");
+                assertSoap11Envelope(response, softly);
+
+                assertDefaultFlowS3AndSqs(expectedRequest, expectedAck, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // PNR
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        @Test
+        @DisplayName("IT: PNR SOAP 1.1 — full flow (HTTP + S3 + SQS)")
+        void pnr_soap11_FullFlow() throws Exception {
+                String expectedRequest = loadFixture("pnr-request_1_1.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_1_PROTOCOL, "9000", softly);
+
+                softly.assertThat(response).as("Response contains RegistryResponse").contains("RegistryResponse");
+                softly.assertThat(response).as("Response contains Success status")
+                                .contains("ResponseStatusType:Success");
+                assertSoap11Envelope(response, softly);
+
+                // PNR has no ACK fixture — pass null; helper skips ACK XPath assertions when
+                // null
+                assertDefaultFlowS3AndSqs(expectedRequest, null, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("IT: PNR SOAP 1.2 — full flow (HTTP + S3 + SQS)")
+        void pnr_soap12_FullFlow() throws Exception {
+                String expectedRequest = loadFixture("pnr-request_1_2.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendSoapRequest(expectedRequest, SOAPConstants.SOAP_1_2_PROTOCOL, "9000", softly);
+
+                softly.assertThat(response).as("Response contains RegistryResponse").contains("RegistryResponse");
+                softly.assertThat(response).as("Response contains Success status")
+                                .contains("ResponseStatusType:Success");
+                assertSoap12Envelope(response, softly);
+
+                assertDefaultFlowS3AndSqs(expectedRequest, null, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // PNR MTOM
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        @Test
+        @DisplayName("IT: PNR MTOM — RegistryResponse Success returned")
+        void pnrMtom_successReturned() throws Exception {
+                String expectedRequest = loadFixture("pnr-xdsb-mtom-request.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendMtomRequest(expectedRequest, "9000", softly);
+
+                softly.assertThat(response).as("Response contains RegistryResponse").contains("RegistryResponse");
+                softly.assertThat(response).as("Response contains Success status")
+                                .contains("ResponseStatusType:Success");
+
+                assertDefaultFlowS3AndSqs(expectedRequest, null, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        @Test
+        @DisplayName("IT: PNR MTOM — wsa:RelatesTo echoes MTOM request MessageID")
+        void pnrMtom_relatesTo_matchesMtomMessageId() throws Exception {
+                String expectedRequest = loadFixture("pnr-xdsb-mtom-request.txt");
+
+                SoftAssertions softly = new SoftAssertions();
+
+                String response = sendMtomRequest(expectedRequest, "9000", softly);
+
+                softly.assertThat(response).as("Response echoes MTOM MessageID")
+                                .contains("f19a3e9e-324d-4c6c-8a96-6747955d86f5");
+
+                assertDefaultFlowS3AndSqs(expectedRequest, null, "127.0.0.1_9000", softly);
+
+                softly.assertAll();
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // Common S3 + SQS assertion helpers
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        /**
+         * Validates the complete S3 → metadata → SQS chain for the <em>default</em>
+         * (port 9000) flow.
+         *
+         * <p>
+         * Expectations:
+         * <ul>
+         * <li>Payload stored in {@link #DEFAULT_DATA_BUCKET} under
+         * {@code data/YYYY/MM/DD/…}</li>
+         * <li>ACK stored in same bucket with {@code _ack} suffix</li>
+         * <li>Metadata stored in {@link #DEFAULT_METADATA_BUCKET} under
+         * {@code metadata/YYYY/MM/DD/…_metadata.json}</li>
+         * <li>SQS message on main queue matches all S3 paths</li>
+         * <li>{@code messageGroupId} equals the supplied {@code expectedGroupId}</li>
+         * </ul>
+         *
+         * @param expectedPayload the raw XML that was sent (used for payload
+         *                        comparison)
+         * @param expectedAck     the fixture ACK (used for sender/receiver XPath
+         *                        check);
+         *                        pass {@code null} to skip ACK XPath assertions
+         * @param expectedGroupId expected {@code messageGroupId} value (e.g.
+         *                        {@code "127.0.0.1_9000"})
+         * @param softly          collector for soft assertion failures
+         */
+        private void assertDefaultFlowS3AndSqs(
+                        String expectedPayload,
+                        String expectedAck,
+                        String expectedGroupId,
+                        SoftAssertions softly) throws Exception {
+
+                // ── S3 data bucket ──────────────────────────────────────────────────────
+                ListObjectsV2Response dataObjects = s3Client.listObjectsV2(
+                                ListObjectsV2Request.builder().bucket(DEFAULT_DATA_BUCKET).build());
+
+                softly.assertThat(dataObjects.contents())
+                                .as("Data bucket should contain payload + ACK").isNotEmpty();
+
+                String payloadKey = dataObjects.contents().stream()
+                                .map(S3Object::key).filter(k -> !k.contains("_ack"))
+                                .findFirst().orElseThrow(() -> new AssertionError("Payload key not found"));
+
+                String ackKey = dataObjects.contents().stream()
+                                .map(S3Object::key).filter(k -> k.contains("_ack"))
+                                .findFirst().orElseThrow(() -> new AssertionError("ACK key not found"));
+
+                String actualPayload = readS3(DEFAULT_DATA_BUCKET, payloadKey);
+                String actualAck = readS3(DEFAULT_DATA_BUCKET, ackKey);
+
+                softly.assertThat(normalizeXml(actualPayload))
+                                .as("Stored payload must match sent request")
+                                .isEqualTo(normalizeXml(expectedPayload));
+
+                if (expectedAck != null) {
+                        softly.assertThat(extractXPath(actualAck, "//sender/device/id/@root"))
+                                        .isEqualTo(extractXPath(expectedAck, "//sender/device/id/@root"));
+                        softly.assertThat(extractXPath(actualAck, "//receiver/device/id/@root"))
+                                        .isEqualTo(extractXPath(expectedAck, "//receiver/device/id/@root"));
+                }
+
+                // ── S3 metadata bucket ──────────────────────────────────────────────────
+                ListObjectsV2Response metadataObjects = s3Client.listObjectsV2(
+                                ListObjectsV2Request.builder().bucket(DEFAULT_METADATA_BUCKET).build());
+
+                softly.assertThat(metadataObjects.contents())
+                                .as("Metadata bucket should contain objects").isNotEmpty();
+
+                String metadataKey = metadataObjects.contents().get(0).key();
+                String metadataContent = readS3(DEFAULT_METADATA_BUCKET, metadataKey);
+
+                JsonNode meta = MAPPER.readTree(metadataContent);
+                String key = meta.get("key").asText();
+                JsonNode jsonMeta = meta.get("json_metadata");
+                String s3DataPath = jsonMeta.get("s3DataObjectPath").asText();
+                String metaPath = jsonMeta.get("fullS3MetaDataPath").asText();
+                String ackPath = jsonMeta.get("fullS3AcknowledgementPath").asText();
+
+                // Date-partitioned prefix
+                String expectedPrefix = todayDataPrefix();
+                softly.assertThat(key).as("Key must start with date prefix").startsWith(expectedPrefix);
+
+                // Suffix consistency
+                String datePrefix = expectedPrefix + "/";
+                String metaPrefix = "metadata/" + expectedPrefix.substring("data/".length()) + "/";
+                String keySuffix = key.substring(datePrefix.length());
+
+                softly.assertThat(extractSuffix(s3DataPath, datePrefix))
+                                .as("Data path suffix").isEqualTo(keySuffix);
+                softly.assertThat(extractSuffix(ackPath, datePrefix))
+                                .as("ACK path suffix").isEqualTo(keySuffix + "_ack");
+                softly.assertThat(extractSuffix(metaPath, metaPrefix))
+                                .as("Metadata path suffix").isEqualTo(keySuffix + "_metadata.json");
+
+                // ── SQS ─────────────────────────────────────────────────────────────────
+                assertSqsConsistency(mainQueueUrl, s3DataPath, metaPath, ackPath, key, expectedGroupId, softly);
+        }
+
+        /**
+         * Validates the complete S3 → metadata → SQS chain for the <em>HOLD</em>
+         * (port 5555) flow.
+         *
+         * <p>
+         * Expectations:
+         * <ul>
+         * <li>All objects (payload, ACK, metadata) in {@link #HOLD_BUCKET}</li>
+         * <li>Payload key starts with {@code http/hold/5555/YYYY/MM/DD/…}</li>
+         * <li>Metadata key starts with
+         * {@code outbound/hold/metadata/5555/YYYY/MM/DD/…}</li>
+         * <li>SQS message on {@code test.fifo} matches all S3 paths</li>
+         * <li>{@code messageGroupId} equals the supplied {@code expectedGroupId}</li>
+         * </ul>
+         *
+         * @param expectedPayload the raw XML that was sent
+         * @param expectedAck     the fixture ACK; {@code null} to skip ACK XPath
+         *                        assertions
+         * @param expectedGroupId expected {@code messageGroupId} (e.g.
+         *                        {@code "127.0.0.1_5555"})
+         * @param softly          collector for soft assertion failures
+         */
+        private void assertHoldFlowS3AndSqs(
+                        String expectedPayload,
+                        String expectedAck,
+                        String expectedGroupId,
+                        SoftAssertions softly) throws Exception {
+
+                ListObjectsV2Response objects = s3Client.listObjectsV2(
+                                ListObjectsV2Request.builder().bucket(HOLD_BUCKET).build());
+
+                softly.assertThat(objects.contents())
+                                .as("HOLD bucket should contain objects").isNotEmpty();
+
+                String metadataKey = objects.contents().stream().map(S3Object::key)
+                                .filter(k -> k.contains("_metadata.json")).findFirst()
+                                .orElseThrow(() -> new AssertionError("Metadata key not found in HOLD bucket"));
+
+                String payloadKey = objects.contents().stream().map(S3Object::key)
+                                .filter(k -> k.contains("soap-message.xml") && !k.contains("_ack")).findFirst()
+                                .orElseThrow(() -> new AssertionError("Payload key not found in HOLD bucket"));
+
+                String ackKey = objects.contents().stream().map(S3Object::key)
+                                .filter(k -> k.contains("_ack")).findFirst()
+                                .orElseThrow(() -> new AssertionError("ACK key not found in HOLD bucket"));
+
+                String actualPayload = readS3(HOLD_BUCKET, payloadKey);
+                String actualAck = readS3(HOLD_BUCKET, ackKey);
+                String metadataContent = readS3(HOLD_BUCKET, metadataKey);
+
+                // ── Payload / ACK ────────────────────────────────────────────────────────
+                softly.assertThat(normalizeXml(actualPayload))
+                                .as("Payload must match request").isEqualTo(normalizeXml(expectedPayload));
+
+                if (expectedAck != null) {
+                        softly.assertThat(extractXPath(actualAck, "//sender/device/id/@root"))
+                                        .isEqualTo(extractXPath(expectedAck, "//sender/device/id/@root"));
+                        softly.assertThat(extractXPath(actualAck, "//receiver/device/id/@root"))
+                                        .isEqualTo(extractXPath(expectedAck, "//receiver/device/id/@root"));
+                }
+
+                // ── Metadata ────────────────────────────────────────────────────────────
+                JsonNode meta = MAPPER.readTree(metadataContent);
+                String key = meta.get("key").asText();
+                JsonNode jsonMeta = meta.get("json_metadata");
+                String s3DataPath = jsonMeta.get("s3DataObjectPath").asText();
+                String metaPath = jsonMeta.get("fullS3MetaDataPath").asText();
+                String ackPath = jsonMeta.get("fullS3AcknowledgementPath").asText();
+
+                String datePath = todayDatePath();
+                String expectedDataPrefix = "http/hold/5555/" + datePath;
+                String expectedMetaPrefix = "outbound/hold/metadata/5555/" + datePath;
+
+                softly.assertThat(key).as("Key must follow HOLD data structure").startsWith(expectedDataPrefix);
+                softly.assertThat(metadataKey).as("Metadata key must follow HOLD metadata structure")
+                                .startsWith(expectedMetaPrefix);
+
+                // Full S3 path validation
+                softly.assertThat(s3DataPath).as("Full data path")
+                                .isEqualTo("s3://" + HOLD_BUCKET + "/" + key);
+                softly.assertThat(metaPath).as("Full metadata path")
+                                .isEqualTo("s3://" + HOLD_BUCKET + "/" + metadataKey);
+                softly.assertThat(ackPath).as("ACK path")
+                                .isEqualTo("s3://" + HOLD_BUCKET + "/" + ackKey);
+
+                // Suffix consistency
+                String suffix = key.substring(expectedDataPrefix.length() + 1);
+                softly.assertThat(ackKey).as("ACK key suffix").endsWith(suffix + "_ack");
+                softly.assertThat(metadataKey).as("Metadata key suffix").endsWith(suffix + "_metadata.json");
+
+                // ── SQS ─────────────────────────────────────────────────────────────────
+                assertSqsConsistency(
+                                queueUrls.get("test.fifo"),
+                                s3DataPath, metaPath, ackPath,
+                                key, expectedGroupId, softly);
+        }
+
+        /**
+         * Validates that the SQS message received from {@code queueUrl} is consistent
+         * with the corresponding S3 metadata.
+         *
+         * <p>
+         * Checks: {@code s3DataObjectPath}, {@code fullS3MetaDataPath},
+         * {@code fullS3AcknowledgementPath}, {@code s3ObjectId}, and
+         * {@code messageGroupId}.
+         */
+        private void assertSqsConsistency(
+                        String queueUrl,
+                        String expectedDataPath,
+                        String expectedMetaPath,
+                        String expectedAckPath,
+                        String expectedObjectId,
+                        String expectedGroupId,
+                        SoftAssertions softly) throws Exception {
+
+                ReceiveMessageResponse sqsResponse = waitForSqsMessage(queueUrl);
+                softly.assertThat(sqsResponse.messages()).as("SQS queue should have a message").isNotEmpty();
+
+                if (sqsResponse.messages().isEmpty()) {
+                        return; // soft — remaining checks would NPE
+                }
+
+                Message msg = sqsResponse.messages().get(0);
+                JsonNode sqsJson = MAPPER.readTree(msg.body());
+
+                softly.assertThat(sqsJson.get("s3DataObjectPath").asText())
+                                .as("SQS s3DataObjectPath").isEqualTo(expectedDataPath);
+                softly.assertThat(sqsJson.get("fullS3MetaDataPath").asText())
+                                .as("SQS fullS3MetaDataPath").isEqualTo(expectedMetaPath);
+                softly.assertThat(sqsJson.get("fullS3AcknowledgementPath").asText())
+                                .as("SQS fullS3AcknowledgementPath").isEqualTo(expectedAckPath);
+                softly.assertThat(sqsJson.get("s3ObjectId").asText())
+                                .as("SQS s3ObjectId").isEqualTo(expectedObjectId);
+                softly.assertThat(sqsJson.get("messageGroupId").asText())
+                                .as("SQS messageGroupId").isEqualTo(expectedGroupId);
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // Envelope assertion helpers (XPath-based)
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        /**
+         * Asserts that the response uses a SOAP 1.2 envelope namespace, verified via
+         * XPath rather than fragile string-contains matching.
+         *
+         * <p>
+         * XPath expression:
+         * {@code //*[local-name()='Envelope']/@*[local-name()='Envelope']}
+         * is unreliable with prefix aliasing; we instead verify the namespace URI
+         * is present in the serialised response, but anchor it to the {@code Envelope}
+         * element to avoid false positives from body content.
+         */
+        private void assertSoap12Envelope(String response, SoftAssertions softly) {
+                String soap12Uri = "http://www.w3.org/2003/05/soap-envelope";
+
+                String namespace = extractXPath(response, "namespace-uri(/*)");
+                String localName = extractXPath(response, "local-name(/*)");
+
+                softly.assertThat(localName)
+                                .as("Root element must be 'Envelope'")
+                                .isEqualTo("Envelope");
+
+                softly.assertThat(namespace)
+                                .as("Envelope must declare SOAP 1.2 namespace")
+                                .isEqualTo(soap12Uri);
+        }
+
+        private void assertSoap11Envelope(String response, SoftAssertions softly) {
+                String soap11Uri = "http://schemas.xmlsoap.org/soap/envelope/";
+
+                String namespace = extractXPath(response, "namespace-uri(/*)");
+                String localName = extractXPath(response, "local-name(/*)");
+
+                softly.assertThat(localName)
+                                .as("Root element must be 'Envelope'")
+                                .isEqualTo("Envelope");
+
+                softly.assertThat(namespace)
+                                .as("Envelope must declare SOAP 1.1 namespace")
+                                .isEqualTo(soap11Uri);
+        }
+        // ═══════════════════════════════════════════════════════════════════════════
+        // Utility helpers
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        /** Reads an S3 object and returns its content as a UTF-8 string. */
+        private String readS3(String bucket, String key) {
+                return s3Client.getObjectAsBytes(
+                                GetObjectRequest.builder().bucket(bucket).key(key).build())
+                                .asUtf8String();
+        }
+
+        /**
+         * Returns the expected S3 key prefix for the <em>default</em> flow:
+         * {@code data/YYYY/MM/DD}.
+         */
+        private static String todayDataPrefix() {
+                LocalDate d = LocalDate.now();
+                return String.format("data/%d/%02d/%02d", d.getYear(), d.getMonthValue(), d.getDayOfMonth());
+        }
+
+        /**
+         * Returns today's date as {@code YYYY/MM/DD}, used inside HOLD key paths.
+         */
+        private static String todayDatePath() {
+                LocalDate d = LocalDate.now();
+                return String.format("%d/%02d/%02d", d.getYear(), d.getMonthValue(), d.getDayOfMonth());
+        }
+
+        /**
+         * Extracts the suffix of a full S3 path after the given prefix.
+         * <p>
+         * Example:
+         * {@code extractSuffix("s3://bucket/data/2025/01/01/foo", "data/2025/01/01/")}
+         * returns {@code "foo"}.
+         */
+        private static String extractSuffix(String fullPath, String prefix) {
+                int idx = fullPath.indexOf(prefix);
+                if (idx < 0) {
+                        throw new AssertionError("Prefix '" + prefix + "' not found in path: " + fullPath);
+                }
+                return fullPath.substring(idx + prefix.length());
+        }
+
+        private String normalizeXml(String xml) {
+                return xml
+                                .replaceAll(">\\s+<", "><")
+                                .replaceAll("\\s+", " ")
+                                .trim();
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // SOAP / MTOM request helpers
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        private String sendSoapRequest(String xml, String soapProtocol, String forwardedPort,
+                        SoftAssertions softly) {
+                HttpHeaders headers = buildSoapHeaders(soapProtocol, forwardedPort);
+                ResponseEntity<String> response = restTemplate.postForEntity(
+                                "http://localhost:" + port + "/ws",
+                                new HttpEntity<>(xml, headers),
+                                String.class);
+                softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                return response.getBody();
+        }
+
+        private String sendMtomRequest(String mtomRaw, String forwardedPort, SoftAssertions softly) {
+                String boundary = extractMtomBoundary(mtomRaw);
+                HttpHeaders headers = new HttpHeaders();
+                headers.set(HttpHeaders.CONTENT_TYPE,
+                                "multipart/related; type=\"application/xop+xml\"; boundary=\"" + boundary + "\"; "
+                                                + "start=\"<request@meditech.com>\"; start-info=\"application/soap+xml\"");
+                headers.set(Constants.REQ_X_FORWARDED_PORT, forwardedPort);
+                headers.set(Constants.REQ_X_SERVER_IP, "127.0.0.1");
+
+                ResponseEntity<String> response = restTemplate.postForEntity(
+                                "http://localhost:" + port + "/ws",
+                                new HttpEntity<>(mtomRaw, headers),
+                                String.class);
+                softly.assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+                return response.getBody();
+        }
+
+        private HttpHeaders buildSoapHeaders(String soapProtocol, String forwardedPort) {
+                HttpHeaders headers = new HttpHeaders();
+                if (SOAPConstants.SOAP_1_2_PROTOCOL.equalsIgnoreCase(soapProtocol)) {
+                        headers.setContentType(MediaType.valueOf("application/soap+xml"));
+                } else if (SOAPConstants.SOAP_1_1_PROTOCOL.equalsIgnoreCase(soapProtocol)) {
+                        headers.setContentType(MediaType.TEXT_XML);
+                        headers.add("SOAPAction", "");
+                } else {
+                        throw new IllegalArgumentException("Unsupported SOAP protocol: " + soapProtocol);
+                }
+                headers.set(Constants.REQ_X_SERVER_IP, "127.0.0.1");
+                headers.set(Constants.REQ_X_FORWARDED_PORT, forwardedPort);
+                return headers;
+        }
+
+        // ── SQS polling ─────────────────────────────────────────────────────────
+
+        /**
+         * Polls the given queue URL until a message arrives or retries are exhausted.
+         *
+         * @throws AssertionError if no message is received after all retry attempts
+         */
+        private ReceiveMessageResponse waitForSqsMessage(String queueUrl) throws InterruptedException {
+                if (queueUrl == null) {
+                        throw new IllegalArgumentException("queueUrl must not be null");
+                }
+                for (int i = 0; i < 5; i++) {
+                        ReceiveMessageResponse resp = sqsClient.receiveMessage(
+                                        ReceiveMessageRequest.builder()
+                                                        .queueUrl(queueUrl)
+                                                        .waitTimeSeconds(2)
+                                                        .build());
+                        if (!resp.messages().isEmpty()) {
+                                return resp;
+                        }
+                        Thread.sleep(1000);
+                }
+                throw new AssertionError("No SQS message received after retries for queue: " + queueUrl);
+        }
+
+        /** Convenience overload that polls the main FIFO queue. */
+        private ReceiveMessageResponse waitForSqsMessage() throws InterruptedException {
+                return waitForSqsMessage(mainQueueUrl);
+        }
+
+        private static String extractMtomBoundary(String mtomRaw) {
+                for (String line : mtomRaw.split("\r?\n")) {
+                        String trimmed = line.trim();
+                        if (trimmed.startsWith("--") && !trimmed.equals("--")) {
+                                return trimmed.substring(2);
+                        }
+                }
+                throw new IllegalArgumentException("Could not extract MTOM boundary from fixture");
+        }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/util/SoapTestFixtures.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/util/SoapTestFixtures.java
@@ -1,0 +1,91 @@
+package org.techbd.ingest.integrationtests.util;
+
+
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.util.StreamUtils;
+import org.xml.sax.InputSource;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import java.io.StringReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Shared fixture-loading utility for SOAP endpoint tests.
+ *
+ * <p>Usable as a static import from both:
+ * <ul>
+ *   <li>{@code SoapEndpointFixtureTest} (Mockito unit tests — no Spring context)</li>
+ *   <li>{@code SoapEndpointIT} and other IT classes (Spring Boot integration tests)</li>
+ * </ul>
+ *
+ * <p>All fixtures live under:
+ * {@code src/test/resources/org/techbd/ingest/soap-test-resources/}
+ *
+ * <p>Usage:
+ * <pre>
+ * import static org.techbd.ingest.util.SoapTestFixtures.*;
+ *
+ * String xml = loadFixture("pix-add-request.txt");
+ * </pre>
+ */
+public final class SoapTestFixtures {
+
+    /** Classpath prefix for all SOAP fixture files. */
+    public static final String RESOURCE_PREFIX =
+            "classpath:org/techbd/ingest/soap-test-resources/";
+
+    /**
+     * File-system path to the same resources — used by tests that read
+     * fixtures with {@code Files.readString()} (e.g. {@code SoapEndpointFixtureTest}).
+     */
+    public static final String RESOURCE_BASE =
+            "src/test/resources/org/techbd/ingest/soap-test-resources/";
+
+    private SoapTestFixtures() {}
+
+    /**
+     * Loads a named fixture from the classpath (works in both unit and
+     * integration tests, and inside JARs). Prefer this over the file-system
+     * variant for portability.
+     */
+    public static String loadFixture(String filename) throws IOException {
+        String path = RESOURCE_PREFIX + filename;
+        try (InputStream is = new DefaultResourceLoader()
+                .getResource(path)
+                .getInputStream()) {
+            return StreamUtils.copyToString(is, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Silent variant for use inside Mockito {@code thenReturn()} / {@code when()}
+     * chains where a checked exception cannot be thrown.
+     */
+    public static String loadFixtureQuiet(String filename) {
+        try {
+            return loadFixture(filename);
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot read fixture: " + filename, e);
+        }
+    }
+    public static String extractXPath(String xml, String expression) {
+    try {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true); 
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        return xpath.evaluate(expression, document);
+
+    } catch (Exception e) {
+        throw new RuntimeException("Failed to evaluate XPath: " + expression, e);
+    }
+}
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/SoapResponseUtilTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/SoapResponseUtilTest.java
@@ -1,0 +1,305 @@
+package org.techbd.ingest.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Iterator;
+
+import javax.xml.namespace.QName;
+import javax.xml.transform.stream.StreamResult;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapHeader;
+import org.springframework.ws.soap.SoapHeaderElement;
+import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.transport.context.TransportContext;
+import org.springframework.ws.transport.context.TransportContextHolder;
+import org.springframework.ws.transport.http.HttpServletConnection;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.config.AppConfig;
+import org.techbd.ingest.feature.FeatureEnum;
+import org.techbd.ingest.model.RequestContext;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@ExtendWith(MockitoExtension.class)
+class SoapResponseUtilTest {
+
+    // ── Config mocks ──────────────────────────────────────────────────────────
+
+    @Mock private AppConfig appConfig;
+    @Mock private AppConfig.Soap soapConfig;
+    @Mock private AppConfig.Soap.Wsa wsaConfig;
+    @Mock private AppConfig.Soap.Techbd techbdConfig;
+
+    // ── Spring-WS mocks ───────────────────────────────────────────────────────
+
+    @Mock private MessageContext messageContext;
+    @Mock private SoapMessage soapResponse;
+    @Mock private SoapMessage soapRequest;
+    @Mock private SoapHeader responseHeader;
+    @Mock private SoapHeader requestHeader;
+    @Mock private SoapHeaderElement requestHeaderElement; // MessageID in the incoming request
+    @Mock private SoapHeaderElement addedElement;         // returned by responseHeader.addHeaderElement
+
+    // ── Servlet mocks ─────────────────────────────────────────────────────────
+
+    @Mock private TransportContext transportContext;
+    @Mock private HttpServletConnection httpServletConnection;
+    @Mock private HttpServletRequest httpServletRequest;
+    @Mock private RequestContext requestContext;
+
+    // ── Logger mocks ──────────────────────────────────────────────────────────
+
+    @Mock private AppLogger appLogger;
+    @Mock private TemplateLogger templateLogger;
+
+    // ── Static mock handles ───────────────────────────────────────────────────
+
+    private MockedStatic<TransportContextHolder> transportContextHolderMock;
+    private MockedStatic<FeatureEnum>            featureEnumMock;
+
+    // ── System under test ─────────────────────────────────────────────────────
+
+    private SoapResponseUtil sut;
+
+    // ── Constants ─────────────────────────────────────────────────────────────
+
+    private static final String INTERACTION_ID = "test-interaction-123";
+    private static final String WSA_NS         = "http://www.w3.org/2005/08/addressing";
+    private static final String WSA_PREFIX     = "wsa";
+    private static final String WSA_ACTION     = "urn:hl7-org:v3:PRPA_IN201301UV02";
+    private static final String WSA_PNR_ACTION = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
+    private static final String WSA_TO         = "urn:hl7-org:v3:PRPA_IN201301UV02";
+    private static final String TECHBD_NS      = "http://techbd.org/ingest";
+    private static final String TECHBD_PREFIX  = "techbd";
+    private static final String APP_VERSION    = "1.0.0-test";
+    private static final String MESSAGE_ID     = "urn:uuid:request-message-id";
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @BeforeEach
+    void setUp() {
+        // ── Logger ────────────────────────────────────────────────────────────
+        // getLogger() is always invoked by the constructor.
+        // doNothing() on void mocks is Mockito's default — no explicit stub needed.
+        when(appLogger.getLogger(SoapResponseUtil.class)).thenReturn(templateLogger);
+
+        // ── AppConfig ─────────────────────────────────────────────────────────
+        // All config stubs are lenient: the exception test throws at getResponse()
+        // before any config is accessed, so no config stub is consumed by every test.
+        lenient().when(appConfig.getSoap()).thenReturn(soapConfig);
+        lenient().when(soapConfig.getWsa()).thenReturn(wsaConfig);
+        lenient().when(wsaConfig.getNamespace()).thenReturn(WSA_NS);
+        lenient().when(wsaConfig.getPrefix()).thenReturn(WSA_PREFIX);
+
+        // Action/PNR-action/To/version are only reached after the PIX/PNR branch.
+        // The exception test throws at getResponse() and never reaches them.
+        lenient().when(wsaConfig.getAction()).thenReturn(WSA_ACTION);
+        lenient().when(wsaConfig.getPnrAction()).thenReturn(WSA_PNR_ACTION);
+        lenient().when(wsaConfig.getTo()).thenReturn(WSA_TO);
+        lenient().when(appConfig.getVersion()).thenReturn(APP_VERSION);
+
+        // TechBD config only reached when the feature flag is on.
+        lenient().when(soapConfig.getTechbd()).thenReturn(techbdConfig);
+        lenient().when(techbdConfig.getNamespace()).thenReturn(TECHBD_NS);
+        lenient().when(techbdConfig.getPrefix()).thenReturn(TECHBD_PREFIX);
+
+        // ── Static mocks ───────────────────────────────────────────────────────
+        transportContextHolderMock = mockStatic(TransportContextHolder.class);
+        featureEnumMock             = mockStatic(FeatureEnum.class);
+
+        // Transport chain — not reached by the exception test.
+        lenient().when(TransportContextHolder.getTransportContext()).thenReturn(transportContext);
+        lenient().when(transportContext.getConnection()).thenReturn(httpServletConnection);
+        lenient().when(httpServletConnection.getHttpServletRequest()).thenReturn(httpServletRequest);
+        lenient().when(httpServletRequest.getAttribute(Constants.REQUEST_CONTEXT)).thenReturn(requestContext);
+
+        // ── Message context ────────────────────────────────────────────────────
+        // getResponse() is always called; getRequest() and getSoapHeader() are not
+        // reached by the exception test (which re-stubs getResponse() to throw).
+        when(messageContext.getResponse()).thenReturn(soapResponse);
+        lenient().when(messageContext.getRequest()).thenReturn(soapRequest);
+        lenient().when(soapResponse.getSoapHeader()).thenReturn(responseHeader);
+        lenient().when(soapRequest.getSoapHeader()).thenReturn(requestHeader);
+
+        // ── Response header ────────────────────────────────────────────────────
+        lenient().when(responseHeader.addHeaderElement(any(QName.class))).thenReturn(addedElement);
+
+        // ── Request MessageID header (default: present and valid) ──────────────
+        Iterator<SoapHeaderElement> iter =
+                Collections.singletonList(requestHeaderElement).iterator();
+        lenient().when(requestHeader.examineAllHeaderElements()).thenReturn(iter);
+        lenient().when(requestHeaderElement.getName())
+                 .thenReturn(new QName(WSA_NS, "MessageID", WSA_PREFIX));
+        lenient().when(requestHeaderElement.getText()).thenReturn(MESSAGE_ID);
+
+        sut = new SoapResponseUtil(appConfig, appLogger);
+    }
+
+    @AfterEach
+    void tearDown() {
+        transportContextHolderMock.close();
+        featureEnumMock.close();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Happy path — PIX request, feature flag disabled.
+     * Exactly four WS-Addressing headers are added; the PIX action is used.
+     */
+    @Test
+    void buildSoapResponse_pixRequest_featureFlagOff_addsWsaHeadersOnly() {
+        when(requestContext.isPixRequest()).thenReturn(true);
+        featureEnumMock
+                .when(() -> FeatureEnum.isEnabled(FeatureEnum.INCLUDE_TECHBD_INTERACTION_ID_IN_SOAP_RESPONSE))
+                .thenReturn(false);
+
+        SoapMessage result = sut.buildSoapResponse(INTERACTION_ID, messageContext);
+
+        assertNotNull(result);
+        verify(responseHeader, times(4)).addHeaderElement(any(QName.class));
+        verify(addedElement, times(4)).setText(anyString());
+        verify(responseHeader).addHeaderElement(new QName(WSA_NS, "Action", WSA_PREFIX));
+    }
+
+    /**
+     * PNR request — verifies the PNR action branch is taken.
+     */
+    @Test
+    void buildSoapResponse_pnrRequest_featureFlagOff_usesPnrAction() {
+        when(requestContext.isPixRequest()).thenReturn(false);
+        featureEnumMock
+                .when(() -> FeatureEnum.isEnabled(FeatureEnum.INCLUDE_TECHBD_INTERACTION_ID_IN_SOAP_RESPONSE))
+                .thenReturn(false);
+
+        SoapMessage result = sut.buildSoapResponse(INTERACTION_ID, messageContext);
+
+        assertNotNull(result);
+        verify(responseHeader, times(4)).addHeaderElement(any(QName.class));
+    }
+
+    /**
+     * Feature flag enabled — TechBD custom segment is appended via Transformer.
+     * Uses a real StreamResult so the JDK transformer has a valid output sink.
+     * Asserts both custom attributes appear in the serialised XML.
+     */
+    @Test
+    void buildSoapResponse_featureFlagOn_appendsTechBdSegment() {
+        when(requestContext.isPixRequest()).thenReturn(true);
+        featureEnumMock
+                .when(() -> FeatureEnum.isEnabled(FeatureEnum.INCLUDE_TECHBD_INTERACTION_ID_IN_SOAP_RESPONSE))
+                .thenReturn(true);
+
+        StringWriter sw = new StringWriter();
+        when(responseHeader.getResult()).thenReturn(new StreamResult(sw));
+
+        SoapMessage result = sut.buildSoapResponse(INTERACTION_ID, messageContext);
+
+        assertNotNull(result);
+        verify(responseHeader, atLeastOnce()).getResult();
+        String xml = sw.toString();
+        assertThat(xml).contains("InteractionID=\"" + INTERACTION_ID + "\"");
+        assertThat(xml).contains("TechBDIngestionApiVersion=\"" + APP_VERSION + "\"");
+    }
+
+    /**
+     * No MessageID header present — extractRelatesTo returns null,
+     * fallback RelatesTo is used, and a warning is logged.
+     */
+    @Test
+    void buildSoapResponse_missingMessageIdHeader_usesFallbackRelatesTo() {
+        when(requestHeader.examineAllHeaderElements()).thenReturn(Collections.emptyIterator());
+        when(requestContext.isPixRequest()).thenReturn(true);
+        featureEnumMock
+                .when(() -> FeatureEnum.isEnabled(FeatureEnum.INCLUDE_TECHBD_INTERACTION_ID_IN_SOAP_RESPONSE))
+                .thenReturn(false);
+
+        SoapMessage result = sut.buildSoapResponse(INTERACTION_ID, messageContext);
+
+        assertNotNull(result);
+        verify(responseHeader).addHeaderElement(new QName(WSA_NS, "RelatesTo", WSA_PREFIX));
+        verify(templateLogger).warn(anyString(), any(Object[].class));
+    }
+
+    /**
+     * Header present but local name is not MessageID — skipped,
+     * fallback RelatesTo is used, and a warning is logged.
+     */
+    @Test
+    void buildSoapResponse_nonMessageIdHeader_usesFallbackRelatesTo() {
+        when(requestHeaderElement.getName()).thenReturn(new QName(WSA_NS, "Action", WSA_PREFIX));
+        when(requestContext.isPixRequest()).thenReturn(false);
+        featureEnumMock
+                .when(() -> FeatureEnum.isEnabled(FeatureEnum.INCLUDE_TECHBD_INTERACTION_ID_IN_SOAP_RESPONSE))
+                .thenReturn(false);
+
+        SoapMessage result = sut.buildSoapResponse(INTERACTION_ID, messageContext);
+
+        assertNotNull(result);
+        verify(templateLogger).warn(anyString(), any(Object[].class));
+    }
+
+    /**
+     * Any exception inside buildSoapResponse is wrapped in RuntimeException
+     * with the expected message, and the error level is logged.
+     */
+    @Test
+    void buildSoapResponse_onException_throwsRuntimeException() {
+        when(messageContext.getResponse()).thenThrow(new IllegalStateException("no response"));
+
+        assertThatThrownBy(() -> sut.buildSoapResponse(INTERACTION_ID, messageContext))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Error creating SOAP response")
+                .hasCauseInstanceOf(IllegalStateException.class);
+
+        verify(templateLogger).error(anyString(), any(Object[].class));
+    }
+
+    /**
+     * MessageID response header is set to a randomly generated urn:uuid: value.
+     */
+    @Test
+    void buildSoapResponse_generatesUrnUuidMessageId() {
+        when(requestContext.isPixRequest()).thenReturn(true);
+        featureEnumMock
+                .when(() -> FeatureEnum.isEnabled(FeatureEnum.INCLUDE_TECHBD_INTERACTION_ID_IN_SOAP_RESPONSE))
+                .thenReturn(false);
+
+        sut.buildSoapResponse(INTERACTION_ID, messageContext);
+
+        verify(addedElement, atLeastOnce()).setText(argThat(text ->
+                text != null && text.startsWith("urn:uuid:")
+        ));
+    }
+
+    /**
+     * To header is populated with the value from AppConfig.
+     */
+    @Test
+    void buildSoapResponse_setsToHeaderFromConfig() {
+        when(requestContext.isPixRequest()).thenReturn(false);
+        featureEnumMock
+                .when(() -> FeatureEnum.isEnabled(FeatureEnum.INCLUDE_TECHBD_INTERACTION_ID_IN_SOAP_RESPONSE))
+                .thenReturn(false);
+
+        sut.buildSoapResponse(INTERACTION_ID, messageContext);
+
+        verify(responseHeader).addHeaderElement(new QName(WSA_NS, "To", WSA_PREFIX));
+        verify(addedElement, atLeastOnce()).setText(WSA_TO);
+    }
+}

--- a/nexus-ingestion-api/src/test/resources/application-test.yml
+++ b/nexus-ingestion-api/src/test/resources/application-test.yml
@@ -1,0 +1,27 @@
+org:
+  techbd:
+    version: "test-version"
+    aws:
+      region: "us-east-1"
+      secret-name: "test-secret"
+      sqs:
+        base-url: "http://localhost:4566"
+        fifo-queue-url: "http://localhost:4566/000000000000/txd-sbx-main-queue.fifo"
+      s3:
+        default-config:
+          bucket: "local-sbx-nexus-ingestion-s3-bucket"
+          metadata-bucket: "local-sbx-nexus-ingestion-s3-metadata-bucket"
+        hold-config:
+          bucket: "local-pdr-txd-sbx-hold"
+          metadata-bucket: "local-pdr-txd-sbx-hold"
+    soap:
+      wsa:
+        namespace: "http://www.w3.org/2005/08/addressing"
+        prefix: "wsa"
+        action: "urn:hl7-org:v3:MCCI_IN000002UV01"
+        pnrAction: "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b"
+        to: "http://www.w3.org/2005/08/addressing/anonymous"
+        understood-namespaces: "http://www.w3.org/2005/08/addressing"
+      techbd:
+        namespace: "urn:techbd:custom"
+        prefix: "techbd"

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/portconfig/list.json
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/portconfig/list.json
@@ -1,0 +1,181 @@
+[
+    {
+        "port": 2575,
+        "responseType": "mllp",
+        "protocol": "TCP"
+    },
+    {
+        "sourceId":"netspective",
+        "msgType":"pnr",
+        "protocol": "TCP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "ackContentType": "application/soap+xml"
+    },
+       {
+        "port": 5555,
+        "responseType": "mllp",
+        "protocol": "TCP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "queue": "test.fifo",
+         "keepAliveTimeout": 20
+    },
+    {
+        "port": 5555,
+        "responseType": "",
+        "protocol": "",
+        "route": "/hold",
+        "dataDir": "/http",
+        "metadataDir": "/outbound",
+        "queue": "test.fifo",
+         "keepAliveTimeout": 20
+    },
+    {
+        "port": 5556,
+        "responseType": "pnr",
+        "protocol": "http",
+        "route": "/xds/XDSbRepositoryWS",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "queue": "test.fifo",
+         "keepAliveTimeout": 20
+    },
+    {
+        "sourceId":"netspective",
+        "msgType":"pix",
+        "protocol": "TCP",
+        "route": "/",
+        "queue": "txd-sbx-util-queue.fifo",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+         "ackContentType": "application/soap+xml"
+    },
+    {
+        "port": 3575,
+        "responseType": "mllp",
+        "protocol": "TCP",
+        "route": "/",
+        "queue": "txd-sbx-util-queue.fifo",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "ackContentType": "application/soap+xml"
+    },
+    {
+        "port": 9203,
+        "responseType": "pnr",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "mtls": "txd",
+        "execType": "async",
+        "trafficTo": "hl7",
+        "route": "/hold",
+        "queue": "txd-sbx-ccd-queue.fifo",
+        "dataDir": "/ccd",
+        "metadataDir": ""
+    },
+    {
+        "port": 9204,
+        "responseType": "pnr",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "mtls": "txd-sbx",
+        "execType": "async",
+        "trafficTo": "hl7",
+        "route": "/hold",
+        "queue": "txd-sbx-ccd-queue.fifo",
+        "dataDir": "/ccd",
+        "metadataDir": ""
+    },
+    {
+        "port": 9050,
+        "responseType": "pix",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "execType": "sync",
+        "trafficTo": "hl7",
+        "route": "/",
+        "queue": "txd-sbx-ccd-queue.fifo",
+        "dataDir": "/ccd",
+        "metadataDir": ""
+    },
+    {
+        "port": 9000,
+        "responseType": "",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        
+        "execType": "sync",
+        "trafficTo": "util"
+    },
+    {
+        "port": 9001,
+        "responseType": "",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "execType": "sync",
+        "trafficTo": "util"
+    },
+    {
+        "port": 9002,
+        "responseType": "",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "execType": "sync",
+        "trafficTo": "util"
+    },
+    {
+        "port": 9003,
+        "responseType": "",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "execType": "sync",
+        "trafficTo": "util"
+    },
+    {
+        "port": 9004,
+        "responseType": "",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "execType": "sync",
+        "trafficTo": "util"
+    },
+    {
+        "port": 9005,
+        "responseType": "",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "execType": "sync",
+        "trafficTo": "util"
+    },
+    {
+        "port": 9006,
+        "responseType": "",
+        "protocol": "HTTP",
+        "whitelistIps": [
+            "0.0.0.0/0"
+        ],
+        "execType": "sync",
+        "trafficTo": "util"
+    }
+]

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-request_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-request_1_1.txt
@@ -1,0 +1,116 @@
+<!-- 
+  SOAP 1.2 Envelope namespace is used here. 
+  xmlns:v3 refers to the HL7 v3 XML namespace, commonly used in healthcare integration.
+  xmlns:wsa is for WS-Addressing headers (MessageID, etc.)
+-->
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:v3="urn:hl7-org:v3"
+                   xmlns:wsa="http://www.w3.org/2005/08/addressing">
+
+   <!-- SOAP Header contains WS-Addressing MessageID -->
+   <SOAP-ENV:Header>
+      <wsa:MessageID>urn:uuid:123e4567-e89b-12d3-a456-426614174000</wsa:MessageID>
+   </SOAP-ENV:Header>
+
+   <!-- SOAP Body starts here -->
+   <SOAP-ENV:Body>
+
+      <!-- HL7 v3 interaction: Patient Registry Record Added Request (ITI-44) -->
+      <v3:PRPA_IN201301UV02 ITSVersion="XML_1.0">
+
+         <!-- Unique ID for the message (OID + extension) -->
+         <v3:id root="2.16.840.1.113883.3.72.5.9.1" extension="12345"/>
+
+         <!-- Timestamp of message creation in format: YYYYMMDDHHMMSS -->
+         <v3:creationTime value="20250805163000"/>
+
+         <!-- Defines the type of HL7 interaction being performed -->
+         <v3:interactionId root="2.16.840.1.113883.1.6" extension="PRPA_IN201301UV02"/>
+
+         <!-- Message processing code: T = Training/Test, P = Production -->
+         <v3:processingCode code="T"/>
+
+         <!-- Processing mode code: T = Training/Test -->
+         <v3:processingModeCode code="T"/>
+
+         <!-- Acknowledgment request code: AL = Always acknowledge -->
+         <v3:acceptAckCode code="AL"/>
+
+         <!-- Message sender (system that sends the request) -->
+         <v3:sender typeCode="SND">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="1.2.3.4.5"/>
+            </v3:device>
+         </v3:sender>
+
+         <!-- Optional: Message receiver (system expected to process the request) -->
+         <v3:receiver typeCode="RCV">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="9.8.7.6.5.4.3.2.1"/>
+            </v3:device>
+         </v3:receiver>
+
+         <!-- Main control structure wrapping the core message payload -->
+         <v3:controlActProcess classCode="CACT" moodCode="EVN">
+
+            <!-- Trigger code for this control act process -->
+            <v3:code code="PRPA_TE201301UV02" codeSystem="2.16.840.1.113883.1.6"/>
+
+            <!-- Subject (the actual patient registration event being submitted) -->
+            <v3:subject typeCode="SUBJ">
+               <v3:registrationEvent classCode="REG" moodCode="EVN">
+                  <v3:statusCode code="active"/>
+
+                  <!-- Actual patient data -->
+                  <v3:subject1>
+                     <v3:patient classCode="PAT">
+                        <!-- Patient Identifier (assigned by the source system) -->
+                        <v3:id root="2.25.123456789" extension="PATIENT-001"/>
+                        <v3:statusCode code="active"/>
+
+                        <!-- Patient demographic info -->
+                        <v3:patientPerson>
+                           <!-- Patient name -->
+                           <v3:name>
+                              <v3:given>John</v3:given>
+                              <v3:family>Doe</v3:family>
+                           </v3:name>
+
+                           <!-- Gender: M = Male, F = Female, U = Unknown -->
+                           <v3:administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+
+                           <!-- Birth date -->
+                           <v3:birthTime value="19900101"/>
+
+                           <!-- Optional: contact details -->
+                           <v3:telecom value="tel:+1-555-555-1234"/>
+
+                           <!-- Optional: address -->
+                           <v3:addr use="HP">
+                              <v3:streetAddressLine>123 Main St</v3:streetAddressLine>
+                              <v3:city>Anytown</v3:city>
+                              <v3:state>CA</v3:state>
+                              <v3:postalCode>90210</v3:postalCode>
+                              <v3:country>USA</v3:country>
+                           </v3:addr>
+
+                        </v3:patientPerson>
+                     </v3:patient>
+                  </v3:subject1>
+
+                  <!-- Custodian: the organization responsible for this patient record -->
+                  <v3:custodian>
+                     <v3:assignedEntity>
+                        <v3:id root="2.16.840.1.113883.3.72.5.9.10"/>
+                     </v3:assignedEntity>
+                  </v3:custodian>
+
+               </v3:registrationEvent>
+            </v3:subject>
+
+         </v3:controlActProcess>
+
+      </v3:PRPA_IN201301UV02>
+
+   </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-request_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-request_1_2.txt
@@ -1,0 +1,116 @@
+<!-- 
+  SOAP 1.2 Envelope namespace is used here. 
+  xmlns:v3 refers to the HL7 v3 XML namespace, commonly used in healthcare integration.
+  xmlns:wsa is for WS-Addressing headers (MessageID, etc.)
+-->
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
+                   xmlns:v3="urn:hl7-org:v3"
+                   xmlns:wsa="http://www.w3.org/2005/08/addressing">
+
+   <!-- SOAP Header contains WS-Addressing MessageID -->
+   <SOAP-ENV:Header>
+      <wsa:MessageID>urn:uuid:123e4567-e89b-12d3-a456-426614174000</wsa:MessageID>
+   </SOAP-ENV:Header>
+
+   <!-- SOAP Body starts here -->
+   <SOAP-ENV:Body>
+
+      <!-- HL7 v3 interaction: Patient Registry Record Added Request (ITI-44) -->
+      <v3:PRPA_IN201301UV02 ITSVersion="XML_1.0">
+
+         <!-- Unique ID for the message (OID + extension) -->
+         <v3:id root="2.16.840.1.113883.3.72.5.9.1" extension="12345"/>
+
+         <!-- Timestamp of message creation in format: YYYYMMDDHHMMSS -->
+         <v3:creationTime value="20250805163000"/>
+
+         <!-- Defines the type of HL7 interaction being performed -->
+         <v3:interactionId root="2.16.840.1.113883.1.6" extension="PRPA_IN201301UV02"/>
+
+         <!-- Message processing code: T = Training/Test, P = Production -->
+         <v3:processingCode code="T"/>
+
+         <!-- Processing mode code: T = Training/Test -->
+         <v3:processingModeCode code="T"/>
+
+         <!-- Acknowledgment request code: AL = Always acknowledge -->
+         <v3:acceptAckCode code="AL"/>
+
+         <!-- Message sender (system that sends the request) -->
+         <v3:sender typeCode="SND">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="1.2.3.4.5"/>
+            </v3:device>
+         </v3:sender>
+
+         <!-- Optional: Message receiver (system expected to process the request) -->
+         <v3:receiver typeCode="RCV">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="9.8.7.6.5.4.3.2.1"/>
+            </v3:device>
+         </v3:receiver>
+
+         <!-- Main control structure wrapping the core message payload -->
+         <v3:controlActProcess classCode="CACT" moodCode="EVN">
+
+            <!-- Trigger code for this control act process -->
+            <v3:code code="PRPA_TE201301UV02" codeSystem="2.16.840.1.113883.1.6"/>
+
+            <!-- Subject (the actual patient registration event being submitted) -->
+            <v3:subject typeCode="SUBJ">
+               <v3:registrationEvent classCode="REG" moodCode="EVN">
+                  <v3:statusCode code="active"/>
+
+                  <!-- Actual patient data -->
+                  <v3:subject1>
+                     <v3:patient classCode="PAT">
+                        <!-- Patient Identifier (assigned by the source system) -->
+                        <v3:id root="2.25.123456789" extension="PATIENT-001"/>
+                        <v3:statusCode code="active"/>
+
+                        <!-- Patient demographic info -->
+                        <v3:patientPerson>
+                           <!-- Patient name -->
+                           <v3:name>
+                              <v3:given>John</v3:given>
+                              <v3:family>Doe</v3:family>
+                           </v3:name>
+
+                           <!-- Gender: M = Male, F = Female, U = Unknown -->
+                           <v3:administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+
+                           <!-- Birth date -->
+                           <v3:birthTime value="19900101"/>
+
+                           <!-- Optional: contact details -->
+                           <v3:telecom value="tel:+1-555-555-1234"/>
+
+                           <!-- Optional: address -->
+                           <v3:addr use="HP">
+                              <v3:streetAddressLine>123 Main St</v3:streetAddressLine>
+                              <v3:city>Anytown</v3:city>
+                              <v3:state>CA</v3:state>
+                              <v3:postalCode>90210</v3:postalCode>
+                              <v3:country>USA</v3:country>
+                           </v3:addr>
+
+                        </v3:patientPerson>
+                     </v3:patient>
+                  </v3:subject1>
+
+                  <!-- Custodian: the organization responsible for this patient record -->
+                  <v3:custodian>
+                     <v3:assignedEntity>
+                        <v3:id root="2.16.840.1.113883.3.72.5.9.10"/>
+                     </v3:assignedEntity>
+                  </v3:custodian>
+
+               </v3:registrationEvent>
+            </v3:subject>
+
+         </v3:controlActProcess>
+
+      </v3:PRPA_IN201301UV02>
+
+   </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-response_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-response_1_1.txt
@@ -1,0 +1,32 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+    <env:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:hl7-org:v3:MCCI_IN000002UV01</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:fbf5c441-e8ff-4a1f-a862-27ac906eeae2</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:123e4567-e89b-12d3-a456-426614174000</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="19db27b9-6d5c-49ac-a374-acc0b870b210" TechBDIngestionApiVersion="0.1092.0"/>
+    </env:Header>
+    <env:Body>
+        <ns2:MCCI_IN000002UV01 xmlns:ns2="urn:hl7-org:v3" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns5="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007">
+            <ns2:id root="68b73eeb-7b06-4b96-afef-55844e1b5e3b"/>
+            <ns2:creationTime value="20260331163216+0530"/>
+            <ns2:interactionId extension="MCCI_IN000002UV01" root="2.16.840.1.113883.1.6"/>
+            <ns2:receiver typeCode="RCV">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                </ns2:device>
+            </ns2:receiver>
+            <ns2:sender typeCode="SND">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                    <ns2:telecom value="HTTP/1.1"/>
+                </ns2:device>
+            </ns2:sender>
+            <ns2:acknowledgement>
+                <ns2:targetMessage>
+                    <ns2:id extension="12345" root="2.16.840.1.113883.3.72.5.9.1"/>
+                </ns2:targetMessage>
+            </ns2:acknowledgement>
+        </ns2:MCCI_IN000002UV01>
+    </env:Body>
+</env:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-response_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-add-response_1_2.txt
@@ -1,0 +1,31 @@
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+    <env:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:hl7-org:v3:MCCI_IN000002UV01</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:fbf5c441-e8ff-4a1f-a862-27ac906eeae2</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:123e4567-e89b-12d3-a456-426614174000</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+    </env:Header>
+    <env:Body>
+        <ns2:MCCI_IN000002UV01 xmlns:ns2="urn:hl7-org:v3" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns5="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007">
+            <ns2:id root="68b73eeb-7b06-4b96-afef-55844e1b5e3b"/>
+            <ns2:creationTime value="20260331163216+0530"/>
+            <ns2:interactionId extension="MCCI_IN000002UV01" root="2.16.840.1.113883.1.6"/>
+            <ns2:receiver typeCode="RCV">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                </ns2:device>
+            </ns2:receiver>
+            <ns2:sender typeCode="SND">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                    <ns2:telecom value="HTTP/1.1"/>
+                </ns2:device>
+            </ns2:sender>
+            <ns2:acknowledgement>
+                <ns2:targetMessage>
+                    <ns2:id extension="12345" root="2.16.840.1.113883.3.72.5.9.1"/>
+                </ns2:targetMessage>
+            </ns2:acknowledgement>
+        </ns2:MCCI_IN000002UV01>
+    </env:Body>
+</env:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-request_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-request_1_1.txt
@@ -1,0 +1,101 @@
+<!-- 
+  SOAP 1.2 Envelope namespace is used here.
+  xmlns:v3 refers to the HL7 v3 XML namespace.
+  xmlns:wsa is for WS-Addressing headers.
+-->
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:v3="urn:hl7-org:v3"
+                   xmlns:wsa="http://www.w3.org/2005/08/addressing">
+
+   <!-- WS-Addressing Header -->
+   <SOAP-ENV:Header>
+      <wsa:MessageID>urn:uuid:223e4567-e89b-12d3-a456-426614174999</wsa:MessageID>
+      <wsa:Action>urn:hl7-org:v3:PRPA_IN201304UV02</wsa:Action>
+   </SOAP-ENV:Header>
+
+   <SOAP-ENV:Body>
+
+      <!-- HL7 v3 interaction: Patient Registry Record Merge Request -->
+      <v3:PRPA_IN201304UV02 ITSVersion="XML_1.0">
+
+         <!-- Message ID -->
+         <v3:id root="2.16.840.1.113883.3.72.5.9.1" extension="MERGE-12345"/>
+
+         <!-- Timestamp -->
+         <v3:creationTime value="20250805164500"/>
+
+         <!-- Interaction ID -->
+         <v3:interactionId root="2.16.840.1.113883.1.6" extension="PRPA_IN201304UV02"/>
+
+         <!-- Processing and acknowledgment codes -->
+         <v3:processingCode code="T"/>
+         <v3:processingModeCode code="T"/>
+         <v3:acceptAckCode code="AL"/>
+
+         <!-- Sender -->
+         <v3:sender typeCode="SND">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="1.2.3.4.5"/>
+            </v3:device>
+         </v3:sender>
+
+         <!-- Receiver -->
+         <v3:receiver typeCode="RCV">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="9.8.7.6.5.4.3.2.1"/>
+            </v3:device>
+         </v3:receiver>
+
+         <!-- Control Act Process for merge -->
+         <v3:controlActProcess classCode="CACT" moodCode="EVN">
+            <v3:code code="PRPA_TE201304UV02" codeSystem="2.16.840.1.113883.1.6"/>
+
+            <!-- Subject contains the merge event -->
+            <v3:subject typeCode="SUBJ">
+               <v3:registrationEvent classCode="REG" moodCode="EVN">
+                  <v3:statusCode code="active"/>
+
+                  <v3:subject1>
+                     <v3:patient classCode="PAT">
+                        <!-- This is the surviving patient record -->
+                        <v3:id root="2.25.123456789" extension="PATIENT-SURVIVOR-001"/>
+                        <v3:statusCode code="active"/>
+                        <v3:patientPerson>
+                           <v3:name>
+                              <v3:given>Jane</v3:given>
+                              <v3:family>Doe</v3:family>
+                           </v3:name>
+                           <v3:administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+                           <v3:birthTime value="19851212"/>
+                        </v3:patientPerson>
+                     </v3:patient>
+                  </v3:subject1>
+
+                  <!-- ReplacementOf indicates the record being merged/deprecated -->
+                  <v3:replacementOf typeCode="RPLC">
+                     <v3:priorRegistration>
+                        <v3:statusCode code="obsolete"/>
+                        <v3:subject1>
+                           <v3:patient>
+                              <!-- This is the obsolete/old patient record -->
+                              <v3:id root="2.25.987654321" extension="PATIENT-OLD-002"/>
+                           </v3:patient>
+                        </v3:subject1>
+                     </v3:priorRegistration>
+                  </v3:replacementOf>
+
+                  <!-- Custodian organization -->
+                  <v3:custodian>
+                     <v3:assignedEntity>
+                        <v3:id root="2.16.840.1.113883.3.72.5.9.10"/>
+                     </v3:assignedEntity>
+                  </v3:custodian>
+
+               </v3:registrationEvent>
+            </v3:subject>
+         </v3:controlActProcess>
+
+      </v3:PRPA_IN201304UV02>
+
+   </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-request_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-request_1_2.txt
@@ -1,0 +1,101 @@
+<!-- 
+  SOAP 1.2 Envelope namespace is used here.
+  xmlns:v3 refers to the HL7 v3 XML namespace.
+  xmlns:wsa is for WS-Addressing headers.
+-->
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
+                   xmlns:v3="urn:hl7-org:v3"
+                   xmlns:wsa="http://www.w3.org/2005/08/addressing">
+
+   <!-- WS-Addressing Header -->
+   <SOAP-ENV:Header>
+      <wsa:MessageID>urn:uuid:223e4567-e89b-12d3-a456-426614174999</wsa:MessageID>
+      <wsa:Action>urn:hl7-org:v3:PRPA_IN201304UV02</wsa:Action>
+   </SOAP-ENV:Header>
+
+   <SOAP-ENV:Body>
+
+      <!-- HL7 v3 interaction: Patient Registry Record Merge Request -->
+      <v3:PRPA_IN201304UV02 ITSVersion="XML_1.0">
+
+         <!-- Message ID -->
+         <v3:id root="2.16.840.1.113883.3.72.5.9.1" extension="MERGE-12345"/>
+
+         <!-- Timestamp -->
+         <v3:creationTime value="20250805164500"/>
+
+         <!-- Interaction ID -->
+         <v3:interactionId root="2.16.840.1.113883.1.6" extension="PRPA_IN201304UV02"/>
+
+         <!-- Processing and acknowledgment codes -->
+         <v3:processingCode code="T"/>
+         <v3:processingModeCode code="T"/>
+         <v3:acceptAckCode code="AL"/>
+
+         <!-- Sender -->
+         <v3:sender typeCode="SND">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="1.2.3.4.5"/>
+            </v3:device>
+         </v3:sender>
+
+         <!-- Receiver -->
+         <v3:receiver typeCode="RCV">
+            <v3:device classCode="DEV" determinerCode="INSTANCE">
+               <v3:id root="9.8.7.6.5.4.3.2.1"/>
+            </v3:device>
+         </v3:receiver>
+
+         <!-- Control Act Process for merge -->
+         <v3:controlActProcess classCode="CACT" moodCode="EVN">
+            <v3:code code="PRPA_TE201304UV02" codeSystem="2.16.840.1.113883.1.6"/>
+
+            <!-- Subject contains the merge event -->
+            <v3:subject typeCode="SUBJ">
+               <v3:registrationEvent classCode="REG" moodCode="EVN">
+                  <v3:statusCode code="active"/>
+
+                  <v3:subject1>
+                     <v3:patient classCode="PAT">
+                        <!-- This is the surviving patient record -->
+                        <v3:id root="2.25.123456789" extension="PATIENT-SURVIVOR-001"/>
+                        <v3:statusCode code="active"/>
+                        <v3:patientPerson>
+                           <v3:name>
+                              <v3:given>Jane</v3:given>
+                              <v3:family>Doe</v3:family>
+                           </v3:name>
+                           <v3:administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+                           <v3:birthTime value="19851212"/>
+                        </v3:patientPerson>
+                     </v3:patient>
+                  </v3:subject1>
+
+                  <!-- ReplacementOf indicates the record being merged/deprecated -->
+                  <v3:replacementOf typeCode="RPLC">
+                     <v3:priorRegistration>
+                        <v3:statusCode code="obsolete"/>
+                        <v3:subject1>
+                           <v3:patient>
+                              <!-- This is the obsolete/old patient record -->
+                              <v3:id root="2.25.987654321" extension="PATIENT-OLD-002"/>
+                           </v3:patient>
+                        </v3:subject1>
+                     </v3:priorRegistration>
+                  </v3:replacementOf>
+
+                  <!-- Custodian organization -->
+                  <v3:custodian>
+                     <v3:assignedEntity>
+                        <v3:id root="2.16.840.1.113883.3.72.5.9.10"/>
+                     </v3:assignedEntity>
+                  </v3:custodian>
+
+               </v3:registrationEvent>
+            </v3:subject>
+         </v3:controlActProcess>
+
+      </v3:PRPA_IN201304UV02>
+
+   </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-response_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-response_1_1.txt
@@ -1,0 +1,32 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+    <env:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:hl7-org:v3:MCCI_IN000002UV01</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:39c2063b-860c-47ab-baf1-a4806bee3449</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:223e4567-e89b-12d3-a456-426614174999</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="630b62c3-6ac9-4292-9113-7757acb0ce8d" TechBDIngestionApiVersion="0.1092.0"/>
+    </env:Header>
+    <env:Body>
+        <ns2:MCCI_IN000002UV01 xmlns:ns2="urn:hl7-org:v3" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns5="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007">
+            <ns2:id root="afcc8f86-8b68-4d4f-b112-da94aa381d2a"/>
+            <ns2:creationTime value="20260331163253+0530"/>
+            <ns2:interactionId extension="MCCI_IN000002UV01" root="2.16.840.1.113883.1.6"/>
+            <ns2:receiver typeCode="RCV">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                </ns2:device>
+            </ns2:receiver>
+            <ns2:sender typeCode="SND">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                    <ns2:telecom value="HTTP/1.1"/>
+                </ns2:device>
+            </ns2:sender>
+            <ns2:acknowledgement>
+                <ns2:targetMessage>
+                    <ns2:id extension="MERGE-12345" root="2.16.840.1.113883.3.72.5.9.1"/>
+                </ns2:targetMessage>
+            </ns2:acknowledgement>
+        </ns2:MCCI_IN000002UV01>
+    </env:Body>
+</env:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-response_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-merge-response_1_2.txt
@@ -1,0 +1,32 @@
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+    <env:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:hl7-org:v3:MCCI_IN000002UV01</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:39c2063b-860c-47ab-baf1-a4806bee3449</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:223e4567-e89b-12d3-a456-426614174999</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="630b62c3-6ac9-4292-9113-7757acb0ce8d" TechBDIngestionApiVersion="0.1092.0"/>
+    </env:Header>
+    <env:Body>
+        <ns2:MCCI_IN000002UV01 xmlns:ns2="urn:hl7-org:v3" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns5="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007">
+            <ns2:id root="afcc8f86-8b68-4d4f-b112-da94aa381d2a"/>
+            <ns2:creationTime value="20260331163253+0530"/>
+            <ns2:interactionId extension="MCCI_IN000002UV01" root="2.16.840.1.113883.1.6"/>
+            <ns2:receiver typeCode="RCV">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                </ns2:device>
+            </ns2:receiver>
+            <ns2:sender typeCode="SND">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5"/>
+                    <ns2:telecom value="HTTP/1.1"/>
+                </ns2:device>
+            </ns2:sender>
+            <ns2:acknowledgement>
+                <ns2:targetMessage>
+                    <ns2:id extension="MERGE-12345" root="2.16.840.1.113883.3.72.5.9.1"/>
+                </ns2:targetMessage>
+            </ns2:acknowledgement>
+        </ns2:MCCI_IN000002UV01>
+    </env:Body>
+</env:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-request_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-request_1_1.txt
@@ -1,0 +1,90 @@
+<!-- 
+  SOAP 1.2 Envelope wrapping an HL7v3 PRPA_IN201302UV02 message 
+  This message is used to indicate a patient record update in PIX/PNR systems.
+-->
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:v3="urn:hl7-org:v3">
+  
+  <!-- SOAP Header is empty in this example -->
+  <SOAP-ENV:Header/>
+
+  <SOAP-ENV:Body>
+
+    <!-- HL7v3 interaction: Patient Registry Record Revised -->
+    <v3:PRPA_IN201302UV02 ITSVersion="XML_1.0">
+
+      <!-- Unique ID for the message: OID + extension -->
+      <v3:id root="2.16.840.1.113883.3.72.5.9.1" extension="update-56789"/>
+
+      <!-- Timestamp when message was created: YYYYMMDDHHMMSS format -->
+      <v3:creationTime value="20250808153000"/>
+
+      <!-- Type of HL7v3 interaction being performed -->
+      <v3:interactionId root="2.16.840.1.113883.1.6" extension="PRPA_IN201302UV02"/>
+
+      <!-- Message is for production (P) or test (T) -->
+      <v3:processingCode code="T"/>
+
+      <!-- Processing mode: T = Training/Test, P = Production -->
+      <v3:processingModeCode code="T"/>
+
+      <!-- Acknowledgment expected: AL = Always, NE = Never -->
+      <v3:acceptAckCode code="AL"/>
+
+      <!-- Device/system sending the message -->
+      <v3:sender typeCode="SND">
+        <v3:device classCode="DEV" determinerCode="INSTANCE">
+          <v3:id root="1.2.3.4.5.6.7.8.9"/>
+        </v3:device>
+      </v3:sender>
+
+      <!-- Optional: receiver of the message (useful for multi-party exchanges) -->
+      <v3:receiver typeCode="RCV">
+        <v3:device classCode="DEV" determinerCode="INSTANCE">
+          <v3:id root="9.8.7.6.5.4.3.2.1"/>
+        </v3:device>
+      </v3:receiver>
+
+      <!-- Main HL7 control structure for the message -->
+      <v3:controlActProcess classCode="CACT" moodCode="EVN">
+
+        <!-- Trigger code indicating the event being processed -->
+        <v3:code code="PRPA_TE201302UV02" codeSystem="2.16.840.1.113883.1.6"/>
+
+        <!-- Subject of the update: registration event -->
+        <v3:subject typeCode="SUBJ">
+          <v3:registrationEvent classCode="REG" moodCode="EVN">
+            <v3:statusCode code="active"/>
+
+            <!-- Patient whose data was updated -->
+            <v3:subject1>
+              <v3:patient classCode="PAT">
+                <!-- Patient identifier (OID + local ID) -->
+                <v3:id root="2.25.987654321" extension="UPDATEDPATIENT001"/>
+                <v3:statusCode code="active"/>
+
+                <!-- Patient demographics -->
+                <v3:patientPerson>
+                  <v3:name>
+                    <v3:given>Jane</v3:given>
+                    <v3:family>Smith</v3:family>
+                  </v3:name>
+                  <v3:administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+                  <v3:birthTime value="19851225"/>
+                </v3:patientPerson>
+              </v3:patient>
+            </v3:subject1>
+
+            <!-- Custodian of the patient record (managing organization) -->
+            <v3:custodian>
+              <v3:assignedEntity>
+                <v3:id root="2.16.840.1.113883.3.72.5.9.10"/>
+              </v3:assignedEntity>
+            </v3:custodian>
+          </v3:registrationEvent>
+        </v3:subject>
+
+      </v3:controlActProcess>
+    </v3:PRPA_IN201302UV02>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-request_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-request_1_2.txt
@@ -1,0 +1,90 @@
+<!-- 
+  SOAP 1.2 Envelope wrapping an HL7v3 PRPA_IN201302UV02 message 
+  This message is used to indicate a patient record update in PIX/PNR systems.
+-->
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
+                   xmlns:v3="urn:hl7-org:v3">
+  
+  <!-- SOAP Header is empty in this example -->
+  <SOAP-ENV:Header/>
+
+  <SOAP-ENV:Body>
+
+    <!-- HL7v3 interaction: Patient Registry Record Revised -->
+    <v3:PRPA_IN201302UV02 ITSVersion="XML_1.0">
+
+      <!-- Unique ID for the message: OID + extension -->
+      <v3:id root="2.16.840.1.113883.3.72.5.9.1" extension="update-56789"/>
+
+      <!-- Timestamp when message was created: YYYYMMDDHHMMSS format -->
+      <v3:creationTime value="20250808153000"/>
+
+      <!-- Type of HL7v3 interaction being performed -->
+      <v3:interactionId root="2.16.840.1.113883.1.6" extension="PRPA_IN201302UV02"/>
+
+      <!-- Message is for production (P) or test (T) -->
+      <v3:processingCode code="T"/>
+
+      <!-- Processing mode: T = Training/Test, P = Production -->
+      <v3:processingModeCode code="T"/>
+
+      <!-- Acknowledgment expected: AL = Always, NE = Never -->
+      <v3:acceptAckCode code="AL"/>
+
+      <!-- Device/system sending the message -->
+      <v3:sender typeCode="SND">
+        <v3:device classCode="DEV" determinerCode="INSTANCE">
+          <v3:id root="1.2.3.4.5.6.7.8.9"/>
+        </v3:device>
+      </v3:sender>
+
+      <!-- Optional: receiver of the message (useful for multi-party exchanges) -->
+      <v3:receiver typeCode="RCV">
+        <v3:device classCode="DEV" determinerCode="INSTANCE">
+          <v3:id root="9.8.7.6.5.4.3.2.1"/>
+        </v3:device>
+      </v3:receiver>
+
+      <!-- Main HL7 control structure for the message -->
+      <v3:controlActProcess classCode="CACT" moodCode="EVN">
+
+        <!-- Trigger code indicating the event being processed -->
+        <v3:code code="PRPA_TE201302UV02" codeSystem="2.16.840.1.113883.1.6"/>
+
+        <!-- Subject of the update: registration event -->
+        <v3:subject typeCode="SUBJ">
+          <v3:registrationEvent classCode="REG" moodCode="EVN">
+            <v3:statusCode code="active"/>
+
+            <!-- Patient whose data was updated -->
+            <v3:subject1>
+              <v3:patient classCode="PAT">
+                <!-- Patient identifier (OID + local ID) -->
+                <v3:id root="2.25.987654321" extension="UPDATEDPATIENT001"/>
+                <v3:statusCode code="active"/>
+
+                <!-- Patient demographics -->
+                <v3:patientPerson>
+                  <v3:name>
+                    <v3:given>Jane</v3:given>
+                    <v3:family>Smith</v3:family>
+                  </v3:name>
+                  <v3:administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1"/>
+                  <v3:birthTime value="19851225"/>
+                </v3:patientPerson>
+              </v3:patient>
+            </v3:subject1>
+
+            <!-- Custodian of the patient record (managing organization) -->
+            <v3:custodian>
+              <v3:assignedEntity>
+                <v3:id root="2.16.840.1.113883.3.72.5.9.10"/>
+              </v3:assignedEntity>
+            </v3:custodian>
+          </v3:registrationEvent>
+        </v3:subject>
+
+      </v3:controlActProcess>
+    </v3:PRPA_IN201302UV02>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-response_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-response_1_1.txt
@@ -1,0 +1,32 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+    <env:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:hl7-org:v3:MCCI_IN000002UV01</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:37605834-d087-4a7f-8ec4-e2d5bd42627d</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:unknown-incoming-message-id</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="e21038b4-db8a-4d7f-a7f7-b36593dcfb03" TechBDIngestionApiVersion="0.1092.0"/>
+    </env:Header>
+    <env:Body>
+        <ns2:MCCI_IN000002UV01 xmlns:ns2="urn:hl7-org:v3" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns5="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007">
+            <ns2:id root="0e80dab0-b97c-49bb-8078-abb6250cc635"/>
+            <ns2:creationTime value="20260331163313+0530"/>
+            <ns2:interactionId extension="MCCI_IN000002UV01" root="2.16.840.1.113883.1.6"/>
+            <ns2:receiver typeCode="RCV">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5.6.7.8.9"/>
+                </ns2:device>
+            </ns2:receiver>
+            <ns2:sender typeCode="SND">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5.6.7.8.9"/>
+                    <ns2:telecom value="HTTP/1.1"/>
+                </ns2:device>
+            </ns2:sender>
+            <ns2:acknowledgement>
+                <ns2:targetMessage>
+                    <ns2:id extension="update-56789" root="2.16.840.1.113883.3.72.5.9.1"/>
+                </ns2:targetMessage>
+            </ns2:acknowledgement>
+        </ns2:MCCI_IN000002UV01>
+    </env:Body>
+</env:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-response_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pix-update-response_1_2.txt
@@ -1,0 +1,32 @@
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+    <env:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:hl7-org:v3:MCCI_IN000002UV01</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:37605834-d087-4a7f-8ec4-e2d5bd42627d</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:unknown-incoming-message-id</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="e21038b4-db8a-4d7f-a7f7-b36593dcfb03" TechBDIngestionApiVersion="0.1092.0"/>
+    </env:Header>
+    <env:Body>
+        <ns2:MCCI_IN000002UV01 xmlns:ns2="urn:hl7-org:v3" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns5="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007">
+            <ns2:id root="0e80dab0-b97c-49bb-8078-abb6250cc635"/>
+            <ns2:creationTime value="20260331163313+0530"/>
+            <ns2:interactionId extension="MCCI_IN000002UV01" root="2.16.840.1.113883.1.6"/>
+            <ns2:receiver typeCode="RCV">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5.6.7.8.9"/>
+                </ns2:device>
+            </ns2:receiver>
+            <ns2:sender typeCode="SND">
+                <ns2:device determinerCode="INSTANCE">
+                    <ns2:id root="1.2.3.4.5.6.7.8.9"/>
+                    <ns2:telecom value="HTTP/1.1"/>
+                </ns2:device>
+            </ns2:sender>
+            <ns2:acknowledgement>
+                <ns2:targetMessage>
+                    <ns2:id extension="update-56789" root="2.16.840.1.113883.3.72.5.9.1"/>
+                </ns2:targetMessage>
+            </ns2:acknowledgement>
+        </ns2:MCCI_IN000002UV01>
+    </env:Body>
+</env:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-request_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-request_1_1.txt
@@ -1,0 +1,27 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:xdsb="urn:ihe:iti:xds-b:2007"
+                  xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                  xmlns:xop="http://www.w3.org/2004/08/xop/include"
+                  xmlns:wsa="http://www.w3.org/2005/08/addressing">
+  <soapenv:Header>
+    <wsa:MessageID>urn:uuid:12345678-90ab-cdef-1234-567890abcdef</wsa:MessageID>
+    <wsa:Action>urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b</wsa:Action>
+    <wsa:To>http://your-server-endpoint-url</wsa:To>
+  </soapenv:Header>
+  <soapenv:Body>
+    <xdsb:ProvideAndRegisterDocumentSetRequest>
+      <xdsb:SubmitObjectsRequest>
+        <rim:RegistryObjectList>
+          <rim:ExtrinsicObject id="Document01" mimeType="text/xml" objectType="urn:ihe:iti:2007:Document">
+            <rim:Name>
+              <rim:LocalizedString value="Test Document"/>
+            </rim:Name>
+          </rim:ExtrinsicObject>
+        </rim:RegistryObjectList>
+      </xdsb:SubmitObjectsRequest>
+      <xdsb:Document id="Document01">
+        <xop:Include href="cid:testdocument@domain.com"/>
+      </xdsb:Document>
+    </xdsb:ProvideAndRegisterDocumentSetRequest>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-request_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-request_1_2.txt
@@ -1,0 +1,27 @@
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"
+                  xmlns:xdsb="urn:ihe:iti:xds-b:2007"
+                  xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                  xmlns:xop="http://www.w3.org/2004/08/xop/include"
+                  xmlns:wsa="http://www.w3.org/2005/08/addressing">
+  <soapenv:Header>
+    <wsa:MessageID>urn:uuid:12345678-90ab-cdef-1234-567890abcdef</wsa:MessageID>
+    <wsa:Action>urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b</wsa:Action>
+    <wsa:To>http://your-server-endpoint-url</wsa:To>
+  </soapenv:Header>
+  <soapenv:Body>
+    <xdsb:ProvideAndRegisterDocumentSetRequest>
+      <xdsb:SubmitObjectsRequest>
+        <rim:RegistryObjectList>
+          <rim:ExtrinsicObject id="Document01" mimeType="text/xml" objectType="urn:ihe:iti:2007:Document">
+            <rim:Name>
+              <rim:LocalizedString value="Test Document"/>
+            </rim:Name>
+          </rim:ExtrinsicObject>
+        </rim:RegistryObjectList>
+      </xdsb:SubmitObjectsRequest>
+      <xdsb:Document id="Document01">
+        <xop:Include href="cid:testdocument@domain.com"/>
+      </xdsb:Document>
+    </xdsb:ProvideAndRegisterDocumentSetRequest>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-response_1_1.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-response_1_1.txt
@@ -1,0 +1,12 @@
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-bResponse</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:88d6f361-34c7-4481-8622-299c0644db93</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:12345678-90ab-cdef-1234-567890abcdef</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="2e50c3d8-8dd5-46e4-bfa6-0a83447c71dc" TechBDIngestionApiVersion="0.1092.0"/>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <ns3:RegistryResponse xmlns:ns2="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns5="urn:hl7-org:v3" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"/>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-response_1_2.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-response_1_2.txt
@@ -1,0 +1,12 @@
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
+    <SOAP-ENV:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-bResponse</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:88d6f361-34c7-4481-8622-299c0644db93</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:12345678-90ab-cdef-1234-567890abcdef</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="2e50c3d8-8dd5-46e4-bfa6-0a83447c71dc" TechBDIngestionApiVersion="0.1092.0"/>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <ns3:RegistryResponse xmlns:ns2="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns5="urn:hl7-org:v3" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"/>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-xdsb-mtom-request.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-xdsb-mtom-request.txt
@@ -1,0 +1,662 @@
+--Boundary_urn_uuid_f19a3e9e-324d-4c6c-8a96-6747955d86f5
+Content-Type: application/xop+xml; charset=UTF-8; type="application/soap+xml"
+Content-Transfer-Encoding: binary
+Content-ID: <request@meditech.com>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+<soap:Header>
+<wsa:To soap:mustUnderstand="1">https://heltestmcccd.myhie.com:9135/xds/XDSbRepositoryWS</wsa:To>
+<wsa:MessageID>f19a3e9e-324d-4c6c-8a96-6747955d86f5</wsa:MessageID>
+<wsa:Action soap:mustUnderstand="1">urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b</wsa:Action>
+</soap:Header>
+<soap:Body>
+<ProvideAndRegisterDocumentSetRequest xmlns="urn:ihe:iti:xds-b:2007" xmlns:xop="http://www.w3.org/2004/08/xop/include">
+<lcm3:SubmitObjectsRequest xmlns:lcm3="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">
+<rim:RegistryObjectList>
+<rim:ExtrinsicObject id="Document1" mimeType="text/xml" objectType="urn:uuid:7edca82f-054d-47f2-a032-9b2a5b5186c1">
+<rim:Slot name="creationTime">
+<rim:ValueList>
+<rim:Value>20220826191955</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="languageCode">
+<rim:ValueList>
+<rim:Value>en-us</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="sourcePatientId">
+<rim:ValueList>
+<rim:Value>H000001552^^^&amp;2.16.840.1.114222.4.1.7701&amp;ISO</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="sourcePatientInfo">
+<rim:ValueList>
+<rim:Value>PID-3|H000001552^^^&amp;2.16.840.1.114222.4.1.7701&amp;ISO</rim:Value>
+<rim:Value>PID-5|OBTV^FIVE^^^^^L^A</rim:Value>
+<rim:Value>PID-7|19891010</rim:Value>
+<rim:Value>PID-8|F</rim:Value>
+<rim:Value>PID-11|^^^^</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="hash">
+<rim:ValueList>
+<rim:Value>D82A0C0FBAC6ACAE0AF7452A53CDDEDBD6EB6648</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="serviceStartTime">
+<rim:ValueList>
+<rim:Value>20220826191955</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="Summarization of Episode Note"/>
+</rim:Name>
+<rim:Classification id="cl1" classificationScheme="urn:uuid:93606bcf-9494-43ec-9b4e-a7748d1a838d" classifiedObject="Document1" nodeRepresentation="">
+<rim:Slot name="authorPerson">
+<rim:ValueList>
+<rim:Value>ITI.41.XO.1^Bradford Regional Medical Ctr Interface Device^^^^^^^&amp;2.16.840.1.114222.4.1.7701&amp;ISO</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="authorRole">
+<rim:ValueList>
+<rim:Value>Interface Device</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="authorSpecialty">
+<rim:ValueList>
+<rim:Value>Interface Device</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="authorTelecommunication">
+<rim:ValueList>
+<rim:Value>^^Internet^UAHSfrom@direct-address.net</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+</rim:Classification>
+<rim:Classification id="cl2" classificationScheme="urn:uuid:41a5887f-8865-4c09-adf7-e362475b143a" classifiedObject="Document1" nodeRepresentation="34133-9">
+<rim:Slot name="codingScheme">
+<rim:ValueList>
+<rim:Value>2.16.840.1.113883.6.1</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="Summarization of Episode Note"/>
+</rim:Name>
+</rim:Classification>
+<rim:Classification id="cl3" classificationScheme="urn:uuid:f4f85eac-e6cb-4883-b524-f2705394840f" classifiedObject="Document1" nodeRepresentation="N">
+<rim:Slot name="codingScheme">
+<rim:ValueList>
+<rim:Value>2.16.840.1.113883.5.25</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="Normal"/>
+</rim:Name>
+</rim:Classification>
+<rim:Classification id="cl4" classificationScheme="urn:uuid:a09d5840-386c-46f2-b5ad-9c3699a4309d" classifiedObject="Document1" nodeRepresentation="2.16.840.1.113883.10.20.1">
+<rim:Slot name="codingScheme">
+<rim:ValueList>
+<rim:Value>HITSP</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="HL7 CCD Document"/>
+</rim:Name>
+</rim:Classification>
+<rim:Classification id="cl5" classificationScheme="urn:uuid:f33fb8ac-18af-42cc-ae0e-ed0b0bdb91e1" classifiedObject="Document1" nodeRepresentation="GACH">
+<rim:Slot name="codingScheme">
+<rim:ValueList>
+<rim:Value>2.16.840.1.113883.5.11</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="Hospitals; General Acute Care Hospital"/>
+</rim:Name>
+</rim:Classification>
+<rim:Classification id="cl6" classificationScheme="urn:uuid:cccf5598-8b07-4b77-a05e-ae952c785ead" classifiedObject="Document1" nodeRepresentation="General Medicine">
+<rim:Slot name="codingScheme">
+<rim:ValueList>
+<rim:Value>Connect-a-thon practiceSettingCodes</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="General Medicine"/>
+</rim:Name>
+</rim:Classification>
+<rim:Classification id="cl7" classificationScheme="urn:uuid:f0306f51-975f-434e-a61c-c59651d33983" classifiedObject="Document1" nodeRepresentation="34133-9">
+<rim:Slot name="codingScheme">
+<rim:ValueList>
+<rim:Value>2.16.840.1.113883.6.1</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="Summarization of Episode Note"/>
+</rim:Name>
+</rim:Classification>
+<rim:ExternalIdentifier id="ei1" registryObject="Document1" identificationScheme="urn:uuid:58a6f841-87b3-4a3e-92fd-a8ffeff98427" value="278189^^^&amp;2.25.256133121442266547198931747355024016667.1.2.1
+&amp;ISO">
+<rim:Name>
+<rim:LocalizedString value="XDSDocumentEntry.patientId"/>
+</rim:Name>
+</rim:ExternalIdentifier>
+<rim:ExternalIdentifier id="ei2" registryObject="Document1" identificationScheme="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab" value="2.25.675659260743594158351868205587962918337">
+<rim:Name>
+<rim:LocalizedString value="XDSDocumentEntry.uniqueId"/>
+</rim:Name>
+</rim:ExternalIdentifier>
+</rim:ExtrinsicObject>
+<rim:RegistryPackage id="SubmissionSet01">
+<rim:Slot name="submissionTime">
+<rim:ValueList>
+<rim:Value>20220826191955</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="Summarization of Episode Note"/>
+</rim:Name>
+<rim:Classification id="cl8" classificationScheme="urn:uuid:a7058bb9-b4e4-4307-ba5b-e3f0ab85e12d" classifiedObject="SubmissionSet01" nodeRepresentation="">
+<rim:Slot name="authorPerson">
+<rim:ValueList>
+<rim:Value>ITI.41.XO.1^Bradford Regional Medical Ctr Interface Device^^^^^^^&amp;2.16.840.1.114222.4.1.7701&amp;ISO</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="authorRole">
+<rim:ValueList>
+<rim:Value>Interface Device</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Slot name="authorSpecialty">
+<rim:ValueList>
+<rim:Value>Interface Device</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+</rim:Classification>
+<rim:Classification id="cl9" classificationScheme="urn:uuid:aa543740-bdda-424e-8c96-df4873be8500" classifiedObject="SubmissionSet01" nodeRepresentation="34133-9">
+<rim:Slot name="codingScheme">
+<rim:ValueList>
+<rim:Value>2.16.840.1.113883.6.1</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+<rim:Name>
+<rim:LocalizedString value="Summarization of Episode Note"/>
+</rim:Name>
+</rim:Classification>
+<rim:ExternalIdentifier id="ei3" registryObject="SubmissionSet01" identificationScheme="urn:uuid:96fdda7c-d067-4183-912e-bf5ee74998a8" value="2.16.840.1.114222.4.1.7701.2.4502567.1">
+<rim:Name>
+<rim:LocalizedString value="XDSSubmissionSet.uniqueId"/>
+</rim:Name>
+</rim:ExternalIdentifier>
+<rim:ExternalIdentifier id="ei4" registryObject="SubmissionSet01" identificationScheme="urn:uuid:554ac39e-e3fe-47fe-b233-965d2a147832" value="2.16.840.1.114222.4.1.7701">
+<rim:Name>
+<rim:LocalizedString value="XDSSubmissionSet.sourceId"/>
+</rim:Name>
+</rim:ExternalIdentifier>
+<rim:ExternalIdentifier id="ei5" registryObject="SubmissionSet01" identificationScheme="urn:uuid:6b5aea1a-874d-4603-a4bc-96a0a7b38446" value="278189^^^&amp;2.25.256133121442266547198931747355024016667
+.1.2.1&amp;ISO">
+<rim:Name>
+<rim:LocalizedString value="XDSSubmissionSet.patientId"/>
+</rim:Name>
+</rim:ExternalIdentifier>
+</rim:RegistryPackage>
+<rim:Classification id="cl10" classifiedObject="SubmissionSet01" classificationNode="urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd" nodeRepresentation=""/>
+<rim:Association id="as1" associationType="urn:oasis:names:tc:ebxml-regrep:AssociationType:HasMember" sourceObject="SubmissionSet01" targetObject="Document1">
+<rim:Slot name="SubmissionSetStatus">
+<rim:ValueList>
+<rim:Value>Original</rim:Value>
+</rim:ValueList>
+</rim:Slot>
+</rim:Association>
+</rim:RegistryObjectList>
+</lcm3:SubmitObjectsRequest>
+<Document id="Document1">
+<xop:Include href="cid:payload@meditech.com"/>
+</Document>
+</ProvideAndRegisterDocumentSetRequest></soap:Body>
+</soap:Envelope>
+
+--Boundary_urn_uuid_f19a3e9e-324d-4c6c-8a96-6747955d86f5
+Content-Type: text/xml; charset=UTF-8; type="application/soap+xml"
+Content-Transfer-Encoding: binary
+Content-ID: <payload@meditech.com>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Continuity of Care Document (CCD) (V3) IGpg115 -->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+  <id extension="1" root="1fc4f3d8-0d18-40f9-b0a7-f50cfb165f5c"/>
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+  <title>Continuity of Care Document</title>
+  <effectiveTime value="202208261518-0400"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en"/>
+  <recordTarget>
+    <patientRole>
+      <!-- Patient Identifiers-->
+      <id extension="H000001552" root="OGH"/>
+      <id extension="H1482" root="OGH"/>
+      <id extension="ce6fdfb4-9263-4b9f-c093-a7e55b68baf6" root="OGH"/>
+      <!-- Patient Address -->
+      <addr>
+        <streetAddressLine nullFlavor="UNK"/>
+        <city nullFlavor="UNK"/>
+        <useablePeriod xsi:type="IVL_TS">
+          <low nullFlavor="UNK"/>
+          <high nullFlavor="NA"/>
+        </useablePeriod>
+      </addr>
+      <!-- Patient Telephone/Contact Details -->
+      <telecom nullFlavor="UNK"/>
+      <patient>
+        <!-- Patient Name -->
+        <name use="L">
+          <family>OBTV</family>
+          <given>FIVE</given>
+        </name>
+        <!-- Administrative Gender -->
+        <administrativeGenderCode code="F" displayName="Female" codeSystemName="AdministrativeGender" codeSystem="2.16.840.1.113883.5.1"/>
+        <!-- Birthdate -->
+        <birthTime value="19891010"/>
+        <!-- Marital Status -->
+        <maritalStatusCode nullFlavor="UNK"/>
+        <!-- Religious Affiliation -->
+        <religiousAffiliationCode nullFlavor="UNK"/>
+        <!-- Patient Race -->
+        <raceCode nullFlavor="UNK"/>
+        <!-- Patient Ethnicity -->
+        <ethnicGroupCode nullFlavor="UNK"/>
+        <!-- Detailed Ethnicity -->
+        <sdtc:ethnicGroupCode nullFlavor="UNK"/>
+        <!-- Place of birth -->
+        <birthplace>
+          <place>
+            <addr nullFlavor="UNK"/>
+          </place>
+        </birthplace>
+        <languageCommunication>
+          <languageCode nullFlavor="UNK"/>
+          <!-- "Patient's preferred language" -->
+          <preferenceInd value="true"/>
+        </languageCommunication>
+      </patient>
+      <!-- Provider Organization -->
+      <providerOrganization>
+        <id nullFlavor="UNK"/>
+        <name nullFlavor="UNK"/>
+        <telecom nullFlavor="UNK"/>
+        <addr>
+          <streetAddressLine nullFlavor="UNK"/>
+          <city nullFlavor="UNK"/>
+        </addr>
+      </providerOrganization>
+    </patientRole>
+  </recordTarget>
+  <!-- The author element represents the creator of the clinical document. The author may be a device or a person. CDA R2 requires that
+author and author timestamp be asserted in the document header. From there, authorship propagates to contained sections and contained
+entries, unless explicitly overridden.-->
+  <author>
+    <time value="20220826151954-0400"/>
+    <assignedAuthor>
+      <id root="2.16.840.1.114222.4.1.7701"/>
+      <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+      <addr nullFlavor="UNK"/>
+      <telecom nullFlavor="UNK"/>
+      <assignedAuthoringDevice>
+        <manufacturerModelName>Bradford Regional Medical Ctr Interface Device</manufacturerModelName>
+        <softwareName>MEDITECH HCIS</softwareName>
+      </assignedAuthoringDevice>
+      <representedOrganization>
+        <id root="2.16.840.1.114222.4.1.7701"/>
+        <addr nullFlavor="UNK"/>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <!-- The custodian element represents the organization that is in charge of maintaining and is entrusted with
+the care of the document. -->
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.114222.4.1.7701"/>
+        <name>Bradford Regional Medical Ctr</name>
+        <telecom nullFlavor="UNK"/>
+        <addr nullFlavor="UNK"/>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <!-- The participant represents supporting entities -->
+  <participant typeCode="IND">
+    <associatedEntity classCode="PRS">
+      <code codeSystemName="HL7 Family Member" codeSystem="2.16.840.1.113883.5.111">
+        <originalText>Admitting Provider</originalText>
+      </code>
+      <addr nullFlavor="UNK"/>
+      <associatedPerson>
+        <name>
+          <prefix qualifier="AC">MD</prefix>
+          <family>TEST</family>
+          <given>DOCTOR</given>
+          <given>M</given>
+        </name>
+      </associatedPerson>
+    </associatedEntity>
+  </participant>
+  <documentationOf>
+    <serviceEvent classCode="PCPR">
+      <!-- The effectiveTime reflects the provision of care summarized in the document. -->
+      <effectiveTime>
+        <low value="202208081143-0400"/>
+        <high value="20220826151800-0400"/>
+      </effectiveTime>
+    </serviceEvent>
+  </documentationOf>
+  <componentOf>
+    <!-- The encompassingEncounter element records the specific encounter the document is detailing-->
+    <encompassingEncounter>
+      <id root="2.16.840.1.114222.4.1.7701" extension="E00004041"/>
+      <effectiveTime>
+        <low value="202208081143-0400"/>
+      </effectiveTime>
+      <dischargeDispositionCode nullFlavor="NA"/>
+      <location>
+        <healthCareFacility>
+          <id nullFlavor="UNK"/>
+          <serviceProviderOrganization>
+            <name>Olean General Hospital</name>
+            <telecom nullFlavor="UNK"/>
+            <addr nullFlavor="UNK"/>
+          </serviceProviderOrganization>
+        </healthCareFacility>
+      </location>
+    </encompassingEncounter>
+  </componentOf>
+  <component>
+    <structuredBody>
+      <!-- Chief Complaint and Reason for Visit Section IGpg269-->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+          <code code="46239-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Chief Complaint and Reason for Visit"/>
+          <title>Chief Complaint and Reason for Visit</title>
+          <text>
+            <table>
+              <tbody>
+                <tr>
+                  <th>Chief Complaint</th>
+                  <td>TESTING FOR REV K</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+        </section>
+      </component>
+      <!-- Health Concern Section IGpg303-->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+          <code code="75310-3" displayName="Health Concerns" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Health Concerns</title>
+          <text>Health concerns may be documented in an alternate section</text>
+        </section>
+      </component>
+      <!-- Allergies and Intolerances Section (entries required) (V3) IGpg261-->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+          <code code="48765-2" displayName="Allergies, adverse reactions, alerts" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Allergies, Adverse Reactions, Alerts</title>
+          <text>No allergy information available</text>
+        </section>
+      </component>
+      <!-- Social History Section (V3) IGpg404 -->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+          <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social History"/>
+          <title>Social History</title>
+          <text>
+            <content styleCode="Bold">Smoking Status</content>
+            <br/>
+            <content>Unknown if ever smoked</content>
+            <br/>
+            <content styleCode="Bold">Additional Data</content>
+            <br/>
+            <table>
+              <tbody>
+                <tr>
+                  <th>Assigned Birth Sex</th>
+                  <td ID="birthsex">Female</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- Smoking Status - Meaningful Use (V2) IGpg834 -->
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.78" extension="2014-06-09"/>
+              <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+              <id root="6db5b41a-2f1a-4bfa-825d-62c0ca277202"/>
+              <code code="72166-2" codeSystem="2.16.840.1.113883.6.1" displayName="Tobacco smoking status NHIS"/>
+              <statusCode code="completed"/>
+              <!-- The effectiveTime reflects when the current smoking status was observed. -->
+              <effectiveTime nullFlavor="UNK"/>
+              <!-- The value represents the patient's smoking status currently observed. -->
+              <value xsi:type="CD" code="266927001" displayName="Unknown if ever smoked" codeSystem="2.16.840.1.113883.6.96"/>
+            </observation>
+          </entry>
+          <!-- Birth Sex Observation CDA21CCIGpg85 -->
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.200" extension="2016-06-01"/>
+              <id root="9ae90f2b-bbe0-49a6-ad2a-3eddfde84cff"/>
+              <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" displayName="Sex Assigned At Birth"/>
+              <statusCode code="completed"/>
+              <effectiveTime value="19891010"/>
+              <value xsi:type="CD" code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" displayName="Female">
+                <originalText>
+                  <reference value="#birthsex"/>
+                </originalText>
+              </value>
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <!-- Problem Section (entries required) (V3) IGpg371-->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+          <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="2.16.840.1.113883.6.1" displayName="PROBLEM LIST"/>
+          <title>Problems</title>
+          <text>No problem information available</text>
+        </section>
+      </component>
+      <!-- Medications section (entries required) IGpg338 -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+          <code code="10160-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HISTORY OF MEDICATION USE"/>
+          <title>Medications</title>
+          <text>No medication information available</text>
+        </section>
+      </component>
+      <!-- Immunizations section IGpg320 -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2014-06-09"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.2"/>
+          <code code="11369-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of immunizations"/>
+          <title>Immunizations</title>
+          <text>No immunization information available</text>
+        </section>
+      </component>
+      <!-- Medical equipment section CG21pg167-->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+          <code code="46264-8" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Medical Equipment</title>
+          <text>No implantable device information available</text>
+        </section>
+      </component>
+      <!-- Procedures Section (entries required) (V2) section: identifier urn:hl7ii:2.16.840.1.113883.10.20.22.2.7.1:2014-06-09 IGpg389-->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.7" extension="2014-06-09"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+          <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="PROCEDURES"/>
+          <title>Procedures</title>
+          <text>No procedure information available</text>
+        </section>
+      </component>
+      <!-- Results Section (entries required) (V3) IGpg 398 -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+          <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="2.16.840.1.113883.6.1" displayName="RELEVANT DIAGNOSTIC TESTS AND/OR LABORATORY DATA"/>
+          <title>Relevant Diagnostic Tests and/or Laboratory Data</title>
+          <text>No known relevant diagnostic tests and/or laboratory data.</text>
+        </section>
+      </component>
+      <!-- Vital Signs Section (entries required) (V3) IGpg412 -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+          <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="VITAL SIGNS"/>
+          <title>Vital Signs</title>
+          <text>No vital signs result information available.</text>
+        </section>
+      </component>
+      <!-- Encounters Section IGpg287-->
+      <component>
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1" extension="2015-08-01"/>
+          <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of encounters"/>
+          <title>Encounters</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Encounter</th>
+                  <th>Location(s)</th>
+                  <th>Arrival/Admit Date</th>
+                  <th>Discharge/Depart Date</th>
+                  <th>Provider(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td ID="encounter-1">Admitted Inpatient</td>
+                  <td>Olean General Hospital</td>
+                  <td>August 8th, 2022 11:43am</td>
+                  <td/>
+                  <td>DOCTOR M TEST , MD</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- Encounter Activity IGpg479-->
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01"/>
+              <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+              <id root="d7f53e9d-9aa7-43c3-848b-4fac690a1ad8"/>
+              <code nullFlavor="UNK">
+                <originalText>
+                  <reference value="#encounter-1"/>
+                </originalText>
+              </code>
+              <effectiveTime>
+                <low value="202208081143-0400"/>
+              </effectiveTime>
+              <!-- Provider Detail -->
+              <performer>
+                <assignedEntity>
+                  <!-- Provider NPI -->
+                  <id extension="1855656561" root="2.16.840.1.113883.4.6"/>
+                  <code nullFlavor="UNK"/>
+                </assignedEntity>
+              </performer>
+              <!-- Service Location -->
+              <participant typeCode="LOC">
+                <participantRole classCode="SDLOC">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                  <code nullFlavor="UNK"/>
+                  <addr nullFlavor="UNK"/>
+                  <playingEntity classCode="PLC">
+                    <name>Olean General Hospital</name>
+                  </playingEntity>
+                </participantRole>
+              </participant>
+            </encounter>
+          </entry>
+        </section>
+      </component>
+      <!-- Functional Status Section IGpg294 -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.14"/>
+          <code code="47420-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Functional Status"/>
+          <title>Functional Status</title>
+          <text>No functional status information available</text>
+        </section>
+      </component>
+      <!-- Mental Status Section IGpg340-->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.56" extension="2015-08-01"/>
+          <code code="10190-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Mental Status"/>
+          <title>Mental Status</title>
+          <text>No mental status information available</text>
+        </section>
+      </component>
+      <!-- Assessment Section IGpg267-->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+          <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="51848-0" displayName="ASSESSMENTS"/>
+          <title>Assessments</title>
+          <text>No assessment information available</text>
+        </section>
+      </component>
+      <!-- Plan of Treatment Section (V2) IGpg357 -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+          <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+          <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Treatment plan"/>
+          <title>Plan of Treatment</title>
+          <text>Plan of treatment may be documented in an alternate section</text>
+        </section>
+      </component>
+      <!-- Goals Section IGpg301 -->
+      <component>
+        <section nullFlavor="NI">
+          <templateId root="2.16.840.1.113883.10.20.22.2.60"/>
+          <code code="61146-7" displayName="Goals" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+          <title>Goals</title>
+          <text>Goals may be documented in an alternate section</text>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>
+
+
+--Boundary_urn_uuid_f19a3e9e-324d-4c6c-8a96-6747955d86f5--

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-xdsb-mtom-response.txt
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/soap-test-resources/pnr-xdsb-mtom-response.txt
@@ -1,0 +1,12 @@
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+    <env:Header>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-bResponse</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:353a2fde-837c-4c1e-a0f3-659eed7a1c0d</wsa:MessageID>
+        <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">f19a3e9e-324d-4c6c-8a96-6747955d86f5</wsa:RelatesTo>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+        <techbd:Interaction xmlns:techbd="urn:techbd:custom" InteractionID="2cce369e-af2d-46da-bd6c-24e2ad9a075e" TechBDIngestionApiVersion="0.1092.0"/>
+    </env:Header>
+    <env:Body>
+        <ns3:RegistryResponse xmlns:ns2="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:ns4="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:ns5="urn:hl7-org:v3" xmlns:ns6="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:ns7="urn:ihe:iti:xds-b:2007" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"/>
+    </env:Body>
+</env:Envelope>


### PR DESCRIPTION
- introduce BaseIntegrationTest with shared LocalStack (S3 + SQS) container
- configure AWS clients and dynamic Spring properties for test environment
- create required S3 buckets and FIFO SQS queues for normal and HOLD flows
- upload port-config fixture to S3 during test setup
- implement per-test cleanup for S3 objects and SQS messages to ensure isolation

- add unit tests for SOAP scenarios:
  - PIX Add
  - PIX Update
  - PIX Merge
  - PNR

- add integration tests covering:
  - PIX and PNR workflows
  - SOAP/WS endpoint scenarios
  - normal flow (default buckets/queues)
  - HOLD flow (hold bucket + hold queue)