### PR TITLE
feat: update Observation.id generation using composite screening identifier #3038

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
@@ -100,7 +100,8 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                         if(!data.getAnswerCode().isEmpty() || !data.getAnswerCodeDescription().isEmpty() || !data.getDataAbsentReasonCode().isEmpty()){
                                 Observation observation = new Observation();
                                 String observationId = data.getScreeningIdentifier();
-                                String observationIdHashed = CsvConversionUtil.sha256(observationId);
+                                String observationIdStringHashed = CsvConversionUtil.sha256_32(data.getFacilityName() + data.getPatientMrIdValue() +  data.getEncounterId()  + data.getScreeningIdentifier() + data.getScreeningStartDateTime());
+                                String observationIdHashed = observationIdStringHashed + "-obs3-" + data.getQuestionCode();
                                 // CsvConversionUtil
                                 //                 .sha256(data.getQuestionCodeDescription().replace(" ", "") +
                                 //                                 data.getQuestionCode() + data.getEncounterId());
@@ -370,12 +371,18 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                 if (QUESTION_CODE_REF_MAP.containsKey(data.getQuestionCode())) {
                                         Set<String> questionCodeSet = QUESTION_CODE_REF_MAP.get(data.getQuestionCode());
                                         List<Reference> derivedFromRefs = screeningObservationDataList.stream()
-                                                        .filter(obs -> questionCodeSet.contains(obs.getQuestionCode()))
-                                                        .map(obs -> {
-                                                                String derivedFromId = CsvConversionUtil.sha256(obs.getScreeningIdentifier());
-                                                                return new Reference("Observation/" + derivedFromId);
-                                                        })
-                                                        .collect(Collectors.toList());
+                                                .filter(obs -> questionCodeSet.contains(obs.getQuestionCode()))
+                                                .map(obs -> {
+                                                    String observationIdStringHashed1 = CsvConversionUtil
+                                                            .sha256_32(obs.getFacilityName() + obs.getPatientMrIdValue()
+                                                                    + obs.getEncounterId()
+                                                                    + obs.getScreeningIdentifier()
+                                                                    + obs.getScreeningStartDateTime());
+                                                    String derivedFromId = observationIdStringHashed1 + "-obs3-"
+                                                            + obs.getQuestionCode();
+                                                    return new Reference("Observation/" + derivedFromId);
+                                                })
+                                                .collect(Collectors.toList());
                                         derivedFromMap.put(observationId, derivedFromRefs);
                                 }
                                 List<Reference> derivedRefs = derivedFromMap.get(observationId);
@@ -627,8 +634,12 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
 
                 // Add member references using observationId directly from the model
                 List<Reference> hasMemberReferences = groupData.stream()
-                                .map(data -> new Reference("Observation/" + CsvConversionUtil.sha256(data.getObservationId())))
-                                .collect(Collectors.toList());
+                        .map(data -> new Reference("Observation/"
+                                + CsvConversionUtil.sha256_32(
+                                        data.getFacilityName() + data.getPatientMrIdValue() + data.getEncounterId()
+                                                + data.getScreeningIdentifier() + data.getScreeningStartDateTime())
+                                + "-obs3-" + data.getQuestionCode()))
+                        .collect(Collectors.toList());
                 groupObservation.setHasMember(hasMemberReferences);
 
                 // Create bundle entry

--- a/csv-service/src/main/java/org/techbd/csv/util/CsvConversionUtil.java
+++ b/csv-service/src/main/java/org/techbd/csv/util/CsvConversionUtil.java
@@ -242,6 +242,12 @@ public class CsvConversionUtil {
             throw new RuntimeException("Error generating SHA-256 hash", e);
         }
     }
