### PR TITLE
fix: use shared UUIDv7 generator to avoid duplicates and ensure monotonicity #2386

### DIFF
--- a/nexus-core-lib/src/main/java/org/techbd/corelib/util/UuidUtil.java
+++ b/nexus-core-lib/src/main/java/org/techbd/corelib/util/UuidUtil.java
@@ -1,19 +1,23 @@
 package org.techbd.corelib.util;
 
 import com.fasterxml.uuid.Generators;
-
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 
 public final class UuidUtil {
-      private UuidUtil() {
-    }
 
-      /**
-     * Generates a UUID Version 7 (time-ordered).
-     * Recommended replacement for UUID.randomUUID().
+    // Single shared generator instance — critical for monotonicity within same ms
+    private static final TimeBasedEpochGenerator UUID_GENERATOR = 
+        Generators.timeBasedEpochGenerator();
+
+    private UuidUtil() {}
+
+    /**
+     * Generates a UUID Version 7 (time-ordered, monotonic).
+     * Uses a shared generator instance to ensure uniqueness within the same millisecond.
      *
      * @return UUIDv7 string
      */
     public static String generateUuid() {
-        return Generators.timeBasedEpochGenerator().generate().toString();    }
-
+        return UUID_GENERATOR.generate().toString();
+    }
 }

--- a/nexus-core-lib/src/test/java/org/techbd/service/util/UuidUtilTest.java
+++ b/nexus-core-lib/src/test/java/org/techbd/service/util/UuidUtilTest.java
@@ -1,0 +1,26 @@
+package org.techbd.service.util;
+
+import org.junit.jupiter.api.Test;
+import org.techbd.corelib.util.UuidUtil;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UuidUtilTest {
+
+    @Test
+    void shouldGenerateUniqueUuids() {
+        int count = 100_000;
+
+        Set<String> uuids = ConcurrentHashMap.newKeySet();
+
+        IntStream.range(0, count)
+                .parallel()
+                .forEach(i -> uuids.add(UuidUtil.generateUuid()));
+
+        assertEquals(count, uuids.size(), "Duplicate UUIDs detected!");
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/util/UuidUtil.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/util/UuidUtil.java
@@ -1,19 +1,23 @@
 package org.techbd.ingest.util;
 
 import com.fasterxml.uuid.Generators;
-
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 
 public final class UuidUtil {
-      private UuidUtil() {
-    }
 
-      /**
-     * Generates a UUID Version 7 (time-ordered).
-     * Recommended replacement for UUID.randomUUID().
+    // Single shared generator instance — critical for monotonicity within same ms
+    private static final TimeBasedEpochGenerator UUID_GENERATOR = 
+        Generators.timeBasedEpochGenerator();
+
+    private UuidUtil() {}
+
+    /**
+     * Generates a UUID Version 7 (time-ordered, monotonic).
+     * Uses a shared generator instance to ensure uniqueness within the same millisecond.
      *
      * @return UUIDv7 string
      */
     public static String generateUuid() {
-        return Generators.timeBasedEpochGenerator().generate().toString();    }
-
+        return UUID_GENERATOR.generate().toString();
+    }
 }

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/UuidUtilTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/UuidUtilTest.java
@@ -1,0 +1,25 @@
+package org.techbd.ingest.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UuidUtilTest {
+
+    @Test
+    void shouldGenerateUniqueUuids() {
+        int count = 100_000;
+
+        Set<String> uuids = ConcurrentHashMap.newKeySet();
+
+        IntStream.range(0, count)
+                .parallel()
+                .forEach(i -> uuids.add(UuidUtil.generateUuid()));
+
+        assertEquals(count, uuids.size(), "Duplicate UUIDs detected!");
+    }
+}


### PR DESCRIPTION
- UUID v7 requires a shared generator to preserve monotonic ordering and avoid duplicates within the same millisecond. #2386