### PR TITLE
feat: add integration tests for DataIngestionController and XdsRepositoryController #3007

### DIFF
--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/DataIngestionControllerIT.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/DataIngestionControllerIT.java
@@ -1,0 +1,128 @@
+package org.techbd.ingest.controller;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.io.ByteArrayResource;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.integrationtests.base.BaseIntegrationTest;
+import org.techbd.ingest.integrationtests.base.NexusIntegrationTest;
+import org.techbd.ingest.service.MessageProcessorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Integration tests for DataIngestionController.
+ * Tests HTTP endpoints, content type handling, and service interactions.
+ */
+@NexusIntegrationTest
+@Tag("integration")
+class DataIngestionControllerIT extends BaseIntegrationTest {
+
+        @Autowired
+        private TestRestTemplate restTemplate;
+
+        @LocalServerPort
+        private int port;
+
+        @MockBean
+        private MessageProcessorService messageProcessorService;
+
+        private static final String BASE_URL = "/ingest/testSource/testType";
+
+        @Test
+        void ingest_rawBody_fullFlow() {
+                ResponseEntity<String> response = postJson("{ \"test\": \"data\" }");
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void ingest_multipart_fullFlow() {
+                ResponseEntity<String> response = postMultipart("test data");
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void ingest_shouldExecuteFailureFallback() {
+
+                when(messageProcessorService.processMessage(any(), any(String.class)))
+                                .thenThrow(new RuntimeException("Simulated failure"));
+
+                ResponseEntity<String> response = postJson("{ \"test\": \"data\" }");
+
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+                verify(messageProcessorService, atLeast(2))
+                                .processMessage(any(), any(String.class));
+        }
+
+        @Test
+        void ingest_multipart_shouldTriggerFailureFallback() {
+
+                when(messageProcessorService.processMessage(any(), any(MultipartFile.class)))
+                                .thenThrow(new RuntimeException("Simulated failure"));
+
+                ResponseEntity<String> response = postMultipart("test data");
+
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+                verify(messageProcessorService, atLeast(2))
+                                .processMessage(any(), any(MultipartFile.class));
+        }
+
+        private HttpHeaders jsonHeaders() {
+                HttpHeaders headers = new HttpHeaders();
+                headers.setContentType(MediaType.APPLICATION_JSON);
+                headers.set("X-Source-Id", "testSource");
+                headers.set("X-Msg-Type", "testType");
+                headers.set(Constants.REQ_X_FORWARDED_PORT, "9050");
+                return headers;
+        }
+
+        private HttpHeaders multipartHeaders() {
+                HttpHeaders headers = new HttpHeaders();
+                headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+                headers.set("X-Source-Id", "testSource");
+                headers.set("X-Msg-Type", "testType");
+                headers.set(Constants.REQ_X_FORWARDED_PORT, "9050");
+                return headers;
+        }
+
+        private ResponseEntity<String> postJson(String body) {
+                HttpEntity<String> request = new HttpEntity<>(body, jsonHeaders());
+                return restTemplate.postForEntity(
+                                "http://localhost:" + port + BASE_URL,
+                                request,
+                                String.class);
+        }
+
+        private ResponseEntity<String> postMultipart(String content) {
+                MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+                body.add("file", new ByteArrayResource(content.getBytes()) {
+                        @Override
+                        public String getFilename() {
+                                return "test.txt";
+                        }
+                });
+
+                HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, multipartHeaders());
+
+                return restTemplate.postForEntity(
+                                "http://localhost:" + port + BASE_URL,
+                                request,
+                                String.class);
+        }
+
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/XdsRepositoryControllerIT.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/XdsRepositoryControllerIT.java
@@ -1,0 +1,87 @@
+package org.techbd.ingest.controller;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.techbd.ingest.integrationtests.base.BaseIntegrationTest;
+import org.techbd.ingest.integrationtests.base.NexusIntegrationTest;
+import org.techbd.ingest.service.SoapForwarderService;
+import org.techbd.ingest.commons.Constants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.springframework.http.*;
+
+@NexusIntegrationTest
+@Tag("integration")
+class XdsRepositoryControllerIT extends BaseIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @LocalServerPort
+    private int port;
+
+    @MockBean
+    private SoapForwarderService forwarder;
+
+    private static final String BASE_URL = "/xds/XDSbRepositoryWS";
+
+    @Test
+    void xdsRequest_shouldForwardSoapRequest() {
+
+        when(forwarder.forward(any(), any(byte[].class), any()))
+                .thenReturn(ResponseEntity.ok("SUCCESS"));
+
+        String soapBody = """
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+                    <soapenv:Body>
+                        <test>data</test>
+                    </soapenv:Body>
+                </soapenv:Envelope>
+                """;
+
+        ResponseEntity<String> response = post(soapBody);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo("SUCCESS");
+
+        verify(forwarder).forward(any(), any(byte[].class), any());
+    }
+
+    @Test
+    void xdsRequest_emptyBody_shouldForwardEmptyPayload() {
+
+        when(forwarder.forward(any(), eq(new byte[0]), any()))
+                .thenReturn(ResponseEntity.ok("EMPTY_OK"));
+
+        ResponseEntity<String> response = post("");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo("EMPTY_OK");
+
+        verify(forwarder).forward(any(), eq(new byte[0]), any());
+    }
+
+    private HttpHeaders defaultHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_XML);
+        headers.set(Constants.REQ_X_FORWARDED_PORT, "9050");
+        return headers;
+    }
+
+    private ResponseEntity<String> post(String body) {
+        HttpEntity<String> request = new HttpEntity<>(body, defaultHeaders());
+        return restTemplate.postForEntity(
+                "http://localhost:" + port + BASE_URL,
+                request,
+                String.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1123.0</revision>
+        <revision>0.1124.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Summary
Added integration tests for DataIngestionController and XdsRepositoryController covering success and failure scenarios. #3007

## Highlights
- Covered raw and multipart ingestion flows
- Added failure path tests with fallback verification
- Tested XDS SOAP forwarding (empty & non-empty payloads)
- Refactored test code to remove duplication

## Result
Improved coverage and test maintainability.