### PR TITLE
feat: add unit tests for exception handling, SOAP fault processing, and utility classes #3007

### DIFF
--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/FeatureToggleControllerTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/FeatureToggleControllerTest.java
@@ -1,0 +1,202 @@
+package org.techbd.ingest.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.techbd.ingest.feature.FeatureEnum;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.repository.StateRepository;
+import org.junit.jupiter.api.Test;
+import org.togglz.core.repository.FeatureState;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureToggleControllerTest {
+
+    @Mock
+    private FeatureManager featureManager;
+
+    @Mock
+    private StateRepository stateRepository;
+
+    @InjectMocks
+    private FeatureToggleController featureToggleController;
+
+    private FeatureEnum feature;
+
+    @BeforeEach
+    void setUp() {
+        feature = FeatureEnum.values()[0];
+    }
+
+    @Test
+    void enableFeature_shouldEnableSuccessfully() {
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.enableFeature(feature.name());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("enabled", response.getBody().get("status"));
+
+        verify(featureManager).setFeatureState(any(FeatureState.class));
+    }
+
+    @Test
+    void disableFeature_shouldDisableSuccessfully() {
+        ResponseEntity<Map<String, Object>> response = featureToggleController.disableFeature(feature.name());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("disabled", response.getBody().get("status"));
+
+        verify(featureManager).setFeatureState(new FeatureState(feature, false));
+    }
+
+    @Test
+    void isFeatureActive_shouldReturnEnabled() {
+        when(featureManager.isActive(feature)).thenReturn(true);
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.isFeatureActive(feature.name());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(true, response.getBody().get("enabled"));
+        assertEquals("enabled", response.getBody().get("status"));
+    }
+
+    @Test
+    void toggleFeature_shouldSwitchState() {
+        when(featureManager.isActive(feature)).thenReturn(false);
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.toggleFeature(feature.name());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("enabled", response.getBody().get("currentStatus"));
+
+        verify(featureManager).setFeatureState(new FeatureState(feature, true));
+    }
+
+    @Test
+    void getFeatureSummary_shouldReturnAllFeatures() {
+        for (FeatureEnum f : FeatureEnum.values()) {
+            when(featureManager.isActive(f)).thenReturn(true);
+        }
+
+        ResponseEntity<Map<String, String>> response = featureToggleController.getFeatureSummary();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("enabled", response.getBody().get(feature.name()));
+    }
+
+    @Test
+    void getFeatureNames_shouldReturnNamesList() {
+        ResponseEntity<Map<String, Object>> response = featureToggleController.getFeatureNames();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(FeatureEnum.values().length, response.getBody().get("count"));
+    }
+
+    @Test
+    void resetFeature_shouldReturnDefaultState() {
+        when(featureManager.isActive(feature)).thenReturn(true);
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.resetFeature(feature.name());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Feature reset to enum default", response.getBody().get("message"));
+
+        verify(stateRepository).setFeatureState(null);
+    }
+
+    @Test
+    void resetAllFeatures_shouldResetAll() throws Exception {
+        ResponseEntity<Map<String, Object>> response = featureToggleController.resetAllFeatures();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("All features reset to default", response.getBody().get("message"));
+
+        verify(featureManager, atLeastOnce()).setFeatureState(any(FeatureState.class));
+    }
+
+    @Test
+    void invalidFeature_shouldReturnBadRequest() {
+        ResponseEntity<Map<String, Object>> response = featureToggleController.enableFeature("INVALID_FEATURE");
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    void disableFeature_shouldReturnBadRequest_whenInvalidFeatureName() {
+
+        String invalidFeature = "INVALID_FEATURE";
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.disableFeature(invalidFeature);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Feature does not exist", response.getBody().get("message"));
+        assertTrue(response.getBody().get("error")
+                .toString()
+                .contains("Invalid feature name"));
+
+        verify(featureManager, never()).setFeatureState(any());
+    }
+
+    @Test
+    void isFeatureActive_shouldReturnBadRequest_whenInvalidFeatureName() {
+
+        String invalidFeature = "INVALID_FEATURE";
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.isFeatureActive(invalidFeature);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Feature does not exist", response.getBody().get("message"));
+        assertTrue(response.getBody().get("error")
+                .toString()
+                .contains("Invalid feature name"));
+
+        verify(featureManager, never()).isActive(any());
+    }
+
+    @Test
+    void toggleFeature_shouldReturnBadRequest_whenInvalidFeatureName() {
+
+        String invalidFeature = "INVALID_FEATURE";
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.toggleFeature(invalidFeature);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Feature does not exist", response.getBody().get("message"));
+        assertTrue(response.getBody().get("error")
+                .toString()
+                .contains("Invalid feature name"));
+
+        verify(featureManager, never()).isActive(any());
+        verify(featureManager, never()).setFeatureState(any());
+    }
+
+    @Test
+    void resetFeature_shouldReturnBadRequest_whenInvalidFeatureName() {
+
+        String invalidFeature = "INVALID_FEATURE";
+
+        ResponseEntity<Map<String, Object>> response = featureToggleController.resetFeature(invalidFeature);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue(response.getBody().get("error")
+                .toString()
+                .contains("Invalid feature name"));
+
+        verify(stateRepository, never()).setFeatureState(any());
+        verify(featureManager, never()).isActive(any());
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/SoapFaultEnhancementFilterTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/SoapFaultEnhancementFilterTest.java
@@ -1,0 +1,722 @@
+package org.techbd.ingest.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.w3c.dom.Element;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import org.techbd.ingest.service.MessageProcessorService;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.TemplateLogger;
+import org.techbd.ingest.model.RequestContext;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.commons.MessageSourceType;
+import org.w3c.dom.Document;
+
+@ExtendWith(MockitoExtension.class)
+public class SoapFaultEnhancementFilterTest {
+
+    @Mock
+    private AppLogger appLogger;
+
+    @Mock
+    private TemplateLogger templateLogger;
+
+    @Mock
+    private MessageProcessorService messageProcessorService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private SoapFaultEnhancementFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        when(appLogger.getLogger(any())).thenReturn(templateLogger);
+        filter = new SoapFaultEnhancementFilter(appLogger, messageProcessorService);
+    }
+
+    /**
+     * Case 1: Non /ws endpoint → should skip processing
+     */
+    @Test
+    void shouldSkipNonWsRequest() throws Exception {
+
+        when(request.getRequestURI()).thenReturn("/api/test");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(messageProcessorService);
+    }
+
+    /**
+     * Case 2: SOAP fault response → should enhance and process
+     */
+    @Test
+    void shouldEnhanceSoapFaultAndProcess() throws Exception {
+
+        String soapFault = "<Envelope><Body><Fault><faultcode>500</faultcode><faultstring>Error</faultstring></Fault></Body></Envelope>";
+
+        when(request.getRequestURI()).thenReturn("/ws/test");
+        when(request.getInputStream()).thenReturn(
+                new jakarta.servlet.ServletInputStream() {
+                    private final ByteArrayInputStream input = new ByteArrayInputStream("<req/>".getBytes());
+
+                    @Override
+                    public int read() {
+                        return input.read();
+                    }
+
+                    @Override
+                    public boolean isFinished() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+
+                    @Override
+                    public void setReadListener(jakarta.servlet.ReadListener readListener) {
+                    }
+                });
+
+        // Mock response output stream
+        ServletOutputStream outputStream = new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener listener) {
+            }
+        };
+
+        when(response.getOutputStream()).thenReturn(outputStream);
+
+        // Simulate filterChain writing SOAP fault
+        doAnswer(invocation -> {
+            HttpServletResponse res = invocation.getArgument(1);
+            res.getOutputStream().write(soapFault.getBytes());
+            return null;
+        }).when(filterChain).doFilter(any(), any());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(templateLogger).info(contains("Detected SOAP fault"));
+        verify(messageProcessorService, atLeastOnce())
+                .processMessage(any(), anyString(), anyString());
+    }
+
+    /**
+     * Case 3: Normal response → should pass through without processing
+     */
+    @Test
+    void shouldPassThroughNonFaultResponse() throws Exception {
+
+        String normalResponse = "<Envelope><Body>SUCCESS</Body></Envelope>";
+
+        when(request.getRequestURI()).thenReturn("/ws/test");
+        when(request.getInputStream()).thenReturn(
+                new jakarta.servlet.ServletInputStream() {
+                    private final ByteArrayInputStream input = new ByteArrayInputStream("<req/>".getBytes());
+
+                    @Override
+                    public int read() {
+                        return input.read();
+                    }
+
+                    @Override
+                    public boolean isFinished() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+
+                    @Override
+                    public void setReadListener(jakarta.servlet.ReadListener readListener) {
+                    }
+                });
+
+        ServletOutputStream outputStream = new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener listener) {
+            }
+        };
+
+        when(response.getOutputStream()).thenReturn(outputStream);
+
+        doAnswer(invocation -> {
+            HttpServletResponse res = invocation.getArgument(1);
+            res.getOutputStream().write(normalResponse.getBytes());
+            return null;
+        }).when(filterChain).doFilter(any(), any());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(messageProcessorService, never()).processMessage(any(), any(), any());
+    }
+
+    /**
+     * Case 4: Exception handling → should not break response
+     */
+    @Test
+    void shouldHandleExceptionGracefully() throws Exception {
+
+        when(request.getRequestURI()).thenReturn("/ws/test");
+
+        when(request.getInputStream()).thenReturn(
+                new jakarta.servlet.ServletInputStream() {
+                    private final ByteArrayInputStream input = new ByteArrayInputStream("<req/>".getBytes());
+
+                    @Override
+                    public int read() {
+                        return input.read();
+                    }
+
+                    @Override
+                    public boolean isFinished() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+
+                    @Override
+                    public void setReadListener(jakarta.servlet.ReadListener readListener) {
+                    }
+                });
+
+        ServletOutputStream outputStream = new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener listener) {
+            }
+        };
+
+        when(response.getOutputStream()).thenReturn(outputStream);
+        doThrow(new RuntimeException("boom"))
+                .when(filterChain).doFilter(any(), any());
+        filter.doFilterInternal(request, response, filterChain);
+        verify(templateLogger).error(
+                contains("Error processing response"),
+                any(),
+                any());
+    }
+
+    @Test
+    void shouldHandleExceptionInSetIngestionFailedFlag() throws Exception {
+
+        String soapFault = "<Envelope><Body><Fault>"
+                + "<faultcode>500</faultcode>"
+                + "<faultstring>Error</faultstring>"
+                + "</Fault></Body></Envelope>";
+
+        when(request.getRequestURI()).thenReturn("/ws/test");
+
+        lenient().when(request.getAttribute(anyString())).thenReturn(null);
+
+        when(request.getInputStream()).thenReturn(
+                new jakarta.servlet.ServletInputStream() {
+                    private final ByteArrayInputStream input = new ByteArrayInputStream("<req/>".getBytes());
+
+                    @Override
+                    public int read() {
+                        return input.read();
+                    }
+
+                    @Override
+                    public boolean isFinished() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+
+                    @Override
+                    public void setReadListener(jakarta.servlet.ReadListener readListener) {
+                    }
+                });
+
+        RequestContext context = mock(RequestContext.class);
+
+        doThrow(new RuntimeException("fail"))
+                .when(context).setIngestionFailed(true);
+
+        when(request.getAttribute(Constants.REQUEST_CONTEXT)).thenReturn(context);
+
+        ServletOutputStream outputStream = new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener listener) {
+            }
+        };
+
+        when(response.getOutputStream()).thenReturn(outputStream);
+
+        doAnswer(invocation -> {
+            HttpServletResponse res = invocation.getArgument(1);
+            res.getOutputStream().write(soapFault.getBytes());
+            return null;
+        }).when(filterChain).doFilter(any(), any());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(templateLogger).warn(
+                contains("Failed to set ingestionFailed flag"),
+                any());
+    }
+
+    @Test
+    void shouldExtractFaultString_fromSoap12() throws Exception {
+
+        String soapFault = "<Envelope xmlns=\"http://www.w3.org/2003/05/soap-envelope\">"
+                + "<Body><Fault>"
+                + "<Code><Value>500</Value></Code>"
+                + "<Reason><Text>SOAP 1.2 Error</Text></Reason>"
+                + "</Fault></Body></Envelope>";
+
+        when(request.getRequestURI()).thenReturn("/ws/test");
+
+        when(request.getInputStream()).thenReturn(new jakarta.servlet.ServletInputStream() {
+            private final ByteArrayInputStream input = new ByteArrayInputStream("<req/>".getBytes());
+
+            @Override
+            public int read() {
+                return input.read();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(jakarta.servlet.ReadListener readListener) {
+            }
+        });
+
+        ServletOutputStream outputStream = new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener listener) {
+            }
+        };
+
+        when(response.getOutputStream()).thenReturn(outputStream);
+
+        doAnswer(invocation -> {
+            HttpServletResponse res = invocation.getArgument(1);
+            res.getOutputStream().write(soapFault.getBytes());
+            return null;
+        }).when(filterChain).doFilter(any(), any());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(templateLogger).error(
+                contains("Enhancing SOAP fault"),
+                any(), any(), any(),
+                eq("SOAP 1.2 Error"));
+    }
+
+    @Test
+    void shouldReturnUnknownFault_whenNoFaultStringPresent() throws Exception {
+
+        String soapFault = "<Envelope><Body><Fault>"
+                + "<faultcode>500</faultcode>"
+                + "</Fault></Body></Envelope>";
+
+        when(request.getRequestURI()).thenReturn("/ws/test");
+
+        when(request.getInputStream()).thenReturn(new jakarta.servlet.ServletInputStream() {
+            private final ByteArrayInputStream input = new ByteArrayInputStream("<req/>".getBytes());
+
+            @Override
+            public int read() {
+                return input.read();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(jakarta.servlet.ReadListener readListener) {
+            }
+        });
+
+        ServletOutputStream outputStream = new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener listener) {
+            }
+        };
+
+        when(response.getOutputStream()).thenReturn(outputStream);
+
+        doAnswer(invocation -> {
+            HttpServletResponse res = invocation.getArgument(1);
+            res.getOutputStream().write(soapFault.getBytes());
+            return null;
+        }).when(filterChain).doFilter(any(), any());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(templateLogger).error(
+                contains("Enhancing SOAP fault"),
+                any(), any(), any(),
+                eq("Unknown fault"));
+    }
+
+    @Test
+    void shouldReturnTrue_whenElementExistsWithNamespace() throws Exception {
+
+        String xml = "<detail xmlns:err=\"http://test\"><err:ErrorTraceId>123</err:ErrorTraceId></detail>";
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true); // IMPORTANT
+
+        Document doc = factory
+                .newDocumentBuilder()
+                .parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element detail = doc.getDocumentElement();
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("hasDetailElement", Element.class, String.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(filter, detail, "ErrorTraceId");
+
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldReturnFalse_andLog_whenExceptionOccurs() throws Exception {
+
+        Element element = mock(Element.class);
+
+        when(element.getElementsByTagNameNS(any(), any()))
+                .thenThrow(new RuntimeException("boom"));
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("hasDetailElement", Element.class, String.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(filter, element, "ErrorTraceId");
+
+        assertFalse(result);
+
+        verify(templateLogger).debug(
+                contains("Error checking for detail element"),
+                any(),
+                any());
+    }
+
+    @Test
+    void shouldSkipProcessing_whenRequestBodyIsEmpty() throws Exception {
+
+        // Mock request
+        when(request.getAttribute(Constants.REQUEST_CONTEXT)).thenReturn(null);
+        when(request.getAttribute("CAPTURED_HEADERS")).thenReturn(null);
+        when(request.getAttribute(Constants.INTERACTION_ID)).thenReturn("test-id"); // 🔥 ADD THIS
+
+        // No headers
+        when(request.getAttribute("CAPTURED_HEADERS")).thenReturn(null);
+
+        // IMPORTANT: empty body
+        String requestBody = "";
+        String enhancedFault = "<fault/>";
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("processEnhancedFault",
+                        HttpServletRequest.class, String.class, String.class);
+        method.setAccessible(true);
+
+        method.invoke(filter, request, requestBody, enhancedFault);
+
+        verify(templateLogger).warn(
+                contains("Request body is empty - skipping messageProcessorService"),
+                any());
+
+        verify(templateLogger).info(
+                contains("Enhanced fault with error trace ID will still be returned to client"));
+
+        verify(messageProcessorService, never())
+                .processMessage(any(), any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldExtractHeadersSuccessfully() throws Exception {
+
+        Enumeration<String> headerNames = Collections.enumeration(List.of("h1", "h2"));
+
+        when(request.getHeaderNames()).thenReturn(headerNames);
+        when(request.getHeader("h1")).thenReturn("v1");
+        when(request.getHeader("h2")).thenReturn("v2");
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("extractHeaders", HttpServletRequest.class);
+        method.setAccessible(true);
+
+        Map<String, String> result = (Map<String, String>) method.invoke(filter, request);
+
+        assertEquals(2, result.size());
+        assertEquals("v1", result.get("h1"));
+        assertEquals("v2", result.get("h2"));
+
+        verify(templateLogger).info(
+                contains("Extracted"),
+                eq(2));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldReturnEmptyMap_andLogWarning_whenExceptionOccurs() throws Exception {
+
+        when(request.getHeaderNames()).thenThrow(new RuntimeException("boom"));
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("extractHeaders", HttpServletRequest.class);
+        method.setAccessible(true);
+
+        Map<String, String> result = (Map<String, String>) method.invoke(filter, request);
+
+        assertTrue(result.isEmpty());
+
+        verify(templateLogger).warn(
+                contains("Failed to extract headers"),
+                any());
+    }
+
+    @Test
+    void shouldReturnSoapPnr_whenPNRDetected() throws Exception {
+
+        String msg = "<ProvideAndRegisterDocumentSetRequest>";
+
+        MessageSourceType result = invokeDetermine(msg);
+
+        assertEquals(MessageSourceType.SOAP_PNR, result);
+    }
+
+    @Test
+    void shouldReturnSoapPix_whenPixAddDetected() throws Exception {
+
+        String msg = "PRPA_IN201301UV02";
+
+        MessageSourceType result = invokeDetermine(msg);
+
+        assertEquals(MessageSourceType.SOAP_PIX, result);
+    }
+
+    @Test
+    void shouldReturnSoapPix_whenPixQueryDetected() throws Exception {
+
+        String msg = "PRPA_IN201309UV02";
+
+        MessageSourceType result = invokeDetermine(msg);
+
+        assertEquals(MessageSourceType.SOAP_PIX, result);
+    }
+
+    @Test
+    void shouldReturnSoapPix_whenPixUpdateDetected() throws Exception {
+
+        String msg = "PRPA_IN201302UV02";
+
+        MessageSourceType result = invokeDetermine(msg);
+
+        assertEquals(MessageSourceType.SOAP_PIX, result);
+    }
+
+    @Test
+    void extractInteractionId_shouldReturnHeaderValue_whenHeaderPresentAndNotBlank() throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(request.getHeader(Constants.HEADER_INTERACTION_ID))
+                .thenReturn("12345");
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("extractInteractionId", HttpServletRequest.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(new SoapFaultEnhancementFilter(appLogger, messageProcessorService),
+                request);
+
+        assertEquals("12345", result);
+    }
+
+    @Test
+    void shouldReturnExistingDetailElement_soap11w() throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.newDocument();
+
+        Element fault = doc.createElement("Fault");
+        doc.appendChild(fault);
+
+        Element detail = doc.createElement("detail");
+        fault.appendChild(detail);
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("findOrCreateDetailElement", Document.class, Element.class);
+        method.setAccessible(true);
+
+        Element result = (Element) method.invoke(new SoapFaultEnhancementFilter(appLogger, messageProcessorService),
+                doc, fault);
+
+        assertSame(detail, result);
+    }
+
+    @Test
+    void shouldReturnExistingDetailElement_soap12() throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true); // IMPORTANT
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.newDocument();
+
+        String soapNS = "http://www.w3.org/2003/05/soap-envelope";
+
+        Element fault = doc.createElementNS(soapNS, "Fault");
+        doc.appendChild(fault);
+
+        Element detail = doc.createElementNS(soapNS, "Detail");
+        fault.appendChild(detail);
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("findOrCreateDetailElement", Document.class, Element.class);
+        method.setAccessible(true);
+
+        Element result = (Element) method.invoke(new SoapFaultEnhancementFilter(appLogger, messageProcessorService),
+                doc, fault);
+
+        assertSame(detail, result);
+    }
+
+    @Test
+    void extractSourceId_shouldReturnSourceId_whenIngestPattern() throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(request.getRequestURI())
+                .thenReturn("/ingest/ABC123/type");
+
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("extractSourceId", HttpServletRequest.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(new SoapFaultEnhancementFilter(appLogger, messageProcessorService),
+                request);
+
+        assertEquals("ABC123", result);
+    }
+
+    private MessageSourceType invokeDetermine(String input) throws Exception {
+        Method method = SoapFaultEnhancementFilter.class
+                .getDeclaredMethod("determineMessageSourceType", String.class);
+        method.setAccessible(true);
+
+        return (MessageSourceType) method.invoke(filter, input);
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/exceptions/CustomSoapFaultResolverTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/exceptions/CustomSoapFaultResolverTest.java
@@ -1,0 +1,200 @@
+package org.techbd.ingest.exceptions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.ws.soap.SoapFaultDetail;
+import org.springframework.ws.soap.SoapFaultDetailElement;
+import org.springframework.ws.transport.context.TransportContext;
+import org.springframework.ws.transport.context.TransportContextHolder;
+import org.springframework.ws.transport.http.HttpServletConnection;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.TemplateLogger;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.ws.soap.SoapFault;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.model.RequestContext;
+
+import javax.xml.namespace.QName;
+
+public class CustomSoapFaultResolverTest {
+    @Mock
+    private AppLogger appLogger;
+
+    @Mock
+    private TemplateLogger templateLogger;
+
+    @Mock
+    private SoapFault soapFault;
+
+    @Mock
+    private SoapFaultDetail faultDetail;
+
+    @Mock
+    private TransportContext transportContext;
+
+    @Mock
+    private HttpServletConnection connection;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private CustomSoapFaultResolver resolver;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        when(appLogger.getLogger(CustomSoapFaultResolver.class))
+                .thenReturn(templateLogger);
+
+        resolver = new CustomSoapFaultResolver(appLogger);
+
+        TransportContextHolder.setTransportContext(transportContext);
+        when(transportContext.getConnection()).thenReturn(connection);
+        when(connection.getHttpServletRequest()).thenReturn(request);
+
+        when(soapFault.getFaultDetail()).thenReturn(faultDetail);
+    }
+
+    @Test
+    void shouldCustomizeFault_successfully() {
+
+        SoapFaultDetailElement elementMock = mock(SoapFaultDetailElement.class);
+
+        when(soapFault.getFaultStringOrReason()).thenReturn("Some error");
+        when(soapFault.getFaultCode()).thenReturn(new QName("500"));
+
+        when(request.getHeader(Constants.HEADER_INTERACTION_ID))
+                .thenReturn("INT-123");
+
+        when(soapFault.getFaultDetail()).thenReturn(faultDetail);
+
+        when(faultDetail.addFaultDetailElement(any()))
+                .thenReturn(elementMock);
+
+        resolver.customizeFault(null, new RuntimeException("boom"), soapFault);
+
+        verify(templateLogger).error(
+                contains("SOAP Fault occurred"),
+                eq("INT-123"),
+                any(),
+                any(),
+                any());
+
+        verify(templateLogger).info(
+                contains("Added error trace details"),
+                any(),
+                any(),
+                any());
+    }
+
+    @Test
+    void shouldHandleMustUnderstandFault() {
+
+        when(soapFault.getFaultStringOrReason())
+                .thenReturn("MustUnderstand header missing");
+
+        when(soapFault.getFaultCode()).thenReturn(new QName("500"));
+        when(request.getHeader(Constants.HEADER_INTERACTION_ID))
+                .thenReturn("INT-456");
+
+        resolver.customizeFault(null, new RuntimeException("error"), soapFault);
+
+        verify(templateLogger).warn(
+                contains("MustUnderstand fault detected"),
+                eq("INT-456"),
+                any());
+    }
+
+    @Test
+    void shouldReturnUnknown_whenNoInteractionId() {
+
+        when(request.getHeader(Constants.HEADER_INTERACTION_ID))
+                .thenReturn(null);
+        when(request.getAttribute(Constants.INTERACTION_ID))
+                .thenReturn(null);
+
+        when(soapFault.getFaultStringOrReason()).thenReturn("Error");
+        when(soapFault.getFaultCode()).thenReturn(new QName("500"));
+
+        resolver.customizeFault(null, new RuntimeException("boom"), soapFault);
+
+        verify(templateLogger).error(
+                contains("SOAP Fault occurred"),
+                eq("unknown"),
+                any(),
+                any(),
+                any());
+    }
+
+    @Test
+    void shouldSetIngestionFailedFlag_whenContextExists() {
+
+        RequestContext context = mock(RequestContext.class);
+
+        when(request.getAttribute(Constants.REQUEST_CONTEXT))
+                .thenReturn(context);
+
+        when(soapFault.getFaultStringOrReason()).thenReturn("Error");
+        when(soapFault.getFaultCode()).thenReturn(new QName("500"));
+
+        resolver.customizeFault(null, new RuntimeException("boom"), soapFault);
+
+        verify(context).setIngestionFailed(true);
+    }
+
+    @Test
+    void shouldLogDebug_whenContextIsNull() {
+
+        when(request.getAttribute(Constants.REQUEST_CONTEXT))
+                .thenReturn(null);
+
+        when(soapFault.getFaultStringOrReason()).thenReturn("Error");
+        when(soapFault.getFaultCode()).thenReturn(new QName("500"));
+
+        resolver.customizeFault(null, new RuntimeException("boom"), soapFault);
+
+        verify(templateLogger).debug(
+                contains("RequestContext not yet available"),
+                any());
+    }
+
+    @Test
+    void shouldHandleException_inSetIngestionFailedFlag() {
+
+        when(transportContext.getConnection()).thenThrow(new RuntimeException("fail"));
+
+        when(soapFault.getFaultStringOrReason()).thenReturn("Error");
+        when(soapFault.getFaultCode()).thenReturn(new QName("500"));
+
+        resolver.customizeFault(null, new RuntimeException("boom"), soapFault);
+
+        verify(templateLogger).warn(
+                contains("Failed to set ingestionFailed flag"),
+                any());
+    }
+
+    @Test
+    void shouldHandleException_inCustomizeFault() {
+
+        when(soapFault.getFaultStringOrReason()).thenThrow(new RuntimeException("fail"));
+
+        resolver.customizeFault(null, new RuntimeException("boom"), soapFault);
+
+        verify(templateLogger).error(
+                contains("Failed to customize SOAP fault"),
+                any(),
+                any(),
+                any(),
+                any());
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/exceptions/GlobalExceptionHandlerTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,262 @@
+package org.techbd.ingest.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.TemplateLogger;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class GlobalExceptionHandlerTest {
+
+    @Mock
+    private AppLogger appLogger;
+
+    @Mock
+    private TemplateLogger templateLogger;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private GlobalExceptionHandler handler;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        when(appLogger.getLogger(GlobalExceptionHandler.class))
+                .thenReturn(templateLogger);
+
+        handler = new GlobalExceptionHandler(appLogger);
+
+    }
+
+    private void mockRequestContext(String interactionId) {
+        ServletRequestAttributes attrs = mock(ServletRequestAttributes.class);
+
+        when(attrs.getRequest()).thenReturn(request);
+        when(request.getAttribute("interactionId")).thenReturn(interactionId);
+
+        RequestContextHolder.setRequestAttributes(attrs);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void shouldHandleHttpMessageNotReadableException() {
+
+        mockRequestContext("INT-1");
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<org.techbd.ingest.util.LogUtil> logMock = mockStatic(
+                        org.techbd.ingest.util.LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-1");
+
+            ResponseEntity<ErrorResponse> response = handler.handleHttpMessageNotReadableException(
+                    new org.springframework.http.converter.HttpMessageNotReadableException("bad"));
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("Malformed JSON request.",
+                    response.getBody().error().message());
+        }
+    }
+
+    @Test
+    void shouldHandleIllegalArgumentException() {
+
+        mockRequestContext("INT-2");
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<org.techbd.ingest.util.LogUtil> logMock = mockStatic(
+                        org.techbd.ingest.util.LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-2");
+
+            ResponseEntity<ErrorResponse> response = handler.handleIllegalArgumentException(
+                    new IllegalArgumentException("bad arg"));
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertEquals("Illegal argument passed to request.",
+                    response.getBody().error().message());
+        }
+    }
+
+    @Test
+    void shouldHandleMultipartException_defaultMessage() {
+
+        mockRequestContext("INT-4");
+
+        Throwable cause = new RuntimeException("random issue");
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<org.techbd.ingest.util.LogUtil> logMock = mockStatic(
+                        org.techbd.ingest.util.LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-4");
+
+            ResponseEntity<ErrorResponse> response = handler.handleMultipartException(
+                    new org.springframework.web.multipart.MultipartException("error", cause));
+
+            assertTrue(response.getBody().error().message()
+                    .contains("File upload failed"));
+        }
+    }
+
+    @Test
+    void shouldReturnUnknown_whenNoRequestContext() {
+
+        RequestContextHolder.resetRequestAttributes();
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<org.techbd.ingest.util.LogUtil> logMock = mockStatic(
+                        org.techbd.ingest.util.LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-5");
+
+            ResponseEntity<ErrorResponse> response = handler.handleGeneralException(new RuntimeException("boom"));
+
+            assertEquals("unknown",
+                    response.getBody().error().interactionId());
+        }
+    }
+
+    @Test
+    void shouldHandleGeneralException() {
+
+        mockRequestContext("INT-6");
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<org.techbd.ingest.util.LogUtil> logMock = mockStatic(
+                        org.techbd.ingest.util.LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-6");
+
+            ResponseEntity<ErrorResponse> response = handler.handleGeneralException(new RuntimeException("boom"));
+
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+            assertTrue(response.getBody().error().message()
+                    .contains("unexpected system error"));
+        }
+    }
+
+    @Test
+    void shouldReturnFileTooLarge() throws Exception {
+        Throwable cause = new MaxUploadSizeExceededException("size exceeded");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("File too large.", result);
+    }
+
+    @Test
+    void shouldReturnIllegalStateMessage() throws Exception {
+        Throwable cause = new IllegalStateException("too big");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("Request too large or malformed.", result);
+    }
+
+    @Test
+    void shouldReturnMultipartExceptionMessage() throws Exception {
+        Throwable cause = new MultipartException("error");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("Multipart request error.", result);
+    }
+
+    @Test
+    void shouldReturnContentTypeError() throws Exception {
+        Throwable cause = new RuntimeException("Content-Type is not multipart");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("Content-Type must be multipart/form-data.", result);
+    }
+
+    @Test
+    void shouldReturnMissingBoundary() throws Exception {
+        Throwable cause = new RuntimeException("missing boundary");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("Missing multipart boundary in request.", result);
+    }
+
+    @Test
+    void shouldReturnStreamEndedMessage() throws Exception {
+        Throwable cause = new RuntimeException("stream ended unexpectedly");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("Upload stream ended unexpectedly. Please retry.", result);
+    }
+
+    @Test
+    void shouldReturnDiskSpaceMessage() throws Exception {
+        Throwable cause = new RuntimeException("disk space error");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("Server is out of disk space.", result);
+    }
+
+    @Test
+    void shouldReturnFallbackMessage() throws Exception {
+        Throwable cause = new RuntimeException("random error");
+
+        String result = invokeGetMultipartErrorMessage(cause);
+
+        assertEquals("File upload failed due to unexpected error.", result);
+    }
+
+    @Test
+    void shouldReturnDefault_whenCauseNull() throws Exception {
+        String result = invokeGetMultipartErrorMessage(null);
+
+        assertEquals("File upload failed.", result);
+    }
+
+    class MaxUploadSizeExceededException extends RuntimeException {
+        public MaxUploadSizeExceededException(String msg) {
+            super(msg);
+        }
+    }
+
+    class MultipartException extends RuntimeException {
+        public MultipartException(String msg) {
+            super(msg);
+        }
+    }
+
+    private String invokeGetMultipartErrorMessage(Throwable cause) throws Exception {
+        Method method = GlobalExceptionHandler.class
+                .getDeclaredMethod("getMultipartErrorMessage", Throwable.class);
+        method.setAccessible(true);
+
+        return (String) method.invoke(handler, cause);
+    }
+
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/DataIngestionControllerIT.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/DataIngestionControllerIT.java
@@ -1,4 +1,4 @@
-package org.techbd.ingest.controller;
+package org.techbd.ingest.integrationtests.controller;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/XdsRepositoryControllerIT.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/XdsRepositoryControllerIT.java
@@ -1,4 +1,4 @@
-package org.techbd.ingest.controller;
+package org.techbd.ingest.integrationtests.controller;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/interceptors/WsaHeaderInterceptorTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/interceptors/WsaHeaderInterceptorTest.java
@@ -1,0 +1,641 @@
+package org.techbd.ingest.interceptors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.techbd.ingest.config.AppConfig;
+import org.techbd.ingest.service.MessageProcessorService;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.SoapHeaderElement;
+import org.springframework.ws.soap.SoapFaultDetail;
+import org.springframework.ws.soap.SoapFaultDetailElement;
+import org.springframework.ws.transport.context.TransportContext;
+import org.springframework.ws.transport.context.TransportContextHolder;
+import org.springframework.ws.transport.http.HttpServletConnection;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.techbd.ingest.model.RequestContext;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.exceptions.ErrorTraceIdGenerator;
+import org.techbd.ingest.util.LogUtil;
+import org.techbd.ingest.feature.FeatureEnum;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Iterator;
+import javax.xml.namespace.QName;
+import java.util.Arrays;
+import org.springframework.ws.soap.SoapBody;
+import org.springframework.ws.soap.SoapFault;
+
+@ExtendWith(MockitoExtension.class)
+public class WsaHeaderInterceptorTest {
+    @Mock
+    private SoapResponseUtil soapResponseUtil;
+
+    @Mock
+    private MessageProcessorService messageProcessorService;
+
+    @Mock
+    private AppConfig appConfig;
+
+    @Mock
+    private AppLogger appLogger;
+
+    @Mock
+    private TemplateLogger templateLogger;
+
+    @Mock
+    private MessageContext messageContext;
+
+    @Mock
+    private SoapMessage soapMessage;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    private WsaHeaderInterceptor interceptor;
+
+    @BeforeEach
+    void setup() {
+        when(appLogger.getLogger(any())).thenReturn(templateLogger);
+        interceptor = new WsaHeaderInterceptor(
+                soapResponseUtil,
+                messageProcessorService,
+                appConfig,
+                appLogger);
+    }
+
+    @Test
+    void shouldHandleRequest_forWsEndpoint() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getRequest()).thenReturn(soapMessage);
+
+        doAnswer(invocation -> {
+            ByteArrayOutputStream os = invocation.getArgument(0);
+            os.write("<soap>req</soap>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any());
+
+        boolean result = interceptor.handleRequest(messageContext, new Object());
+
+        assertTrue(result);
+        verify(messageContext).setProperty(
+                eq(Constants.RAW_SOAP_ATTRIBUTE),
+                eq("<soap>req</soap>"));
+    }
+
+    @Test
+    void shouldSkipHandleRequest_whenNotWsEndpoint() throws Exception {
+
+        mockTransportContext("/other");
+
+        boolean result = interceptor.handleRequest(messageContext, new Object());
+
+        assertTrue(result);
+        verify(messageContext, never()).setProperty(any(), any());
+    }
+
+    @Test
+    void shouldHandleResponse_successfully() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(request.getAttribute(Constants.INTERACTION_ID)).thenReturn("INT-1");
+
+        when(soapResponseUtil.buildSoapResponse(any(), any()))
+                .thenReturn(soapMessage);
+
+        when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE))
+                .thenReturn("<req/>");
+
+        when(request.getAttribute(Constants.REQUEST_CONTEXT))
+                .thenReturn(mock(RequestContext.class));
+
+        boolean result = interceptor.handleResponse(messageContext, new Object());
+
+        assertTrue(result);
+
+        verify(messageProcessorService).processMessage(
+                any(),
+                eq("<req/>"),
+                any());
+    }
+
+    @Test
+    void shouldHandleFault_andLogError() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+        when(messageContext.getProperty("interactionId")).thenReturn("INT-2");
+
+        doAnswer(invocation -> {
+            ByteArrayOutputStream os = invocation.getArgument(0);
+            os.write("<fault><faultstring>Error</faultstring></fault>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any());
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-1");
+
+            boolean result = interceptor.handleFault(messageContext, new Object());
+
+            assertTrue(result);
+
+            verify(templateLogger).error(
+                    contains("SOAP Fault encountered"),
+                    eq("INT-2"),
+                    eq("TRACE-1"),
+                    any());
+        }
+    }
+
+    @Test
+    void shouldHandleAfterCompletion_success() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty("interactionId")).thenReturn("INT-3");
+
+        interceptor.afterCompletion(messageContext, new Object(), null);
+
+        verify(templateLogger).info(
+                contains("completed"),
+                eq("INT-3"),
+                eq("SUCCESS"));
+    }
+
+    @Test
+    void shouldHandleAfterCompletion_withException() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty("interactionId")).thenReturn("INT-4");
+
+        Exception ex = new RuntimeException("boom");
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-2");
+
+            interceptor.afterCompletion(messageContext, new Object(), ex);
+
+            verify(templateLogger).error(
+                    contains("completed with ERROR"),
+                    eq("INT-4"),
+                    eq("TRACE-2"),
+                    eq("boom"),
+                    eq(ex));
+        }
+    }
+
+    @Test
+    void shouldReturnTrue_whenFeatureEnabled() {
+
+        SoapHeaderElement header = mock(SoapHeaderElement.class);
+
+        when(header.getName()).thenReturn(
+                new QName("ns", "Header", "p"));
+
+        try (MockedStatic<FeatureEnum> featureMock = mockStatic(FeatureEnum.class)) {
+
+            featureMock.when(() -> FeatureEnum.isEnabled(FeatureEnum.IGNORE_MUST_UNDERSTAND_HEADERS)).thenReturn(true);
+
+            assertTrue(interceptor.understands(header));
+        }
+    }
+
+    @Test
+    void shouldExtractFaultString() throws Exception {
+
+        Method method = WsaHeaderInterceptor.class
+                .getDeclaredMethod("extractFaultString", String.class);
+
+        method.setAccessible(true);
+
+        String xml = "<fault><faultstring>Error123</faultstring></fault>";
+
+        String result = (String) method.invoke(interceptor, xml);
+
+        assertEquals("Error123", result);
+    }
+
+    @Test
+    void shouldReturnFalse_whenNoDetailElements() throws Exception {
+
+        SoapFaultDetail detail = mock(SoapFaultDetail.class);
+
+        when(detail.getDetailEntries())
+                .thenReturn(Collections.emptyIterator());
+
+        Method method = WsaHeaderInterceptor.class
+                .getDeclaredMethod("hasDetailElement", SoapFaultDetail.class, String.class);
+
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(interceptor, detail, "ErrorTraceId");
+
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldInjectErrorTraceIdIntoFault_whenNotPresent() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID))
+                .thenReturn("INT-1");
+
+        SoapBody soapBody = mock(SoapBody.class);
+        SoapFault soapFault = mock(SoapFault.class);
+        SoapFaultDetail faultDetail = mock(SoapFaultDetail.class);
+
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+        when(soapMessage.getSoapBody()).thenReturn(soapBody);
+        when(soapBody.getFault()).thenReturn(soapFault);
+        when(soapFault.getFaultDetail()).thenReturn(null);
+        when(soapFault.addFaultDetail()).thenReturn(faultDetail);
+
+        SoapFaultDetailElement interactionElement = mock(SoapFaultDetailElement.class);
+        SoapFaultDetailElement traceElement = mock(SoapFaultDetailElement.class);
+
+        when(faultDetail.addFaultDetailElement(any()))
+                .thenReturn(interactionElement)
+                .thenReturn(traceElement);
+
+        try (MockedStatic<ErrorTraceIdGenerator> mockTrace = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            mockTrace.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-1");
+
+            interceptor.handleFault(messageContext, new Object());
+
+            verify(interactionElement).addText("INT-1");
+            verify(traceElement).addText("TRACE-1");
+        }
+    }
+
+    @Test
+    void shouldSkipInjection_whenAlreadyPresent() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID))
+                .thenReturn("INT-1");
+
+        SoapBody soapBody = mock(SoapBody.class);
+        SoapFault soapFault = mock(SoapFault.class);
+        SoapFaultDetail faultDetail = mock(SoapFaultDetail.class);
+
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+        when(soapMessage.getSoapBody()).thenReturn(soapBody);
+        when(soapBody.getFault()).thenReturn(soapFault);
+        when(soapFault.getFaultDetail()).thenReturn(faultDetail);
+
+        Iterator<SoapFaultDetailElement> iterator = Arrays.asList(
+                mockDetailElement("InteractionId"),
+                mockDetailElement("ErrorTraceId")).iterator();
+
+        when(faultDetail.getDetailEntries()).thenReturn(iterator);
+
+        interceptor.handleFault(messageContext, new Object());
+
+        // No new elements added
+        verify(faultDetail, never()).addFaultDetailElement(any());
+    }
+
+    @Test
+    void shouldExtractFaultString_fromSoap12() throws Exception {
+
+        String xml = "<soap:Text xml:lang=\"en\">Invalid request</soap:Text>";
+
+        String result = invokeExtractFaultString(xml);
+
+        assertEquals("Invalid request", result);
+    }
+
+    @Test
+    void shouldReturnUnknown_whenNoFaultStringPresent() throws Exception {
+
+        String xml = "<soap>No fault here</soap>";
+
+        String result = invokeExtractFaultString(xml);
+
+        assertEquals("Unknown fault", result);
+    }
+
+    @Test
+    void shouldReturnUnknown_whenIncompleteFaultString() throws Exception {
+
+        String xml = "<faultstring>Error only start tag";
+
+        String result = invokeExtractFaultString(xml);
+
+        assertEquals("Unknown fault", result);
+    }
+
+    @Test
+    void shouldReturnFailureMessage_whenExceptionOccurs() throws Exception {
+
+        String result = invokeExtractFaultString(null);
+
+        assertEquals("Failed to extract fault string", result);
+    }
+
+    @Test
+    void shouldReturnTrue_whenNamespaceMatchesConfigured() {
+
+        SoapHeaderElement header = mock(SoapHeaderElement.class);
+        QName qName = new QName("http://test.com", "TestHeader");
+        when(header.getName()).thenReturn(qName);
+
+        AppConfig.Soap soap = mock(AppConfig.Soap.class);
+        AppConfig.Soap.Wsa wsa = mock(AppConfig.Soap.Wsa.class);
+
+        when(appConfig.getSoap()).thenReturn(soap);
+        when(soap.getWsa()).thenReturn(wsa);
+        when(wsa.getUnderstoodNamespaces())
+                .thenReturn("http://test.com,http://other.com");
+
+        try (MockedStatic<FeatureEnum> mockFeature = mockStatic(FeatureEnum.class)) {
+
+            mockFeature.when(() -> FeatureEnum.isEnabled(FeatureEnum.IGNORE_MUST_UNDERSTAND_HEADERS)).thenReturn(false);
+
+            boolean result = interceptor.understands(header);
+
+            assertTrue(result);
+        }
+    }
+
+    @Test
+    void shouldSkipAfterCompletion_whenNotWsEndpoint() throws Exception {
+
+        mockTransportContext("/not-ws"); // IMPORTANT
+
+        interceptor.afterCompletion(messageContext, new Object(), null);
+
+        verify(templateLogger, never()).info(any(), any(), any());
+    }
+
+    @Test
+    void shouldOverrideContentType_whenAckContentTypePresent() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID))
+                .thenReturn("INT-1");
+
+        when(request.getAttribute(Constants.ACK_CONTENT_TYPE))
+                .thenReturn("application/xml");
+
+        HttpServletConnection connection = (HttpServletConnection) TransportContextHolder.getTransportContext()
+                .getConnection();
+
+        when(connection.getHttpServletResponse()).thenReturn(response);
+
+        interceptor.afterCompletion(messageContext, new Object(), null);
+
+        verify(response).setHeader("Content-Type", "application/xml");
+        verify(response).setContentType("application/xml");
+
+        verify(templateLogger).info(
+                contains("Overriding response content type"),
+                eq("application/xml"),
+                eq("INT-1"));
+    }
+
+    @Test
+    void shouldLogWarning_whenOverrideContentTypeFails() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID))
+                .thenReturn("INT-1");
+
+        when(request.getAttribute(Constants.ACK_CONTENT_TYPE))
+                .thenReturn("application/xml");
+
+        HttpServletConnection connection = (HttpServletConnection) TransportContextHolder.getTransportContext()
+                .getConnection();
+
+        when(connection.getHttpServletResponse()).thenReturn(response);
+
+        doThrow(new RuntimeException("fail"))
+                .when(response).setHeader(any(), any());
+
+        interceptor.afterCompletion(messageContext, new Object(), null);
+
+        verify(templateLogger).warn(
+                contains("Failed to override response content type"),
+                eq("INT-1"),
+                contains("fail"));
+    }
+
+    @Test
+    void shouldSkipHandleFault_whenNotWsEndpoint() throws Exception {
+
+        mockTransportContext("/not-ws");
+
+        boolean result = interceptor.handleFault(messageContext, new Object());
+
+        assertTrue(result);
+        verify(messageContext, never()).getResponse();
+        verify(templateLogger, never()).error(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldSkipHandleResponse_whenNotWsEndpoint() throws Exception {
+
+        mockTransportContext("/not-ws");
+
+        boolean result = interceptor.handleResponse(messageContext, new Object());
+
+        assertTrue(result);
+
+        verifyNoInteractions(soapResponseUtil);
+        verifyNoInteractions(messageProcessorService);
+        verify(messageContext, never()).getProperty(any());
+    }
+
+    @Test
+    void shouldUseRawSoapFromRequest_whenAvailable() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getRequest()).thenReturn(soapMessage);
+
+        doAnswer(invocation -> {
+            ByteArrayOutputStream os = invocation.getArgument(0);
+            os.write("<soap>original</soap>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any());
+
+        when(request.getAttribute(Constants.RAW_SOAP_ATTRIBUTE))
+                .thenReturn("<soap>from-request</soap>");
+
+        boolean result = interceptor.handleRequest(messageContext, new Object());
+
+        assertTrue(result);
+
+        verify(messageContext).setProperty(
+                Constants.RAW_SOAP_ATTRIBUTE,
+                "<soap>from-request</soap>");
+
+        verify(templateLogger, never()).info(any(), any());
+    }
+
+    @Test
+    void shouldReturnFalse_andLogWarning_whenExceptionOccursInIsWsEndpoint() throws Exception {
+
+        TransportContext transportContext = mock(TransportContext.class);
+
+        when(transportContext.getConnection())
+                .thenThrow(new RuntimeException("boom"));
+
+        TransportContextHolder.setTransportContext(transportContext);
+
+        boolean result = interceptor.handleRequest(messageContext, new Object());
+
+        assertTrue(result);
+
+        verify(templateLogger).warn(
+                contains("Error checking request URI"),
+                eq("boom"));
+    }
+
+    @Test
+    void shouldHandleException_inHandleFaultOuterCatch() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID))
+                .thenReturn("INT-1");
+
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+
+        doThrow(new RuntimeException("write-fail"))
+                .when(soapMessage).writeTo(any());
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-2");
+
+            boolean result = interceptor.handleFault(messageContext, new Object());
+
+            assertTrue(result);
+
+            verify(templateLogger).error(
+                    contains("Exception while processing SOAP fault"),
+                    eq("INT-1"),
+                    eq("TRACE-2"),
+                    contains("write-fail"),
+                    any(Exception.class));
+
+            logMock.verify(() -> LogUtil.logDetailedError(
+                    eq(500),
+                    contains("Exception while processing SOAP fault"),
+                    eq("INT-1"),
+                    eq("TRACE-2"),
+                    any(Exception.class)));
+        }
+    }
+
+    @Test
+    void shouldGenerateErrorTraceId_whenNull_inOuterCatch() throws Exception {
+
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID))
+                .thenReturn("INT-1");
+
+        when(messageContext.getResponse())
+                .thenThrow(new RuntimeException("early-fail"));
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
+                    .thenReturn("TRACE-NULL");
+
+            boolean result = interceptor.handleFault(messageContext, new Object());
+
+            assertTrue(result);
+
+            verify(templateLogger).error(
+                    contains("Exception while processing SOAP fault"),
+                    eq("INT-1"),
+                    eq("TRACE-NULL"), // <-- generated in catch block
+                    contains("early-fail"),
+                    any(Exception.class));
+
+            logMock.verify(() -> LogUtil.logDetailedError(
+                    eq(500),
+                    contains("Exception while processing SOAP fault"),
+                    eq("INT-1"),
+                    eq("TRACE-NULL"),
+                    any(Exception.class)));
+        }
+    }
+
+    private String invokeExtractFaultString(String xml) throws Exception {
+        Method method = WsaHeaderInterceptor.class
+                .getDeclaredMethod("extractFaultString", String.class);
+
+        method.setAccessible(true);
+
+        return (String) method.invoke(interceptor, xml);
+    }
+
+    private SoapFaultDetailElement mockDetailElement(String name) {
+        SoapFaultDetailElement element = mock(SoapFaultDetailElement.class);
+        QName qName = new QName("ns", name);
+        when(element.getName()).thenReturn(qName);
+        return element;
+    }
+
+    private void mockTransportContext(String uri) {
+
+        HttpServletConnection connection = mock(HttpServletConnection.class);
+
+        when(connection.getHttpServletRequest()).thenReturn(request);
+
+        when(request.getRequestURI()).thenReturn(uri);
+
+        TransportContext transportContext = mock(TransportContext.class);
+        when(transportContext.getConnection()).thenReturn(connection);
+
+        TransportContextHolder.setTransportContext(transportContext);
+    }
+
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/Hl7UtilTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/Hl7UtilTest.java
@@ -1,0 +1,134 @@
+package org.techbd.ingest.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.ws.WebServiceMessage;
+import org.techbd.iti.schema.MCCIIN000002UV01;
+
+import jakarta.xml.bind.JAXBElement;
+import static org.junit.jupiter.api.Assertions.*;
+import java.io.ByteArrayOutputStream;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.Test;
+import org.techbd.iti.schema.RegistryResponseType;
+
+public class Hl7UtilTest {
+    @Mock
+    private AppLogger appLogger;
+
+    @Mock
+    private TemplateLogger templateLogger;
+
+    private Hl7Util hl7Util;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(appLogger.getLogger(Hl7Util.class)).thenReturn(templateLogger);
+
+        // Initialize static LOG
+        hl7Util = new Hl7Util(appLogger);
+    }
+
+    @Test
+    void shouldConvertMCCIMessageToXml() {
+        MCCIIN000002UV01 message = new MCCIIN000002UV01();
+
+        String result = Hl7Util.toXmlString(message, "123");
+
+        assertNotNull(result);
+        assertFalse(result.isBlank());
+        assertTrue(result.contains("<")); // basic XML check
+    }
+
+    @Test
+    void shouldConvertRegistryResponseToXml() {
+        RegistryResponseType responseType = new RegistryResponseType();
+
+        JAXBElement<RegistryResponseType> element = new JAXBElement<>(
+                new QName("urn:test", "RegistryResponse"),
+                RegistryResponseType.class,
+                responseType);
+
+        String result = Hl7Util.toXmlString(element, "123");
+
+        assertNotNull(result);
+        assertTrue(result.contains("RegistryResponse"));
+    }
+
+    @Test
+    void shouldConvertSoapMessageToString() throws Exception {
+        WebServiceMessage soapMessage = mock(WebServiceMessage.class);
+
+        doAnswer(invocation -> {
+            ByteArrayOutputStream out = invocation.getArgument(0);
+            out.write("<soap>test</soap>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any());
+
+        String result = Hl7Util.soapMessageToString(soapMessage, "123");
+
+        assertEquals("<soap>test</soap>", result);
+    }
+
+    @Test
+    void shouldThrowException_whenMcciMarshallingFails() {
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> Hl7Util.toXmlString((MCCIIN000002UV01) null, "123"));
+
+        assertTrue(ex.getMessage().contains("interactionId=123"));
+
+        verify(templateLogger).error(
+                contains("Error converting MCCIIN000002UV01"),
+                eq("123"),
+                any(Exception.class));
+    }
+
+    @Test
+    void shouldThrowException_whenRegistryMarshallingFails() {
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> Hl7Util.toXmlString((JAXBElement<RegistryResponseType>) null, "123"));
+
+        assertTrue(ex.getMessage().contains("interactionId=123"));
+
+        verify(templateLogger).error(
+                contains("Error converting"),
+                any(),
+                eq("123"),
+                any(Exception.class));
+    }
+
+    @Test
+    void shouldThrowException_whenSoapMessageFails() throws Exception {
+
+        WebServiceMessage soapMessage = mock(WebServiceMessage.class);
+
+        doThrow(new RuntimeException("boom"))
+                .when(soapMessage)
+                .writeTo(any());
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> Hl7Util.soapMessageToString(soapMessage, "123"));
+
+        assertTrue(ex.getMessage().contains("interactionId=123"));
+
+        verify(templateLogger).error(
+                contains("Error converting SoapMessage"),
+                eq("123"),
+                any(Exception.class));
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/SoapFaultUtilTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/util/SoapFaultUtilTest.java
@@ -1,0 +1,96 @@
+package org.techbd.ingest.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SoapFaultUtilTest {
+
+    private SoapFaultUtil util;
+
+    @BeforeEach
+    void setUp() {
+        util = new SoapFaultUtil();
+    }
+
+    @Test
+    void shouldCreateSoap12ServerFault() {
+        String result = util.createSoapFault("error", "int123", "trace123", true);
+
+        assertTrue(result.contains("env:Envelope"));
+        assertTrue(result.contains("env:Receiver"));
+        assertTrue(result.contains("error"));
+        assertTrue(result.contains("int123"));
+        assertTrue(result.contains("trace123"));
+    }
+
+    @Test
+    void shouldCreateSoap11ServerFault() {
+        String result = util.createSoapFault("error", "int123", "trace123", false);
+
+        assertTrue(result.contains("SOAP-ENV:Envelope"));
+        assertTrue(result.contains("SOAP-ENV:Server"));
+        assertTrue(result.contains("error"));
+        assertTrue(result.contains("int123"));
+        assertTrue(result.contains("trace123"));
+    }
+
+    @Test
+    void shouldCreateSoap12ClientFault() {
+        String result = util.createClientSoap12Fault("client error", "int1", "trace1");
+
+        assertTrue(result.contains("env:Sender"));
+        assertTrue(result.contains("client error"));
+        assertTrue(result.contains("int1"));
+        assertTrue(result.contains("trace1"));
+    }
+
+    @Test
+    void shouldCreateSoap11ClientFault() {
+        String result = util.createClientSoap11Fault("client error", "int1", "trace1");
+
+        assertTrue(result.contains("SOAP-ENV:Client"));
+        assertTrue(result.contains("client error"));
+        assertTrue(result.contains("int1"));
+        assertTrue(result.contains("trace1"));
+    }
+
+    @Test
+    void shouldEscapeXmlCharacters() {
+        String input = "<tag> & \" '";
+        String result = util.createSoapFault(input, input, input, true);
+
+        assertTrue(result.contains("&lt;tag&gt;"));
+        assertTrue(result.contains("&amp;"));
+        assertTrue(result.contains("&quot;"));
+        assertTrue(result.contains("&apos;"));
+    }
+
+    @Test
+    void shouldHandleNullValues() {
+        String result = util.createSoapFault(null, null, null, true);
+
+        assertNotNull(result);
+
+        assertTrue(result.contains("<env:Text xml:lang=\"en\"></env:Text>"));
+    }
+
+    @Test
+    void shouldReturnTrue_whenSoap12ContentType() {
+        assertTrue(util.isSoap12("application/soap+xml"));
+    }
+
+    @Test
+    void shouldReturnFalse_whenSoap11ContentType() {
+        assertFalse(util.isSoap12("text/xml"));
+    }
+
+    @Test
+    void shouldReturnFalse_whenContentTypeIsNull() {
+        assertFalse(util.isSoap12(null));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1127.0</revision>
+        <revision>0.1128.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
This PR introduces comprehensive unit test coverage across key components related to exception handling, SOAP fault processing, interceptor logic, and utility functions. #3007

Key highlights:
- Improved coverage for GlobalExceptionHandler including multipart and Apache Camel exception scenarios
- Validated SOAP fault customization and error trace injection in CustomSoapFaultResolver
- Added test coverage for SoapFaultEnhancementFilter including fault parsing, header extraction, and processing flows
- Implemented extensive tests for WsaHeaderInterceptor covering request/response handling, fault processing, interceptor branching, and error trace injection
- Added unit tests for Hl7Util and SoapFaultUtil covering XML conversion and SOAP fault generation (SOAP 1.1 & SOAP 1.2)
- Covered edge cases and hard-to-reach branches including exception paths, fallback logic, and private methods using reflection where necessary

