### PR TITLE
revert: restore previous resource ID generation logic (#3026)

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
@@ -100,7 +100,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                         if(!data.getAnswerCode().isEmpty() || !data.getAnswerCodeDescription().isEmpty() || !data.getDataAbsentReasonCode().isEmpty()){
                                 Observation observation = new Observation();
                                 String observationId = data.getScreeningIdentifier();
-                                String observationIdHashed = CsvConversionUtil.sha256(observationId + data.getQuestionCode());
+                                String observationIdHashed = CsvConversionUtil.sha256(observationId);
                                 // CsvConversionUtil
                                 //                 .sha256(data.getQuestionCodeDescription().replace(" ", "") +
                                 //                                 data.getQuestionCode() + data.getEncounterId());
@@ -372,7 +372,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                         List<Reference> derivedFromRefs = screeningObservationDataList.stream()
                                                         .filter(obs -> questionCodeSet.contains(obs.getQuestionCode()))
                                                         .map(obs -> {
-                                                                String derivedFromId = CsvConversionUtil.sha256(obs.getScreeningIdentifier() +  obs.getQuestionCode());
+                                                                String derivedFromId = CsvConversionUtil.sha256(obs.getScreeningIdentifier());
                                                                 return new Reference("Observation/" + derivedFromId);
                                                         })
                                                         .collect(Collectors.toList());
@@ -627,7 +627,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
 
                 // Add member references using observationId directly from the model
                 List<Reference> hasMemberReferences = groupData.stream()
-                                .map(data -> new Reference("Observation/" + CsvConversionUtil.sha256(data.getObservationId() + data.getQuestionCode())))
+                                .map(data -> new Reference("Observation/" + CsvConversionUtil.sha256(data.getObservationId())))
                                 .collect(Collectors.toList());
                 groupObservation.setHasMember(hasMemberReferences);
 

--- a/hub-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
+++ b/hub-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
@@ -100,7 +100,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                         if(!data.getAnswerCode().isEmpty() || !data.getAnswerCodeDescription().isEmpty() || !data.getDataAbsentReasonCode().isEmpty()){
                                 Observation observation = new Observation();
                                 String observationId = data.getScreeningIdentifier();
-                                String observationIdHashed = CsvConversionUtil.sha256(observationId +  data.getQuestionCode());
+                                String observationIdHashed = CsvConversionUtil.sha256(observationId);
                                 // CsvConversionUtil
                                 //                 .sha256(data.getQuestionCodeDescription().replace(" ", "") +
                                 //                                 data.getQuestionCode() + data.getEncounterId());
@@ -371,7 +371,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                         List<Reference> derivedFromRefs = screeningObservationDataList.stream()
                                                         .filter(obs -> questionCodeSet.contains(obs.getQuestionCode()))
                                                         .map(obs -> {
-                                                                String derivedFromId = CsvConversionUtil.sha256(obs.getScreeningIdentifier() +  obs.getQuestionCode());
+                                                                String derivedFromId = CsvConversionUtil.sha256(obs.getScreeningIdentifier());
                                                                 return new Reference("Observation/" + derivedFromId);
                                                         })
                                                         .collect(Collectors.toList());
@@ -626,7 +626,7 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
 
                 // Add member references using observationId directly from the model
                 List<Reference> hasMemberReferences = groupData.stream()
-                                .map(data -> new Reference("Observation/" + CsvConversionUtil.sha256(data.getObservationId() +  data.getQuestionCode())))
+                                .map(data -> new Reference("Observation/" + CsvConversionUtil.sha256(data.getObservationId())))
                                 .collect(Collectors.toList());
                 groupObservation.setHasMember(hasMemberReferences);
 


### PR DESCRIPTION
- Reverted SHA-256 hash changes using SCREENING_IDENTIFIER + QUESTION_CODE
- Restored original ID generation for:
  - observationIdHashed
  - derivedFromId
  - hasMember references