### PR TITLE
fix: update the XSLT file to remove the observation reference with no answer, from the derived block in the HL7 to FHIR conversion

### DIFF
--- a/support/specifications/develop/hl7/hl7v2-fhir-bundle.xslt
+++ b/support/specifications/develop/hl7/hl7v2-fhir-bundle.xslt
@@ -1048,6 +1048,8 @@
 					  <!-- Loop through all OBX segments globally and filter by code -->
 					  <xsl:for-each select="//OBX[
 											  contains($derivedFromCodes, concat('|', normalize-space(OBX.3/OBX.3.1), '|'))
+                        and string(OBX.5/OBX.5.1)
+                        and normalize-space(OBX.5/OBX.5.1) != 'UNK'
 											  and not(preceding::OBX[
 												normalize-space(OBX.3/OBX.3.1) = normalize-space(current()/OBX.3/OBX.3.1)
 											  ])


### PR DESCRIPTION
Updated the XSLT file to remove the observation reference with no answer, from the derived block in the HL7 to FHIR conversion.