+
+    public static String sha256_32(String input) {
+        String fullHash = sha256(input); // your existing method
+        return fullHash.substring(0, 32);
+    }
+    
      public static Map<String, Object> createOperationOutcomeForError(AppConfig appConfig,
             final String masterInteractionId,
             final String groupInteractionId,

--- a/hub-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
+++ b/hub-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
@@ -100,7 +100,8 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                         if(!data.getAnswerCode().isEmpty() || !data.getAnswerCodeDescription().isEmpty() || !data.getDataAbsentReasonCode().isEmpty()){
                                 Observation observation = new Observation();
                                 String observationId = data.getScreeningIdentifier();
-                                String observationIdHashed = CsvConversionUtil.sha256(observationId);
+                                String observationIdStringHashed = CsvConversionUtil.sha256_32(data.getFacilityName() + data.getPatientMrIdValue() +  data.getEncounterId()  + data.getScreeningIdentifier() + data.getScreeningStartDateTime());
+                                String observationIdHashed = observationIdStringHashed + "-obs3-" + data.getQuestionCode();
                                 // CsvConversionUtil
                                 //                 .sha256(data.getQuestionCodeDescription().replace(" ", "") +
                                 //                                 data.getQuestionCode() + data.getEncounterId());
@@ -369,12 +370,18 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                 if (QUESTION_CODE_REF_MAP.containsKey(data.getQuestionCode())) {
                                         Set<String> questionCodeSet = QUESTION_CODE_REF_MAP.get(data.getQuestionCode());
                                         List<Reference> derivedFromRefs = screeningObservationDataList.stream()
-                                                        .filter(obs -> questionCodeSet.contains(obs.getQuestionCode()))
-                                                        .map(obs -> {
-                                                                String derivedFromId = CsvConversionUtil.sha256(obs.getScreeningIdentifier());
-                                                                return new Reference("Observation/" + derivedFromId);
-                                                        })
-                                                        .collect(Collectors.toList());
+                                                .filter(obs -> questionCodeSet.contains(obs.getQuestionCode()))
+                                                .map(obs -> {
+                                                    String observationIdStringHashed1 = CsvConversionUtil
+                                                            .sha256_32(obs.getFacilityName() + obs.getPatientMrIdValue()
+                                                                    + obs.getEncounterId()
+                                                                    + obs.getScreeningIdentifier()
+                                                                    + obs.getScreeningStartDateTime());
+                                                    String derivedFromId = observationIdStringHashed1 + "-obs3-"
+                                                            + obs.getQuestionCode();
+                                                    return new Reference("Observation/" + derivedFromId);
+                                                })
+                                                .collect(Collectors.toList());
                                         derivedFromMap.put(observationId, derivedFromRefs);
                                 }
                                 List<Reference> derivedRefs = derivedFromMap.get(observationId);
@@ -626,8 +633,12 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
 
                 // Add member references using observationId directly from the model
                 List<Reference> hasMemberReferences = groupData.stream()
-                                .map(data -> new Reference("Observation/" + CsvConversionUtil.sha256(data.getObservationId())))
-                                .collect(Collectors.toList());
+                        .map(data -> new Reference("Observation/"
+                                + CsvConversionUtil.sha256_32(
+                                        data.getFacilityName() + data.getPatientMrIdValue() + data.getEncounterId()
+                                                + data.getScreeningIdentifier() + data.getScreeningStartDateTime())
+                                + "-obs3-" + data.getQuestionCode()))
+                        .collect(Collectors.toList());
                 groupObservation.setHasMember(hasMemberReferences);
 
                 // Create bundle entry

--- a/hub-core-lib/src/main/java/org/techbd/util/csv/CsvConversionUtil.java
+++ b/hub-core-lib/src/main/java/org/techbd/util/csv/CsvConversionUtil.java
@@ -243,6 +243,11 @@ public class CsvConversionUtil {
         }
     }
     
+    public static String sha256_32(String input) {
+        String fullHash = sha256(input); // your existing method
+        return fullHash.substring(0, 32);
+    }
+    
      public static Map<String, Object> createOperationOutcomeForError(CoreAppConfig appConfig,
             final String masterInteractionId,
             final String groupInteractionId,

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1121.0</revision>
+        <revision>0.1122.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Generate Observation.id using sha256_32 hash of facility, patient MRN, encounter ID, screening identifier, and screening start datetime
- Append "-obs3-" and questionCode to ensure uniqueness per observation
- Align derivedFrom and hasMember references with new Observation.id logic
- Ensure consistent and deterministic ID generation across screening observations