### PR TITLE
Replay / NYEC failed submission API - Removed the 'startDate cannot be same as endDate' validation from these APIs(#30582)

### DIFF
--- a/fhir-validation-service/src/main/java/org/techbd/fhir/controller/FhirController.java
+++ b/fhir-validation-service/src/main/java/org/techbd/fhir/controller/FhirController.java
@@ -268,10 +268,7 @@ public class FhirController {
                 UUID requestId = UUID.fromString(UuidUtil.generateUuid());
 
                 try {
-                        if (startDateStr.equals(endDateStr)) {
-                                throw new IllegalArgumentException(
-                                                "startDate cannot be same as endDate for requestId: " + requestId);
-                        }
+                        
                         OffsetDateTime startDate = parseFlexibleDate(startDateStr, true);
                         OffsetDateTime endDate = parseFlexibleDate(endDateStr, false);
 

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FhirController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/FhirController.java
@@ -389,11 +389,7 @@ public class FhirController {
 
                 UUID interactionId = UUID.randomUUID();
                  try {
-                         if (startDateStr.equals(endDateStr)) {
-                                 throw new IllegalArgumentException(
-                                                 "startDate cannot be same as endDate for interactionId: "
-                                                                 + interactionId);
-                         }
+                         
                         OffsetDateTime startDate = parseFlexibleDate(startDateStr, true);
                         OffsetDateTime endDate = parseFlexibleDate(endDateStr, false);
 
@@ -439,10 +435,7 @@ public class FhirController {
                 UUID requestId = UUID.randomUUID();
 
                 try {
-                        if (startDateStr.equals(endDateStr)) {
-                                throw new IllegalArgumentException(
-                                                "startDate cannot be same as endDate for requestId: " + requestId);
-                        }
+                        
                         OffsetDateTime startDate = parseFlexibleDate(startDateStr, true);
                         OffsetDateTime endDate = parseFlexibleDate(endDateStr, false);
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1124.0</revision>
+        <revision>0.1125.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Removed the validation error for '/replay' and '/nyec-submission-failed' APIs if we provide same StartDate and EndDate the 
"startDate cannot be same as endDate" . 