### PR TITLE
fix: populate valueQuantity for 77594-0 in valid value path  #3038

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
+++ b/csv-service/src/main/java/org/techbd/csv/converters/ScreeningResponseObservationConverter.java
@@ -345,6 +345,9 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                                         LOG.warn("Unexpected value: "+codeDescription+" could not be converted to a double.", nfe);
                                                         quantity.setValue(0.0);
                                                 }
+                                                quantity.setUnit("minutes per week");
+                                                quantity.setSystem("http://unitsofmeasure.org");
+                                                observation.setValue(quantity);
                                                 }  else if (!data.getDataAbsentReasonCode().isEmpty()) {
                                                         CodeableConcept dataAbsentReason = new CodeableConcept();
                                                         String dataAbsentReasonCode = fetchCode(data.getDataAbsentReasonCode(), CsvConstants.DATA_ABSENT_REASON_CODE, interactionId);

--- a/hub-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
+++ b/hub-core-lib/src/main/java/org/techbd/converters/csv/ScreeningResponseObservationConverter.java
@@ -344,6 +344,9 @@ public class ScreeningResponseObservationConverter extends BaseConverter {
                                                         LOG.warn("Unexpected value: "+codeDescription+" could not be converted to a double.", nfe);
                                                         quantity.setValue(0.0);
                                                 }
+                                                quantity.setUnit("minutes per week");
+                                                quantity.setSystem("http://unitsofmeasure.org");
+                                                observation.setValue(quantity);
                                                 }  else if (!data.getDataAbsentReasonCode().isEmpty()) {
                                                         CodeableConcept dataAbsentReason = new CodeableConcept();
                                                         String dataAbsentReasonCode = fetchCode(data.getDataAbsentReasonCode(), CsvConstants.DATA_ABSENT_REASON_CODE, interactionId);

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1125.0</revision>
+        <revision>0.1126.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Added observation.setValue(quantity) inside value branch
- Ensured unit and system are set when codeDescription is present
- Aligns behavior with previous implementation