### PR TITLE
feat(integration-tests): add keep-alive tests for MLLP and raw TCP #3007

### DIFF
--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/base/IngestionAssertionHelper.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/base/IngestionAssertionHelper.java
@@ -53,6 +53,14 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
  * {@code interactionId} and {@code timestamp} from it, and then verifies that
  * the actual S3 keys follow the expected naming convention.  This approach is
  * robust against small timestamp-format changes in the application code.
+ *
+ * <h3>Multi-message session support</h3>
+ * When {@code expectedPayload} is set and multiple S3 objects exist in the
+ * bucket (e.g. two HL7 messages sent on one keep-alive TCP session), the helper
+ * locates the <em>exact</em> payload key by content match rather than picking
+ * the first key found. The corresponding metadata key and SQS message are then
+ * located by matching on the derived {@code s3DataObjectPath}, ensuring all
+ * assertions are anchored to the same ingestion event.
  */
 public class IngestionAssertionHelper {
 
@@ -85,16 +93,6 @@ public class IngestionAssertionHelper {
 
     /**
      * Validates the <em>default</em> two-bucket flow (no route or hold).
-     *
-     * <p>Equivalent to the port-9000 SOAP or port-2575 TCP happy-path:
-     * <pre>
-     * Data:     DEFAULT_DATA_BUCKET   /  data/YYYY/MM/DD/{interactionId}_{ts}
-     * Metadata: DEFAULT_METADATA_BUCKET / metadata/YYYY/MM/DD/{interactionId}_{ts}_metadata.json
-     * ACK:      DEFAULT_DATA_BUCKET   /  data/YYYY/MM/DD/{interactionId}_{ts}_ack
-     * </pre>
-     *
-     * @param params      assertion parameters (see {@link FlowAssertionParams})
-     * @param softly      soft-assertion collector
      */
     public void assertDefaultFlow(FlowAssertionParams params, SoftAssertions softly) throws Exception {
         assertCustomFlow(params, softly);
@@ -102,19 +100,6 @@ public class IngestionAssertionHelper {
 
     /**
      * Validates the <em>hold</em> single-bucket flow.
-     *
-     * <p>Applies when {@code route=/hold} is set in the port-config entry.
-     * Both data and metadata land in the same bucket (HOLD_BUCKET).
-     *
-     * <p>Key structure (port-based, no tenant):
-     * <pre>
-     * Data:     HOLD_BUCKET / {dataDir}/hold/{port}/YYYY/MM/DD/{ts}_{fileName}
-     * Metadata: HOLD_BUCKET / {metadataDir}/hold/metadata/{port}/YYYY/MM/DD/{ts}_{fileName}_metadata.json
-     * ACK:      HOLD_BUCKET / {dataDir}/hold/{port}/YYYY/MM/DD/{ts}_{fileName}_ack
-     * </pre>
-     *
-     * @param params      assertion parameters
-     * @param softly      soft-assertion collector
      */
     public void assertHoldFlow(FlowAssertionParams params, SoftAssertions softly) throws Exception {
         assertCustomFlow(params, softly);
@@ -122,16 +107,6 @@ public class IngestionAssertionHelper {
 
     /**
      * Validates the <em>error</em> flow.
-     *
-     * <p>When ingestion fails the application stores the payload under the
-     * {@code error/} prefix (no dataDir applied). SQS assertion is skipped.
-     *
-     * <pre>
-     * Data: dataBucket / error/YYYY/MM/DD/{interactionId}_{ts}
-     * </pre>
-     *
-     * @param params      assertion parameters (set {@code isErrorFlow=true})
-     * @param softly      soft-assertion collector
      */
     public void assertErrorFlow(FlowAssertionParams params, SoftAssertions softly) throws Exception {
         assertCustomFlow(params, softly);
@@ -141,61 +116,59 @@ public class IngestionAssertionHelper {
      * Fully-parameterised assertion method that covers every {@code list.json}
      * combination. All convenience methods delegate here.
      *
-     * <p>Algorithm:
+     * <p><b>Key-selection strategy</b>:
      * <ol>
-     *   <li>List objects in the data bucket and locate the payload / ACK keys.</li>
-     *   <li>List objects in the metadata bucket and read the metadata JSON.</li>
-     *   <li>Extract {@code interactionId}, {@code timestamp}, and optional
-     *       {@code fileName} from the metadata JSON to build <em>expected</em>
-     *       key patterns.</li>
-     *   <li>Verify prefix, suffix, and full {@code s3://} URI consistency.</li>
-     *   <li>If not an error flow and a queue URL is supplied, poll SQS and verify
-     *       all path fields and {@code messageGroupId}.</li>
+     *   <li>List all objects in the data bucket.</li>
+     *   <li>Collect all candidate payload keys (no {@code _ack}, no {@code _metadata}).</li>
+     *   <li>If {@code expectedPayload} is set, read each candidate in turn and pick
+     *       the one whose normalised content matches the normalised expected payload.
+     *       This is the <em>content-aware</em> selection that makes multi-message
+     *       sessions work correctly — each call finds its own S3 object regardless
+     *       of how many objects are in the bucket.</li>
+     *   <li>If {@code expectedPayload} is null (or no match found after retries),
+     *       fall back to the first candidate — preserving existing behaviour for
+     *       SOAP/TCP tests that rely on single-object buckets.</li>
+     *   <li>Locate the matching metadata key by matching on the
+     *       {@code s3DataObjectPath} embedded in each metadata JSON — so the
+     *       metadata is always the one that belongs to the selected payload.</li>
+     *   <li>Locate the SQS message by matching its {@code s3DataObjectPath} field
+     *       against the path derived from the selected payload key.</li>
      * </ol>
-     *
-     * @param params assertion parameters
-     * @param softly soft-assertion collector
      */
     public void assertCustomFlow(FlowAssertionParams params, SoftAssertions softly) throws Exception {
 
-        // ── 1. Locate objects in the data bucket ─────────────────────────────
-        ListObjectsV2Response dataObjects = s3Client.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(params.dataBucket).build());
+        // ── 1. Wait for the payload key for THIS specific assertion ────────────
+        // When expectedPayload is set this blocks until the specific object is
+        // durably written — critical for multi-message keep-alive sessions where
+        // MSG1 is already present when asserting MSG2.
+        String payloadKey = waitForMatchingPayloadKey(params.dataBucket, params);
 
-        softly.assertThat(dataObjects.contents())
-                .as("[S3] Data bucket '%s' must not be empty", params.dataBucket)
-                .isNotEmpty();
-        if (dataObjects.contents().isEmpty()) return;
-
-        String payloadKey = findKey(dataObjects, k -> !k.contains("_ack") && !k.contains("_metadata"));
-        String ackKey     = params.ackExpected ? findKey(dataObjects, k -> k.contains("_ack")) : null;
-
-        softly.assertThat(payloadKey).as("[S3] Payload key must exist in '%s'", params.dataBucket).isNotNull();
-        if (params.ackExpected) {
-            softly.assertThat(ackKey).as("[S3] ACK key must exist in '%s'", params.dataBucket).isNotNull();
-        }
+        softly.assertThat(payloadKey)
+                .as("[S3] Could not locate a payload key matching the expected content in '%s'",
+                        params.dataBucket)
+                .isNotNull();
         if (payloadKey == null) return;
 
-        // ── 2. Locate metadata object ────────────────────────────────────────
+        // ── 2. Locate the metadata key that belongs to THIS payload ─────────────────────
         String metaBucket = params.metadataBucket != null ? params.metadataBucket : params.dataBucket;
-        ListObjectsV2Response metaObjects = s3Client.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(metaBucket).build());
 
-        softly.assertThat(metaObjects.contents())
-                .as("[S3] Metadata bucket '%s' must not be empty", metaBucket)
-                .isNotEmpty();
-        if (metaObjects.contents().isEmpty()) return;
+        // Build the expected data s3:// URI from the selected payload key.
+        // We use it to find the right metadata JSON among potentially many.
+        String expectedDataS3Uri = "s3://" + params.dataBucket + "/" + payloadKey;
 
-        String metadataKey = findKey(metaObjects, k -> k.contains("_metadata.json"));
-        softly.assertThat(metadataKey).as("[S3] Metadata key must exist in '%s'", metaBucket).isNotNull();
+        String metadataKey = waitForMatchingMetadataKey(metaBucket, expectedDataS3Uri);
+
+        softly.assertThat(metadataKey)
+                .as("[S3] Metadata key anchored to payload '%s' must exist in bucket '%s'",
+                        payloadKey, metaBucket)
+                .isNotNull();
         if (metadataKey == null) return;
 
-        // ── 3. Parse metadata JSON and extract canonical IDs ─────────────────
+        // ── 3. Parse metadata JSON ────────────────────────────────────────────
         String metadataContent = readS3(metaBucket, metadataKey);
-        JsonNode meta = MAPPER.readTree(metadataContent);
-
-        String keyFromMeta   = meta.get("key").asText();       // the stored objectKey
-        JsonNode jsonMeta    = meta.get("json_metadata");
+        JsonNode meta      = MAPPER.readTree(metadataContent);
+        String keyFromMeta = meta.get("key").asText();
+        JsonNode jsonMeta  = meta.get("json_metadata");
 
         String interactionId = jsonMeta.has("interactionId") ? jsonMeta.get("interactionId").asText() : null;
         String timestamp     = jsonMeta.has("timestamp")     ? jsonMeta.get("timestamp").asText()     : null;
@@ -205,18 +178,30 @@ public class IngestionAssertionHelper {
         String s3AckPath     = params.ackExpected && jsonMeta.has("fullS3AcknowledgementPath")
                                ? jsonMeta.get("fullS3AcknowledgementPath").asText() : null;
 
-        // ── 4. Build expected key structures ─────────────────────────────────
-        String datePath = todayDatePath();
+        // ── 4. Locate ACK key (if expected) ───────────────────────────────────
+        String ackKey = null;
+        if (params.ackExpected && s3AckPath != null) {
+            // Derive the ack key from the canonical ack path stored in metadata —
+            // this is safe even when multiple ack objects exist in the bucket.
+            ackKey = s3AckPath.replaceFirst("^s3://[^/]+/", "");
+        } else if (params.ackExpected) {
+            // Fallback: find an ack key that shares the same key stem as payloadKey
+            ackKey = findAckKeyForPayload(params.dataBucket, payloadKey);
+        }
 
-        // Build the expected file stem from metadata-derived values
-        String expectedFileStem = buildExpectedFileStem(interactionId, timestamp, fileName, params);
+        if (params.ackExpected) {
+            softly.assertThat(ackKey)
+                    .as("[S3] ACK key must exist for payload '%s'", payloadKey)
+                    .isNotNull();
+        }
 
-        // Determine expected prefix for data key
+        // ── 5. Build expected key structures ──────────────────────────────────
+        String datePath          = todayDatePath();
+        String expectedFileStem  = buildExpectedFileStem(interactionId, timestamp, fileName, params);
         String expectedDataPrefix = buildExpectedDataPrefix(params, datePath);
-        // Determine expected prefix for metadata key
         String expectedMetaPrefix = buildExpectedMetaPrefix(params, datePath);
 
-        // ── 5. Assert key prefixes ────────────────────────────────────────────
+        // ── 6. Assert key prefixes ────────────────────────────────────────────
         softly.assertThat(payloadKey)
                 .as("[S3] Payload key must start with '%s'", expectedDataPrefix)
                 .startsWith(expectedDataPrefix);
@@ -225,7 +210,7 @@ public class IngestionAssertionHelper {
                 .as("[S3] Metadata key must start with '%s'", expectedMetaPrefix)
                 .startsWith(expectedMetaPrefix);
 
-        // ── 6. Assert file-stem / suffix consistency ──────────────────────────
+        // ── 7. Assert file-stem / suffix consistency ──────────────────────────
         if (expectedFileStem != null) {
             softly.assertThat(payloadKey)
                     .as("[S3] Payload key must contain file stem '%s'", expectedFileStem)
@@ -236,10 +221,6 @@ public class IngestionAssertionHelper {
                     .contains(expectedFileStem);
 
             if (params.ackExpected && ackKey != null) {
-                // For hold flow the stem is just "{timestamp}_" (no fixed filename), so
-                // we verify the key contains the timestamp anchor AND ends with "_ack".
-                // For normal flow the stem is "{interactionId}_{timestamp}", so the full
-                // suffix "{stem}_ack" is the right check.
                 if (params.isHoldFlow) {
                     softly.assertThat(ackKey)
                             .as("[S3] ACK key must contain timestamp stem '%s' and end with '_ack'",
@@ -254,7 +235,7 @@ public class IngestionAssertionHelper {
             }
         }
 
-        // ── 7. Assert full s3:// URI consistency ──────────────────────────────
+        // ── 8. Assert full s3:// URI consistency ─────────────────────────────
         softly.assertThat(s3DataPath)
                 .as("[S3] s3DataObjectPath must equal s3://%s/%s", params.dataBucket, keyFromMeta)
                 .isEqualTo("s3://" + params.dataBucket + "/" + keyFromMeta);
@@ -269,7 +250,7 @@ public class IngestionAssertionHelper {
                     .isEqualTo("s3://" + params.dataBucket + "/" + ackKey);
         }
 
-        // ── 8. Optional payload content verification ──────────────────────────
+        // ── 9. Optional payload content verification ─────────────────────────
         if (params.expectedPayload != null) {
             String actualPayload = readS3(params.dataBucket, payloadKey);
             softly.assertThat(params.normalizePayload(actualPayload))
@@ -277,13 +258,13 @@ public class IngestionAssertionHelper {
                     .isEqualTo(params.normalizePayload(params.expectedPayload));
         }
 
-        // ── 9. Optional ACK content verification ─────────────────────────────
+        // ── 10. Optional ACK content verification ─────────────────────────────
         if (params.ackExpected && params.ackXPathAssertions != null && ackKey != null) {
             String actualAck = readS3(params.dataBucket, ackKey);
             params.ackXPathAssertions.accept(actualAck, softly);
         }
 
-        // ── 10. SQS consistency check (skipped for error flow) ───────────────
+        // ── 11. SQS consistency check (skipped for error flow) ────────────────
         if (!params.isErrorFlow && params.queueUrl != null) {
             assertSqsConsistency(
                     params.queueUrl,
@@ -303,9 +284,10 @@ public class IngestionAssertionHelper {
     /**
      * Polls {@code queueUrl} and validates all SQS message fields.
      *
-     * <p>Fields checked: {@code s3DataObjectPath}, {@code fullS3MetaDataPath},
-     * {@code fullS3AcknowledgementPath} (if not null), {@code s3ObjectId},
-     * {@code messageGroupId}.
+     * <p>When multiple messages are present (e.g. two HL7 messages on one keep-alive
+     * session), the poll finds the message whose {@code s3DataObjectPath} equals
+     * {@code expectedDataPath} — anchoring the SQS assertion to the correct
+     * ingestion event rather than assuming arrival order.
      */
     public void assertSqsConsistency(
             String queueUrl,
@@ -316,13 +298,14 @@ public class IngestionAssertionHelper {
             String expectedGroupId,
             SoftAssertions softly) throws Exception {
 
-        ReceiveMessageResponse sqsResponse = waitForSqsMessage(queueUrl);
-        softly.assertThat(sqsResponse.messages())
-                .as("[SQS] Queue '%s' must contain a message", queueUrl)
-                .isNotEmpty();
-        if (sqsResponse.messages().isEmpty()) return;
+        Message msg = waitForSqsMessageMatchingDataPath(queueUrl, expectedDataPath);
 
-        Message msg = sqsResponse.messages().get(0);
+        softly.assertThat(msg)
+                .as("[SQS] Queue '%s' must contain a message with s3DataObjectPath='%s'",
+                        queueUrl, expectedDataPath)
+                .isNotNull();
+        if (msg == null) return;
+
         JsonNode sqsJson = MAPPER.readTree(msg.body());
 
         softly.assertThat(sqsJson.get("s3DataObjectPath").asText())
@@ -399,15 +382,6 @@ public class IngestionAssertionHelper {
 
     /**
      * Builds the expected data key prefix from flow params.
-     *
-     * <p>Rules (mirrors {@code DataDirResolverImpl}):
-     * <ul>
-     *   <li>Error flow → {@code error/YYYY/MM/DD} (no dataDir)</li>
-     *   <li>Hold + tenant → {@code {dataDir}/hold/{tenantId}/YYYY/MM/DD}</li>
-     *   <li>Hold + port  → {@code {dataDir}/hold/{port}/YYYY/MM/DD}</li>
-     *   <li>Normal + tenant → {@code {dataDir}/data/{tenantId}/YYYY/MM/DD}</li>
-     *   <li>Normal + no dir → {@code data/YYYY/MM/DD}</li>
-     * </ul>
      */
     public static String buildExpectedDataPrefix(FlowAssertionParams p, String datePath) {
         if (p.isErrorFlow) {
@@ -434,9 +408,6 @@ public class IngestionAssertionHelper {
 
     /**
      * Builds the expected metadata key prefix from flow params.
-     *
-     * <p>Mirrors {@code DataDirResolverImpl#buildHoldMetadataKey} /
-     * {@code buildNormalMetadataKey}.
      */
     public static String buildExpectedMetaPrefix(FlowAssertionParams p, String datePath) {
         if (p.isErrorFlow) {
@@ -462,29 +433,182 @@ public class IngestionAssertionHelper {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // Private helpers
+    // Private helpers — key selection
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Waits (with retries) until a payload key whose content matches
+     * {@code expectedPayload} exists in {@code bucket}, then returns that key.
+     *
+     * <p>When {@code expectedPayload} is null the method waits for any payload
+     * key to appear and returns the first one found — preserving existing
+     * single-object behaviour for SOAP/TCP tests.
+     *
+     * <p>Critically, each retry re-lists the bucket and re-reads every candidate,
+     * so the method blocks until the <em>specific</em> object for this assertion
+     * call is durably written.  This is what makes two-message keep-alive sessions
+     * work: the assertion for MSG2 keeps waiting past the point where only MSG1
+     * is visible, rather than returning early because MSG1 satisfied a weaker
+     * "any candidate" check.
+     */
+    private String waitForMatchingPayloadKey(String bucket, FlowAssertionParams params)
+            throws InterruptedException {
+        String expectedPayload = params.expectedPayload;
+
+        for (int i = 0; i < 20; i++) {
+            ListObjectsV2Response response = s3Client.listObjectsV2(
+                    ListObjectsV2Request.builder().bucket(bucket).build());
+
+            List<String> candidates = response.contents().stream()
+                    .map(S3Object::key)
+                    .filter(k -> !k.contains("_ack") && !k.contains("_metadata"))
+                    .collect(Collectors.toList());
+
+            if (expectedPayload == null) {
+                // No content match needed — return first key as soon as one exists
+                if (!candidates.isEmpty()) return candidates.get(0);
+            } else {
+                // Must find the key whose content matches THIS assertion's payload
+                for (String key : candidates) {
+                    try {
+                        String actual = readS3(bucket, key);
+                        if (params.normalizePayload(actual)
+                                .equals(params.normalizePayload(expectedPayload))) {
+                            return key;
+                        }
+                    } catch (Exception ignored) { /* object may still be in flight */ }
+                }
+            }
+            Thread.sleep(1_000);
+        }
+        return null; // timed out — caller will produce a clear assertion failure
+    }
+
+    /**
+     * Polls the metadata bucket (with retries) until a metadata JSON is found
+     * whose embedded {@code s3DataObjectPath} equals {@code expectedDataS3Uri}.
+     *
+     * <p>This ensures that in multi-message sessions the metadata key returned
+     * always belongs to the same ingestion event as the selected payload key.
+     */
+    private String waitForMatchingMetadataKey(String bucket, String expectedDataS3Uri)
+            throws InterruptedException {
+        for (int i = 0; i < 15; i++) {
+            ListObjectsV2Response response = s3Client.listObjectsV2(
+                    ListObjectsV2Request.builder().bucket(bucket).build());
+
+            for (S3Object obj : response.contents()) {
+                String key = obj.key();
+                if (!key.contains("_metadata.json")) continue;
+                try {
+                    String content = readS3(bucket, key);
+                    JsonNode meta  = MAPPER.readTree(content);
+                    JsonNode jsonMeta = meta.get("json_metadata");
+                    if (jsonMeta != null && jsonMeta.has("s3DataObjectPath")) {
+                        String dataPath = jsonMeta.get("s3DataObjectPath").asText();
+                        if (expectedDataS3Uri.equals(dataPath)) {
+                            return key;
+                        }
+                    }
+                } catch (Exception ignored) { /* metadata may still be in flight */ }
+            }
+            Thread.sleep(1_000);
+        }
+        return null;
+    }
+
+    /**
+     * Finds an ACK key in the data bucket that corresponds to the given payload key.
+     *
+     * <p>The ACK key is expected to share the same timestamp/stem prefix as the
+     * payload key and end with {@code _ack}.  Used only as a fallback when the
+     * metadata JSON does not carry {@code fullS3AcknowledgementPath}.
+     */
+    private String findAckKeyForPayload(String bucket, String payloadKey) {
+        // Extract the stem: everything after the last '/' and up to (not including)
+        // any extension-like suffix that may be specific to the payload file name.
+        // We try to match on timestamp prefix common to both payload and ack.
+        String payloadName = payloadKey.contains("/")
+                ? payloadKey.substring(payloadKey.lastIndexOf('/') + 1)
+                : payloadKey;
+
+        ListObjectsV2Response response = s3Client.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(bucket).build());
+
+        // First pass: exact stem match — "{payloadName}_ack"
+        String exact = response.contents().stream()
+                .map(S3Object::key)
+                .filter(k -> k.contains("_ack") && k.endsWith(payloadName + "_ack"))
+                .findFirst().orElse(null);
+        if (exact != null) return exact;
+
+        // Second pass: share same directory prefix and timestamp stem
+        String dir = payloadKey.contains("/")
+                ? payloadKey.substring(0, payloadKey.lastIndexOf('/') + 1)
+                : "";
+        // Extract leading timestamp (digits before first '_')
+        String ts = payloadName.contains("_") ? payloadName.substring(0, payloadName.indexOf('_')) : payloadName;
+
+        return response.contents().stream()
+                .map(S3Object::key)
+                .filter(k -> k.startsWith(dir) && k.contains("_ack"))
+                .filter(k -> {
+                    String name = k.contains("/") ? k.substring(k.lastIndexOf('/') + 1) : k;
+                    return name.startsWith(ts + "_");
+                })
+                .findFirst().orElse(null);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Private helpers — SQS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Polls {@code queueUrl} (up to 15 × 2 s) until a message whose body contains
+     * {@code s3DataObjectPath == expectedDataPath} is found.
+     *
+     * <p>Receiving messages does <em>not</em> delete them from the FIFO queue, so
+     * both messages sent in a two-message session remain available for the second
+     * {@code assertHoldFlow} call.
+     */
+    private Message waitForSqsMessageMatchingDataPath(String queueUrl, String expectedDataPath)
+            throws InterruptedException {
+        for (int i = 0; i < 15; i++) {
+            // Receive up to 10 messages per poll — FIFO queues may hold both messages
+            ReceiveMessageResponse resp = sqsClient.receiveMessage(
+                    ReceiveMessageRequest.builder()
+                            .queueUrl(queueUrl)
+                            .maxNumberOfMessages(10)
+                            .waitTimeSeconds(2)
+                            .build());
+
+            for (Message msg : resp.messages()) {
+                try {
+                    JsonNode body = MAPPER.readTree(msg.body());
+                    if (body.has("s3DataObjectPath")
+                            && expectedDataPath.equals(body.get("s3DataObjectPath").asText())) {
+                        return msg;
+                    }
+                } catch (Exception ignored) { /* malformed message — skip */ }
+            }
+            Thread.sleep(1_000);
+        }
+        return null;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Private helpers — misc
     // ═══════════════════════════════════════════════════════════════════════════
 
     /**
      * Builds the expected file stem used to verify key names.
-     *
-     * <p>For hold flow: returns just {@code "{timestamp}_"} as a prefix-anchor.
-     * The full file name (including extension) is preserved by the application
-     * ({@code DataDirResolverImpl#buildTimestampedName}), so we only assert that
-     * the key contains the timestamp prefix — avoiding false failures caused by
-     * extension stripping (e.g. {@code soap-message.xml} must not become
-     * {@code soap-message}).
-     *
-     * <p>For normal flow: {@code {interactionId}_{timestamp}}
      */
     private static String buildExpectedFileStem(
             String interactionId, String timestamp, String fileName, FlowAssertionParams p) {
 
-        if (timestamp == null) return null; // can't derive without timestamp
+        if (timestamp == null) return null;
 
         if (p.isHoldFlow) {
-            // Only anchor on the timestamp prefix; let the full filename+extension be
-            // whatever the application wrote — verified indirectly via the s3:// URI check.
             return timestamp + "_";
         }
         if (interactionId != null) {
@@ -498,30 +622,6 @@ public class IngestionAssertionHelper {
         return path.replaceAll("^/+", "").replaceAll("/+$", "");
     }
 
-    private static String findKey(ListObjectsV2Response response,
-                                   java.util.function.Predicate<String> predicate) {
-        return response.contents().stream()
-                .map(S3Object::key)
-                .filter(predicate)
-                .findFirst()
-                .orElse(null);
-    }
-
-    /**
-     * Polls {@code queueUrl} (up to 10 × 2 s) until a message arrives.
-     */
-    private ReceiveMessageResponse waitForSqsMessage(String queueUrl) throws InterruptedException {
-        for (int i = 0; i < 10; i++) {
-            ReceiveMessageResponse resp = sqsClient.receiveMessage(
-                    ReceiveMessageRequest.builder()
-                            .queueUrl(queueUrl)
-                            .waitTimeSeconds(2)
-                            .build());
-            if (!resp.messages().isEmpty()) return resp;
-            Thread.sleep(1_000);
-        }
-        throw new AssertionError("No SQS message received after retries for queue: " + queueUrl);
-    }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // FlowAssertionParams – builder-style configuration object
@@ -529,78 +629,31 @@ public class IngestionAssertionHelper {
 
     /**
      * Encapsulates all parameters needed to assert a single ingestion flow.
-     *
-     * <p>Use the fluent {@link Builder} to construct instances:
-     * <pre>{@code
-     * FlowAssertionParams params = FlowAssertionParams.builder()
-     *     .dataBucket(DEFAULT_DATA_BUCKET)
-     *     .metadataBucket(DEFAULT_METADATA_BUCKET)
-     *     .queueUrl(mainQueueUrl)
-     *     .expectedMessageGroupId("ORU_PUSH")
-     *     .expectedPayload(hl7)
-     *     .payloadNormalizer(IngestionAssertionHelper::normalizeHl7)
-     *     .build();
-     * }</pre>
      */
     public static final class FlowAssertionParams {
 
         // ── Bucket config ──────────────────────────────────────────────────────
-        /** S3 bucket that holds the raw payload (and ACK). Required. */
         public final String dataBucket;
-        /**
-         * S3 bucket that holds the metadata JSON. If null, defaults to
-         * {@code dataBucket} (hold flow has both in one bucket).
-         */
         public final String metadataBucket;
 
         // ── Flow type flags ────────────────────────────────────────────────────
-        /** True when the port-config has {@code route=/hold}. */
         public final boolean isHoldFlow;
-        /**
-         * True when the ingestion failed and data lands in the {@code error/}
-         * prefix. SQS assertion is skipped for error flows.
-         */
         public final boolean isErrorFlow;
 
-        // ── Port-config attributes (from list.json) ────────────────────────────
-        /** The listening port (used in hold-key path when no tenant). */
+        // ── Port-config attributes ─────────────────────────────────────────────
         public final int port;
-        /** {@code dataDir} from port-config (e.g. {@code "/outbound"}). */
         public final String dataDir;
-        /** {@code metadataDir} from port-config; falls back to dataDir if null. */
         public final String metadataDir;
-        /**
-         * Tenant ID ({@code sourceId_msgType}). Null if neither field is set in
-         * the port-config entry.
-         */
         public final String tenantId;
 
         // ── SQS config ─────────────────────────────────────────────────────────
-        /** Queue URL to poll. Null skips SQS check. */
         public final String queueUrl;
-        /**
-         * Expected {@code messageGroupId} in the SQS message body. Null skips
-         * that specific field assertion.
-         */
         public final String expectedMessageGroupId;
 
         // ── Payload / ACK ──────────────────────────────────────────────────────
-        /**
-         * Raw payload that was sent. When non-null the stored S3 object is
-         * compared after normalisation.
-         */
         public final String expectedPayload;
-        /** Whether to look for an ACK object ({@code _ack} suffix). */
         public final boolean ackExpected;
-        /**
-         * Optional lambda to assert fields inside the stored ACK. Signature:
-         * {@code (ackXml, softly) -> ...}
-         */
         public final AckAssertion ackXPathAssertions;
-        /**
-         * Normalizer applied to both the sent and stored payload before comparison.
-         * Defaults to {@link IngestionAssertionHelper#normalizeGeneric}.
-         */
         final PayloadNormalizer payloadNormalizer;
 
         private FlowAssertionParams(Builder b) {
@@ -628,17 +681,6 @@ public class IngestionAssertionHelper {
 
         public static Builder builder() { return new Builder(); }
 
-        /**
-         * Returns a new {@link Builder} pre-populated with all values from this
-         * instance, allowing callers to clone-and-override specific fields.
-         *
-         * <pre>{@code
-         * FlowAssertionParams noAck = defaultFlowParams(request, null, groupId)
-         *         .toBuilder()
-         *         .ackExpected(false)
-         *         .build();
-         * }</pre>
-         */
         public Builder toBuilder() {
             return new Builder()
                     .dataBucket(this.dataBucket)
@@ -673,33 +715,19 @@ public class IngestionAssertionHelper {
             private AckAssertion ackXPathAssertions;
             private PayloadNormalizer payloadNormalizer;
 
-            /** S3 bucket for data payload + ACK. */
             public Builder dataBucket(String v)             { dataBucket = v;             return this; }
-            /** S3 bucket for metadata JSON (null → same as dataBucket). */
             public Builder metadataBucket(String v)         { metadataBucket = v;         return this; }
-            /** Mark as hold flow ({@code route=/hold}). */
             public Builder holdFlow(boolean v)              { isHoldFlow = v;             return this; }
-            /** Mark as error flow (payload lands in {@code error/…}). */
             public Builder errorFlow(boolean v)             { isErrorFlow = v;            return this; }
-            /** Listening port number (used in hold-key when no tenant). */
             public Builder port(int v)                      { port = v;                   return this; }
-            /** {@code dataDir} from port-config entry. */
             public Builder dataDir(String v)                { dataDir = v;                return this; }
-            /** {@code metadataDir} from port-config entry. */
             public Builder metadataDir(String v)            { metadataDir = v;            return this; }
-            /** Tenant ID ({@code sourceId_msgType}); null if absent. */
             public Builder tenantId(String v)               { tenantId = v;               return this; }
-            /** SQS queue URL to poll; null skips SQS assertion. */
             public Builder queueUrl(String v)               { queueUrl = v;               return this; }
-            /** Expected {@code messageGroupId}; null skips that check. */
             public Builder expectedMessageGroupId(String v) { expectedMessageGroupId = v; return this; }
-            /** Raw payload that was sent (for stored-payload comparison). */
             public Builder expectedPayload(String v)        { expectedPayload = v;        return this; }
-            /** Whether to assert an ACK object exists (default true). */
             public Builder ackExpected(boolean v)           { ackExpected = v;            return this; }
-            /** Optional lambda to assert content inside the stored ACK. */
             public Builder ackXPathAssertions(AckAssertion v) { ackXPathAssertions = v;  return this; }
-            /** Custom payload normalizer (default: {@link IngestionAssertionHelper#normalizeGeneric}). */
             public Builder payloadNormalizer(PayloadNormalizer v) { payloadNormalizer = v; return this; }
 
             public FlowAssertionParams build() {
@@ -724,7 +752,7 @@ public class IngestionAssertionHelper {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // Built-in normalizers (static, for convenience)
+    // Built-in normalizers
     // ═══════════════════════════════════════════════════════════════════════════
 
     /** Collapses all whitespace – works for both XML and HL7. */

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/tcp/NettyTcpServerKeepAliveITCase.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/tcp/NettyTcpServerKeepAliveITCase.java
@@ -1,0 +1,461 @@
+package org.techbd.ingest.integrationtests.tcp;
+
+import static org.techbd.ingest.integrationtests.util.NettyTcpServerKeepAliveFixtures.TCP_MSG1_CCD_XML;
+import static org.techbd.ingest.integrationtests.util.NettyTcpServerKeepAliveFixtures.TCP_MSG2_ADT_A03;
+
+import java.io.ByteArrayOutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.techbd.ingest.integrationtests.base.BaseIntegrationTest;
+import org.techbd.ingest.integrationtests.base.IngestionAssertionHelper;
+import org.techbd.ingest.integrationtests.base.IngestionAssertionHelper.FlowAssertionParams;
+
+/**
+ * Integration tests for <b>persistent (keep-alive) MLLP connections</b>.
+ *
+ * <p>Port under test:</p>
+ *
+ *
+ * <h3>Port 6555 — raw TCP / delimiter-framed (keep-alive)</h3>
+ * <pre>{@code
+ * {
+ *   "port": 6555,
+ *   "responseType": "tcp",
+ *   "protocol": "TCP",
+ *   "route": "/hold",
+ *   "dataDir": "/outbound",
+ *   "metadataDir": "/outbound",
+ *   "queue": "test.fifo",
+ *   "keepAliveTimeout": 20
+ * }
+ * }</pre>
+ *
+ * <h3>Keep-alive behaviour (from NettyTcpServer)</h3>
+ * <ul>
+ *   <li>When the server resolves a {@code keepAliveTimeout > 0} for the destination
+ *       port it replaces the default {@link io.netty.handler.timeout.ReadTimeoutHandler}
+ *       with an {@link io.netty.handler.timeout.IdleStateHandler IdleStateHandler}.</li>
+ *   <li>After flushing each ACK/response the channel is <em>kept open</em>; per-message
+ *       attributes ({@code INTERACTION_ATTRIBUTE_KEY}, {@code FRAGMENT_COUNT_KEY}, etc.)
+ *       are reset, while session attributes ({@code SESSION_ID_KEY},
+ *       {@code SESSION_MESSAGE_COUNT_KEY}) are preserved across messages.</li>
+ *   <li>The channel is closed only when the idle reader fires or on error.</li>
+ * </ul>
+ *
+ *
+ * <h3>TCP test scenarios (port 6555)</h3>
+ * <ol>
+ *   <li><b>Two TCP messages, one session</b> — send two TCP-delimited messages on the
+ *       same connection, verify two simple ACKs, two S3+SQS payloads.</li>
+ *   <li><b>One TCP message, channel survives read-timeout window</b> — send one message,
+ *       confirm the ACK arrives, then verify the channel is still open after the
+ *       default read-timeout (10 s) but closes around the keepAliveTimeout (20 s).</li>
+ *   <li><b>No TCP message sent, channel closes at keepAliveTimeout</b> — open a
+ *       connection, send only the HAProxy header, and verify the server holds the
+ *       channel open past the default read-timeout (10 s).</li>
+ * </ol>
+ *
+ * <h3>SQS deduplication note</h3>
+ * <p>The fixtures ({@link NettyTcpServerKeepAliveFixtures#TCP_MSG1_CCD_XML} and
+ * {@link NettyTcpServerKeepAliveFixtures#TCP_MSG2_ADT_A03}) are intentionally
+ * content-distinct so that the SQS FIFO deduplication window (5 minutes) does not
+ * suppress the second message within each pair.
+ *
+ * @see NettyTcpServerKeepAliveFixtures  for shared fixture strings and group-ID constants
+ */
+class NettyTcpServerKeepAliveITCase extends BaseIntegrationTest {
+
+    // ── Network constants ────────────────────────────────────────────────────
+
+    /** Dispatcher port — HAProxy PROXY-protocol entry point. */
+    private static final int    TCP_SERVER_PORT = 7980;
+    private static final String TCP_HOST        = "localhost";
+    /**
+     * Raw-TCP destination port in the HAProxy header.
+     * The server resolves the port-config for this port
+     * ({@code keepAliveTimeout=20, responseType=tcp, route=/hold, queue=test.fifo}).
+     */
+    private static final int TCP_DEST_PORT = 6555;
+
+    private static final String CLIENT_IP        = "203.0.113.10";
+    private static final String DEST_IP          = "127.0.0.1";
+    private static final int    TCP_CLIENT_PORT  = 55200;
+
+    // ── Timeout constants (seconds) ──────────────────────────────────────────
+
+    /**
+     * Default server read-timeout — the channel must <em>not</em> close within
+     * this window when keepAlive is active.
+     */
+    private static final int DEFAULT_READ_TIMEOUT_S = 10;
+
+    /**
+     * keepAliveTimeout configured on both port 5555 and port 6555.
+     * The channel <em>must</em> close within this window when no subsequent
+     * message arrives.
+     */
+    private static final int KEEP_ALIVE_TIMEOUT_S = 20;
+
+    /**
+     * Grace margin (seconds) added when asserting an upper bound, to absorb
+     * scheduling jitter in CI environments.
+     */
+    private static final int GRACE_S = 5;
+
+    // ── TCP delimiter framing (STX / ETX / LF — default env config) ──────────
+
+    private static final byte TCP_START = 0x02; // STX
+    private static final byte TCP_END_1 = 0x03; // ETX
+    private static final byte TCP_END_2 = 0x0A; // LF
+
+    // ── Setup ────────────────────────────────────────────────────────────────
+
+    @BeforeAll
+    static void initProfile() {
+        System.setProperty("SPRING_PROFILES_ACTIVE", "test");
+    }
+
+    // ── Helper factory ───────────────────────────────────────────────────────
+
+    private IngestionAssertionHelper assertionHelper() {
+        return new IngestionAssertionHelper(s3Client, sqsClient);
+    }
+
+    // =========================================================================
+    // TCP TESTS — port 6555
+    // =========================================================================
+
+    // ── TCP Test 1 — Two TCP messages on one persistent session ───────────────
+
+    /**
+     * Sends two content-distinct TCP-delimited messages on a single TCP session
+     * (port 6555) and verifies:
+     * <ul>
+     *   <li>Both messages receive a simple ACK ({@code ACK|…}) on the
+     *       <em>same socket</em>, proving the channel was not closed between them
+     *       (session-level keep-alive is active).</li>
+     *   <li>The channel remains open after the second ACK.</li>
+     *   <li>Two independent S3 payloads and two SQS entries exist in the hold-flow
+     *       bucket and {@code test.fifo} queue respectively.</li>
+     * </ul>
+     *
+     * <h4>S3 / SQS assertion strategy</h4>
+     * <p>{@link IngestionAssertionHelper#assertHoldFlow} locates each S3 payload by
+     * <em>content match</em> and each SQS message by its {@code s3DataObjectPath},
+     * so the two assertions are independent of queue order.
+     */
+    @Test
+    @DisplayName("IT[TCP-6555]: keepAlive TCP — two TCP messages on one session — " +
+                 "both ACKed, channel stays open, S3+SQS asserted per message")
+    void tcp_shouldProcessTwoMessagesOnSingleSession_channelStaysOpen() throws Exception {
+        SoftAssertions softly = new SoftAssertions();
+
+        try (Socket socket = new Socket(TCP_HOST, TCP_SERVER_PORT)) {
+            // Socket read-timeout generous enough to span two round-trips + keep-alive gap
+            socket.setSoTimeout((KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000);
+
+            // ── Send HAProxy header once — shared by both messages on this session ──
+            socket.getOutputStream().write(
+                    buildProxyV1Header(CLIENT_IP, DEST_IP, TCP_CLIENT_PORT, TCP_DEST_PORT));
+            socket.getOutputStream().flush();
+
+            // ── Message 1: CCD XML payload ────────────────────────────────────────
+            socket.getOutputStream().write(wrapTcp(TCP_MSG1_CCD_XML));
+            socket.getOutputStream().flush();
+
+            byte[] ack1 = readTcpResponse(socket);
+
+            softly.assertThat(socket.isConnected())
+                    .as("SESSION_ID_KEY persists — socket must remain connected after TCP ACK-1")
+                    .isTrue();
+            softly.assertThat(socket.isClosed())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY active — server must NOT close channel after TCP message 1")
+                    .isFalse();
+            assertTcpAck(ack1, softly, "TCP Session-1 / Message-1 ACK");
+
+            // Brief pause so message 1 is fully committed to S3/SQS before message 2 arrives
+            Thread.sleep(500);
+
+            // ── Message 2: HL7- ADT A03 payload (same session, no new PROXY header) ─────
+            socket.getOutputStream().write(wrapTcp(TCP_MSG2_ADT_A03));
+            socket.getOutputStream().flush();
+
+            byte[] ack2 = readTcpResponse(socket);
+
+            softly.assertThat(socket.isConnected())
+                    .as("SESSION_ID_KEY persists — socket must remain connected after TCP ACK-2")
+                    .isTrue();
+            softly.assertThat(socket.isClosed())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY active — server must NOT close channel after TCP message 2")
+                    .isFalse();
+            assertTcpAck(ack2, softly, "TCP Session-1 / Message-2 ACK");
+
+            // SESSION_MESSAGE_COUNT_KEY = 2: same socket, two distinct non-empty ACKs
+            softly.assertThat(ack1).as("TCP ACK-1 must be non-empty (message count ≥ 1)").isNotEmpty();
+            softly.assertThat(ack2).as("TCP ACK-2 must be non-empty (message count = 2)").isNotEmpty();
+            softly.assertThat(ack1)
+                    .as("TCP ACK-1 and ACK-2 must be distinct (INTERACTION_ATTRIBUTE_KEY reset)")
+                    .isNotEqualTo(ack2);
+        }
+
+        // ── S3 + SQS: assert each TCP message independently by payload content ────
+        assertionHelper().assertHoldFlow(
+                tcpHoldFlowParams(TCP_MSG1_CCD_XML, "6555"), softly);
+
+        assertionHelper().assertHoldFlow(
+                tcpHoldFlowParams(TCP_MSG2_ADT_A03, "6555"), softly);
+
+        softly.assertAll();
+    }
+
+    // ── TCP Test 2 — One TCP message, channel survives default read-timeout ────
+
+    /**
+     * Sends one TCP-delimited message on port 6555 and verifies that the channel
+     * survives past the default read-timeout (10 s) but closes by the
+     * keepAliveTimeout (20 s).
+     *
+     * <h4>What is verified</h4>
+     * <ul>
+     *   <li>The ACK for the single message is received as a valid simple ACK.</li>
+     *   <li>Channel-attribute {@code KEEP_ALIVE_TIMEOUT_KEY=20} is active — proved by
+     *       confirming the socket is still open {@code DEFAULT_READ_TIMEOUT_S + 2 s}
+     *       after the ACK (i.e., past the point where {@code ReadTimeoutHandler} would
+     *       have fired).</li>
+     *   <li>The channel closes within {@code KEEP_ALIVE_TIMEOUT_S + GRACE_S} seconds
+     *       of the last data sent.</li>
+     *   <li>S3 hold-flow bucket and SQS queue each contain exactly one matching payload.</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("IT[TCP-6555]: keepAlive TCP — one TCP message — channel survives " +
+                 "readTimeout(10 s), closes at keepAliveTimeout(20 s)")
+    void tcp_shouldKeepChannelOpenAfterOneMessage_closesAtKeepAliveTimeout() throws Exception {
+        SoftAssertions softly = new SoftAssertions();
+        long testStart = System.currentTimeMillis();
+
+        try (Socket socket = new Socket(TCP_HOST, TCP_SERVER_PORT)) {
+            socket.setSoTimeout((KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000);
+
+            // ── Send PROXY header + single TCP message ────────────────────────────
+            socket.getOutputStream().write(
+                    buildProxyV1Header(CLIENT_IP, DEST_IP, TCP_CLIENT_PORT, TCP_DEST_PORT));
+            socket.getOutputStream().write(wrapTcp(TCP_MSG1_CCD_XML));
+            socket.getOutputStream().flush();
+
+            byte[] ack = readTcpResponse(socket);
+            assertTcpAck(ack, softly, "TCP single-message keepAlive ACK");
+
+            long afterAckMs = System.currentTimeMillis();
+
+            // Wait past the default read-timeout; if ReadTimeoutHandler were still
+            // installed the server would have closed the connection by now.
+            Thread.sleep((DEFAULT_READ_TIMEOUT_S + 2) * 1_000L);
+
+            softly.assertThat(socket.isConnected())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY active — TCP socket must still be connected " +
+                        (DEFAULT_READ_TIMEOUT_S + 2) + " s after ACK (past default read-timeout)")
+                    .isTrue();
+
+            // Poll for EOF — the IdleStateHandler should fire at ~KAT seconds
+            long elapsedSinceLastData = (System.currentTimeMillis() - afterAckMs) / 1_000;
+            long remainingBudgetMs = Math.max(1_000L,
+                    (KEEP_ALIVE_TIMEOUT_S - elapsedSinceLastData + GRACE_S) * 1_000L);
+            socket.setSoTimeout((int) remainingBudgetMs);
+
+            boolean channelClosed = waitForChannelClose(socket);
+            long totalElapsedMs   = System.currentTimeMillis() - testStart;
+
+            softly.assertThat(channelClosed)
+                    .as("IdleStateHandler(20 s) must close the TCP channel after keepAliveTimeout")
+                    .isTrue();
+            softly.assertThat(totalElapsedMs)
+                    .as("TCP channel must close within keepAliveTimeout(%d s) + grace(%d s)",
+                            KEEP_ALIVE_TIMEOUT_S, GRACE_S)
+                    .isLessThan((long) (KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000L);
+            softly.assertThat(totalElapsedMs)
+                    .as("TCP channel must NOT close before default readTimeout(%d s)",
+                            DEFAULT_READ_TIMEOUT_S)
+                    .isGreaterThan((long) DEFAULT_READ_TIMEOUT_S * 1_000L);
+        }
+
+        assertionHelper().assertHoldFlow(
+                tcpHoldFlowParams(TCP_MSG1_CCD_XML, "6555"), softly);
+
+        softly.assertAll();
+    }
+
+    // ── TCP Test 3 — No TCP message sent, channel closes at keepAliveTimeout ──
+
+    /**
+     * Opens a connection to the TCP port (6555) and sends only the HAProxy header —
+     * no payload.
+     *
+     * <h4>What is verified</h4>
+     * <ul>
+     *   <li>{@code KEEP_ALIVE_TIMEOUT_KEY=20} is resolved from the HAProxy header's
+     *       {@code destPort=6555} before any message arrives — proved by confirming
+     *       the socket is still open {@code DEFAULT_READ_TIMEOUT_S + 2 s} after the
+     *       PROXY header.</li>
+     *   <li>The channel closes within {@code KEEP_ALIVE_TIMEOUT_S + GRACE_S} seconds
+     *       (idle handler fires because no message ever arrives).</li>
+     *   <li>S3 hold bucket remains empty — no message was ingested.</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("IT[TCP-6555]: keepAlive TCP — no message sent — channel survives " +
+                 "readTimeout(10 s), closes at keepAliveTimeout(20 s)")
+    void tcp_shouldKeepChannelOpenWhenNoMessageSent_closesAtKeepAliveTimeout() throws Exception {
+        SoftAssertions softly = new SoftAssertions();
+        long testStart = System.currentTimeMillis();
+
+        try (Socket socket = new Socket(TCP_HOST, TCP_SERVER_PORT)) {
+            socket.setSoTimeout((KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000);
+
+            // ── Send ONLY the HAProxy header — no TCP payload ─────────────────────
+            socket.getOutputStream().write(
+                    buildProxyV1Header(CLIENT_IP, DEST_IP, TCP_CLIENT_PORT, TCP_DEST_PORT));
+            socket.getOutputStream().flush();
+
+            // Assert still open after DEFAULT_READ_TIMEOUT_S + 2 s
+            Thread.sleep((DEFAULT_READ_TIMEOUT_S + 2) * 1_000L);
+
+            softly.assertThat(socket.isConnected())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY resolved from PROXY destPort=%d — " +
+                        "TCP channel must survive past default readTimeout=%d s",
+                        TCP_DEST_PORT, DEFAULT_READ_TIMEOUT_S)
+                    .isTrue();
+
+            boolean channelClosed = waitForChannelClose(socket);
+            long totalElapsedMs   = System.currentTimeMillis() - testStart;
+
+            softly.assertThat(channelClosed)
+                    .as("IdleStateHandler(20 s) must eventually close the TCP channel")
+                    .isTrue();
+            softly.assertThat(totalElapsedMs)
+                    .as("TCP channel must close within keepAliveTimeout(%d s) + grace(%d s)",
+                            KEEP_ALIVE_TIMEOUT_S, GRACE_S)
+                    .isLessThan((long) (KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000L);
+            softly.assertThat(totalElapsedMs)
+                    .as("TCP channel must NOT close before default readTimeout(%d s)",
+                            DEFAULT_READ_TIMEOUT_S)
+                    .isGreaterThan((long) DEFAULT_READ_TIMEOUT_S * 1_000L);
+        }
+
+        softly.assertThat(assertionHelper().bucketIsEmpty(HOLD_BUCKET))
+                .as("HOLD_BUCKET must be empty — no TCP message was delivered")
+                .isTrue();
+
+        softly.assertAll();
+    }
+
+    // =========================================================================
+    // FlowAssertionParams factories
+    // =========================================================================
+
+
+    /**
+     * Builds hold-flow assertion params for the raw-TCP port 6555 / {@code test.fifo}.
+     *
+     * @param payload   raw TCP payload that was sent (pre-delimiter-wrap)
+     * @param groupId   expected SQS {@code messageGroupId}
+     */
+    private FlowAssertionParams tcpHoldFlowParams(String payload, String groupId) {
+        return FlowAssertionParams.builder()
+                .dataBucket(HOLD_BUCKET)
+                .metadataBucket(null)
+                .holdFlow(true)
+                .port(TCP_DEST_PORT)
+                .dataDir("/outbound")
+                .metadataDir("/outbound")
+                .tenantId(null)
+                .queueUrl(queueUrls.get("test.fifo"))
+                .expectedMessageGroupId(groupId)
+                .expectedPayload(payload)
+                .payloadNormalizer(IngestionAssertionHelper::normalizeGeneric)
+                .ackExpected(false)   // TCP simple-ACK is not stored as a separate S3 object
+                .build();
+    }
+
+   
+    // =========================================================================
+    // TCP ACK assertion helpers
+    // =========================================================================
+
+    /**
+     * Asserts that {@code rawAck} is a valid simple TCP ACK.
+     * The server produces {@code ACK|<interactionId>|<version>|<timestamp>}.
+     */
+    private void assertTcpAck(byte[] rawAck, SoftAssertions softly, String label) {
+        softly.assertThat(rawAck)
+                .as(label + ": raw TCP ACK bytes must not be empty")
+                .isNotEmpty();
+        if (rawAck == null || rawAck.length == 0) return;
+
+        String ackStr = new String(rawAck, StandardCharsets.UTF_8).trim();
+        softly.assertThat(ackStr)
+                .as(label + ": TCP ACK must start with 'ACK|'")
+                .startsWith("ACK|");
+    }
+
+    // =========================================================================
+    // TCP / MLLP / PROXY low-level helpers
+    // =========================================================================
+
+    /** Builds a HAProxy PROXY protocol v1 text header. */
+    private static byte[] buildProxyV1Header(String clientIp, String destIp,
+            int clientPort, int destPort) {
+        return String.format("PROXY TCP4 %s %s %d %d\r\n",
+                        clientIp, destIp, clientPort, destPort)
+                .getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Wraps {@code message} in TCP delimiter framing:
+     * {@code <STX>(0x02) payload <ETX>(0x03)<LF>(0x0A)}.
+     */
+    private static byte[] wrapTcp(String message) {
+        byte[] payload = message.getBytes(StandardCharsets.UTF_8);
+        byte[] framed  = new byte[1 + payload.length + 2];
+        framed[0] = TCP_START;
+        System.arraycopy(payload, 0, framed, 1, payload.length);
+        framed[framed.length - 2] = TCP_END_1;
+        framed[framed.length - 1] = TCP_END_2;
+        return framed;
+    }
+
+    /**
+     * Reads bytes from {@code socket} until a newline ({@code 0x0A}) is received,
+     * which marks the end of a simple TCP ACK/NACK response.
+     */
+    private static byte[] readTcpResponse(Socket socket) throws Exception {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        int b;
+        while ((b = socket.getInputStream().read()) != -1) {
+            buf.write(b);
+            if (b == '\n') break;
+        }
+        return buf.toByteArray();
+    }
+
+    /**
+     * Blocks until the server closes the connection (EOF) or the socket read-timeout fires.
+     *
+     * @return {@code true} if EOF was received (clean server-side close);
+     *         {@code false} if the socket timed out before EOF.
+     */
+    private static boolean waitForChannelClose(Socket socket) {
+        try {
+            return socket.getInputStream().read() == -1;
+        } catch (java.net.SocketTimeoutException e) {
+            return false;
+        } catch (Exception e) {
+            return true; // connection-reset or similar counts as closed
+        }
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/tcp/mllp/NettyMllpServerKeepAliveITCase.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/tcp/mllp/NettyMllpServerKeepAliveITCase.java
@@ -1,0 +1,455 @@
+package org.techbd.ingest.integrationtests.tcp.mllp;
+
+import static org.techbd.ingest.integrationtests.util.NettyTcpServerKeepAliveFixtures.GROUP_ID_HL7_MSG1;
+import static org.techbd.ingest.integrationtests.util.NettyTcpServerKeepAliveFixtures.GROUP_ID_HL7_MSG2;
+import static org.techbd.ingest.integrationtests.util.NettyTcpServerKeepAliveFixtures.HL7_MSG1_ORU;
+import static org.techbd.ingest.integrationtests.util.NettyTcpServerKeepAliveFixtures.HL7_MSG2_ADT_A01;
+
+import java.io.ByteArrayOutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.techbd.ingest.integrationtests.base.BaseIntegrationTest;
+import org.techbd.ingest.integrationtests.base.IngestionAssertionHelper;
+import org.techbd.ingest.integrationtests.base.IngestionAssertionHelper.FlowAssertionParams;
+
+/**
+ * Integration tests for <b>persistent (keep-alive) TCP connections</b>.
+ *
+ * <p>Port under test:</p>
+ *
+ * <h3>Port 5555 — MLLP / outbound-response (keep-alive)</h3>
+ * <pre>{@code
+ * {
+ *   "port": 5555,
+ *   "responseType": "outbound",
+ *   "protocol": "TCP",
+ *   "route": "/hold",
+ *   "dataDir": "/outbound",
+ *   "metadataDir": "/outbound",
+ *   "queue": "test.fifo",
+ *   "keepAliveTimeout": 20
+ * }
+ * }</pre>
+ *
+ *
+ * <h3>Keep-alive behaviour (from NettyTcpServer)</h3>
+ * <ul>
+ *   <li>When the server resolves a {@code keepAliveTimeout > 0} for the destination
+ *       port it replaces the default {@link io.netty.handler.timeout.ReadTimeoutHandler}
+ *       with an {@link io.netty.handler.timeout.IdleStateHandler IdleStateHandler}.</li>
+ *   <li>After flushing each ACK/response the channel is <em>kept open</em>; per-message
+ *       attributes ({@code INTERACTION_ATTRIBUTE_KEY}, {@code FRAGMENT_COUNT_KEY}, etc.)
+ *       are reset, while session attributes ({@code SESSION_ID_KEY},
+ *       {@code SESSION_MESSAGE_COUNT_KEY}) are preserved across messages.</li>
+ *   <li>The channel is closed only when the idle reader fires or on error.</li>
+ * </ul>
+ *
+ * <h3>MLLP test scenarios (port 5555)</h3>
+ * <ol>
+ *   <li><b>Two MLLP messages, one session</b> — send two HL7 messages on the same TCP
+ *       connection, verify two MLLP ACKs ({@code MSA|AA}), two S3+SQS payloads.</li>
+ *   <li><b>One MLLP message, channel survives read-timeout window</b> — send one message,
+ *       confirm the ACK arrives, then verify the channel is still open after the
+ *       default read-timeout (10 s) but closes around the keepAliveTimeout (20 s).</li>
+ *   <li><b>No MLLP message sent, channel closes at keepAliveTimeout</b> — open a
+ *       connection, send only the HAProxy header, and verify the server holds the
+ *       channel open past the default read-timeout (10 s) but closes it near the
+ *       keepAliveTimeout (20 s).</li>
+ * </ol>
+ *
+ * <h3>SQS deduplication note</h3>
+ * <p>The HL7 fixtures ({@link NettyTcpServerKeepAliveFixtures#HL7_MSG1_ORU} and
+ * {@link NettyTcpServerKeepAliveFixtures#HL7_MSG2_ADT_A01}) are intentionally
+ * content-distinct so that the SQS FIFO deduplication window (5 minutes) does not
+ * suppress the second message within each pair.
+ *
+ * @see NettyTcpServerKeepAliveFixtures  for shared fixture strings and group-ID constants
+ */
+class NettyMllpServerKeepAliveITCase extends BaseIntegrationTest {
+
+    // ── Network constants ────────────────────────────────────────────────────
+
+    /** Dispatcher port — HAProxy PROXY-protocol entry point. */
+    private static final int    TCP_SERVER_PORT = 7980;
+    private static final String TCP_HOST        = "localhost";
+
+    /**
+     * MLLP destination port in the HAProxy header.
+     * The server resolves the port-config for this port
+     * ({@code keepAliveTimeout=20, responseType=outbound, route=/hold, queue=test.fifo}).
+     */
+    private static final int MLLP_DEST_PORT = 5555;
+
+
+    private static final String CLIENT_IP        = "203.0.113.10";
+    private static final String DEST_IP          = "127.0.0.1";
+    private static final int    MLLP_CLIENT_PORT = 55100;
+
+    // ── Timeout constants (seconds) ──────────────────────────────────────────
+
+    /**
+     * Default server read-timeout — the channel must <em>not</em> close within
+     * this window when keepAlive is active.
+     */
+    private static final int DEFAULT_READ_TIMEOUT_S = 10;
+
+    /**
+     * keepAliveTimeout configured on both port 5555 and port 6555.
+     * The channel <em>must</em> close within this window when no subsequent
+     * message arrives.
+     */
+    private static final int KEEP_ALIVE_TIMEOUT_S = 20;
+
+    /**
+     * Grace margin (seconds) added when asserting an upper bound, to absorb
+     * scheduling jitter in CI environments.
+     */
+    private static final int GRACE_S = 5;
+
+    // ── MLLP framing ─────────────────────────────────────────────────────────
+
+    private static final byte MLLP_START = 0x0B;
+    private static final byte MLLP_END_1 = 0x1C;
+    private static final byte MLLP_END_2 = 0x0D;
+
+    // ── Setup ────────────────────────────────────────────────────────────────
+
+    @BeforeAll
+    static void initProfile() {
+        System.setProperty("SPRING_PROFILES_ACTIVE", "test");
+    }
+
+    // ── Helper factory ───────────────────────────────────────────────────────
+
+    private IngestionAssertionHelper assertionHelper() {
+        return new IngestionAssertionHelper(s3Client, sqsClient);
+    }
+
+    // =========================================================================
+    // MLLP TESTS — port 5555
+    // =========================================================================
+
+    // ── MLLP Test 1 — Two HL7 messages on one persistent MLLP session ─────────
+
+    /**
+     * Sends two content-distinct HL7 messages on a single MLLP TCP session and verifies:
+     * <ul>
+     *   <li>Both messages receive a valid MLLP ACK ({@code MSA|AA}) on the
+     *       <em>same socket</em>, proving the channel was not closed between them.</li>
+     *   <li>The channel remains open after the second ACK.</li>
+     *   <li>Two independent S3 payloads and two SQS entries exist in the hold-flow
+     *       bucket and {@code test.fifo} queue respectively.</li>
+     * </ul>
+     *
+     */
+    @Test
+    @DisplayName("IT[MLLP-5555]: keepAlive outbound — two HL7 messages on one MLLP session — " +
+                 "both ACKed (MSA|AA), channel stays open, S3+SQS asserted per message")
+    void mllp_shouldProcessTwoMessagesOnSingleSession_channelStaysOpen() throws Exception {
+        SoftAssertions softly = new SoftAssertions();
+
+        try (Socket socket = new Socket(TCP_HOST, TCP_SERVER_PORT)) {
+            socket.setSoTimeout((KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000);
+
+            // ── Send HAProxy header once — shared by both messages on this session ──
+            socket.getOutputStream().write(
+                    buildProxyV1Header(CLIENT_IP, DEST_IP, MLLP_CLIENT_PORT, MLLP_DEST_PORT));
+            socket.getOutputStream().flush();
+
+            // ── Message 1: ORU^R01 ────────────────────────────────────────────────
+            socket.getOutputStream().write(wrapMllp(HL7_MSG1_ORU));
+            socket.getOutputStream().flush();
+
+            byte[] ack1 = readMllpFrame(socket);
+
+            softly.assertThat(socket.isConnected())
+                    .as("SESSION_ID_KEY persists — socket must remain connected after MLLP ACK-1")
+                    .isTrue();
+            softly.assertThat(socket.isClosed())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY active — server must NOT close channel after MLLP message 1")
+                    .isFalse();
+            assertMllpAck(ack1, softly, "MLLP Session-1 / Message-1 ACK");
+
+            // Brief pause so message 1 is fully committed to S3/SQS before message 2 arrives
+            Thread.sleep(500);
+
+            // ── Message 2: ADT^A01 (same session, no new PROXY header) ────────────
+            socket.getOutputStream().write(wrapMllp(HL7_MSG2_ADT_A01));
+            socket.getOutputStream().flush();
+
+            byte[] ack2 = readMllpFrame(socket);
+
+            softly.assertThat(socket.isConnected())
+                    .as("SESSION_ID_KEY persists — socket must remain connected after MLLP ACK-2")
+                    .isTrue();
+            softly.assertThat(socket.isClosed())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY active — server must NOT close channel after MLLP message 2")
+                    .isFalse();
+            assertMllpAck(ack2, softly, "MLLP Session-1 / Message-2 ACK");
+
+            softly.assertThat(ack1).as("MLLP ACK-1 must be non-empty").isNotEmpty();
+            softly.assertThat(ack2).as("MLLP ACK-2 must be non-empty").isNotEmpty();
+            softly.assertThat(ack1)
+                    .as("MLLP ACK-1 and ACK-2 must be distinct (INTERACTION_ATTRIBUTE_KEY reset)")
+                    .isNotEqualTo(ack2);
+        }
+
+        // ── S3 + SQS: assert each MLLP message independently by payload content ──
+        assertionHelper().assertHoldFlow(
+                mllpHoldFlowParams(HL7_MSG1_ORU, GROUP_ID_HL7_MSG1), softly);
+
+        assertionHelper().assertHoldFlow(
+                mllpHoldFlowParams(HL7_MSG2_ADT_A01, GROUP_ID_HL7_MSG2), softly);
+
+        softly.assertAll();
+    }
+
+    // ── MLLP Test 2 — One MLLP message, channel survives default read-timeout ──
+
+    /**
+     * Sends one HL7 message on an MLLP session and verifies that the channel
+     * survives past the default read-timeout (10 s) but closes by the
+     * keepAliveTimeout (20 s).
+     *
+     * <h4>What is verified</h4>
+     * <ul>
+     *   <li>The ACK for the single message is received and is a valid {@code MSA|AA}.</li>
+     *   <li>Channel-attribute {@code KEEP_ALIVE_TIMEOUT_KEY=20} is active — proved by
+     *       confirming the socket is still open {@code DEFAULT_READ_TIMEOUT_S + 2 s}
+     *       after the ACK.</li>
+     *   <li>The channel closes within {@code KEEP_ALIVE_TIMEOUT_S + GRACE_S} seconds.</li>
+     *   <li>S3 hold-flow bucket and SQS queue each contain exactly one matching payload.</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("IT[MLLP-5555]: keepAlive outbound — one HL7 MLLP message — channel survives " +
+                 "readTimeout(10 s), closes at keepAliveTimeout(20 s)")
+    void mllp_shouldKeepChannelOpenAfterOneMessage_closesAtKeepAliveTimeout() throws Exception {
+        SoftAssertions softly = new SoftAssertions();
+        long testStart = System.currentTimeMillis();
+
+        try (Socket socket = new Socket(TCP_HOST, TCP_SERVER_PORT)) {
+            socket.setSoTimeout((KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000);
+
+            socket.getOutputStream().write(
+                    buildProxyV1Header(CLIENT_IP, DEST_IP, MLLP_CLIENT_PORT, MLLP_DEST_PORT));
+            socket.getOutputStream().write(wrapMllp(HL7_MSG1_ORU));
+            socket.getOutputStream().flush();
+
+            byte[] ack = readMllpFrame(socket);
+            assertMllpAck(ack, softly, "MLLP single-message keepAlive ACK");
+
+            long afterAckMs = System.currentTimeMillis();
+
+            // Wait past the default read-timeout; ReadTimeoutHandler would have closed by now
+            Thread.sleep((DEFAULT_READ_TIMEOUT_S + 2) * 1_000L);
+
+            softly.assertThat(socket.isConnected())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY active — MLLP socket must still be connected " +
+                        (DEFAULT_READ_TIMEOUT_S + 2) + " s after ACK (past default read-timeout)")
+                    .isTrue();
+
+            long elapsedSinceLastData = (System.currentTimeMillis() - afterAckMs) / 1_000;
+            long remainingBudgetMs = Math.max(1_000L,
+                    (KEEP_ALIVE_TIMEOUT_S - elapsedSinceLastData + GRACE_S) * 1_000L);
+            socket.setSoTimeout((int) remainingBudgetMs);
+
+            boolean channelClosed = waitForChannelClose(socket);
+            long totalElapsedMs   = System.currentTimeMillis() - testStart;
+
+            softly.assertThat(channelClosed)
+                    .as("IdleStateHandler(20 s) must close the MLLP channel after keepAliveTimeout")
+                    .isTrue();
+            softly.assertThat(totalElapsedMs)
+                    .as("MLLP channel must close within keepAliveTimeout(%d s) + grace(%d s)",
+                            KEEP_ALIVE_TIMEOUT_S, GRACE_S)
+                    .isLessThan((long) (KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000L);
+            softly.assertThat(totalElapsedMs)
+                    .as("MLLP channel must NOT close before default readTimeout(%d s)",
+                            DEFAULT_READ_TIMEOUT_S)
+                    .isGreaterThan((long) DEFAULT_READ_TIMEOUT_S * 1_000L);
+        }
+
+        assertionHelper().assertHoldFlow(
+                mllpHoldFlowParams(HL7_MSG1_ORU, GROUP_ID_HL7_MSG1), softly);
+
+        softly.assertAll();
+    }
+
+    // ── MLLP Test 3 — No MLLP message sent, channel closes at keepAliveTimeout ─
+
+    /**
+     * Opens a connection to the MLLP port and sends only the HAProxy header — no HL7 payload.
+     *
+     * <h4>What is verified</h4>
+     * <ul>
+     *   <li>{@code KEEP_ALIVE_TIMEOUT_KEY=20} is resolved from the HAProxy header's
+     *       {@code destPort=5555} before any HL7 message arrives — proved by confirming
+     *       the socket is still open {@code DEFAULT_READ_TIMEOUT_S + 2 s} after the
+     *       PROXY header.</li>
+     *   <li>The channel closes within {@code KEEP_ALIVE_TIMEOUT_S + GRACE_S} seconds.</li>
+     *   <li>S3 hold bucket remains empty — no message was ingested.</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("IT[MLLP-5555]: keepAlive outbound — no MLLP message sent — channel survives " +
+                 "readTimeout(10 s), closes at keepAliveTimeout(20 s)")
+    void mllp_shouldKeepChannelOpenWhenNoMessageSent_closesAtKeepAliveTimeout() throws Exception {
+        SoftAssertions softly = new SoftAssertions();
+        long testStart = System.currentTimeMillis();
+
+        try (Socket socket = new Socket(TCP_HOST, TCP_SERVER_PORT)) {
+            socket.setSoTimeout((KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000);
+
+            // ── Send ONLY the HAProxy header — no HL7 payload ─────────────────────
+            socket.getOutputStream().write(
+                    buildProxyV1Header(CLIENT_IP, DEST_IP, MLLP_CLIENT_PORT, MLLP_DEST_PORT));
+            socket.getOutputStream().flush();
+
+            Thread.sleep((DEFAULT_READ_TIMEOUT_S + 2) * 1_000L);
+
+            softly.assertThat(socket.isConnected())
+                    .as("KEEP_ALIVE_TIMEOUT_KEY resolved from PROXY destPort=%d — " +
+                        "MLLP channel must survive past default readTimeout=%d s",
+                        MLLP_DEST_PORT, DEFAULT_READ_TIMEOUT_S)
+                    .isTrue();
+
+            boolean channelClosed = waitForChannelClose(socket);
+            long totalElapsedMs   = System.currentTimeMillis() - testStart;
+
+            softly.assertThat(channelClosed)
+                    .as("IdleStateHandler(20 s) must eventually close the MLLP channel")
+                    .isTrue();
+            softly.assertThat(totalElapsedMs)
+                    .as("MLLP channel must close within keepAliveTimeout(%d s) + grace(%d s)",
+                            KEEP_ALIVE_TIMEOUT_S, GRACE_S)
+                    .isLessThan((long) (KEEP_ALIVE_TIMEOUT_S + GRACE_S) * 1_000L);
+            softly.assertThat(totalElapsedMs)
+                    .as("MLLP channel must NOT close before default readTimeout(%d s)",
+                            DEFAULT_READ_TIMEOUT_S)
+                    .isGreaterThan((long) DEFAULT_READ_TIMEOUT_S * 1_000L);
+        }
+
+        softly.assertThat(assertionHelper().bucketIsEmpty(HOLD_BUCKET))
+                .as("HOLD_BUCKET must be empty — no HL7 message was delivered via MLLP")
+                .isTrue();
+
+        softly.assertAll();
+    }
+
+    // =========================================================================
+    // FlowAssertionParams factories
+    // =========================================================================
+
+    /**
+     * Builds hold-flow assertion params for the MLLP port 5555 / {@code test.fifo}.
+     *
+     * @param payload   raw HL7 payload that was sent (pre-MLLP-wrap)
+     * @param groupId   expected SQS {@code messageGroupId}
+     */
+    private FlowAssertionParams mllpHoldFlowParams(String payload, String groupId) {
+        return FlowAssertionParams.builder()
+                .dataBucket(HOLD_BUCKET)
+                .metadataBucket(null)
+                .holdFlow(true)
+                .port(MLLP_DEST_PORT)
+                .dataDir("/outbound")
+                .metadataDir("/outbound")
+                .tenantId(null)
+                .queueUrl(queueUrls.get("test.fifo"))
+                .expectedMessageGroupId(groupId)
+                .expectedPayload(payload)
+                .payloadNormalizer(IngestionAssertionHelper::normalizeHl7)
+                .ackExpected(true)
+                .build();
+    }
+    // =========================================================================
+    // MLLP ACK assertion helpers
+    // =========================================================================
+
+    /**
+     * Asserts that {@code rawAck} is a valid MLLP-wrapped HL7 ACK ({@code MSA|AA}).
+     */
+    private void assertMllpAck(byte[] rawAck, SoftAssertions softly, String label) {
+        softly.assertThat(rawAck)
+                .as(label + ": raw MLLP ACK bytes must not be empty")
+                .isNotEmpty();
+        if (rawAck == null || rawAck.length == 0) return;
+
+        String ackStr = stripMllpFraming(rawAck);
+        softly.assertThat(ackStr).as(label + ": must contain MSH segment").contains("MSH");
+        softly.assertThat(ackStr).as(label + ": must contain MSA segment").contains("MSA");
+        softly.assertThat(ackStr).as(label + ": acknowledgement code must be AA").contains("MSA|AA");
+    }
+
+    // =========================================================================
+    // TCP / MLLP / PROXY low-level helpers
+    // =========================================================================
+
+    /** Builds a HAProxy PROXY protocol v1 text header. */
+    private static byte[] buildProxyV1Header(String clientIp, String destIp,
+            int clientPort, int destPort) {
+        return String.format("PROXY TCP4 %s %s %d %d\r\n",
+                        clientIp, destIp, clientPort, destPort)
+                .getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Wraps {@code hl7Text} in MLLP framing:
+     * {@code <VT>(0x0B) payload <FS>(0x1C)<CR>(0x0D)}.
+     */
+    private static byte[] wrapMllp(String hl7Text) {
+        byte[] payload = hl7Text.getBytes(StandardCharsets.UTF_8);
+        byte[] framed  = new byte[1 + payload.length + 2];
+        framed[0] = MLLP_START;
+        System.arraycopy(payload, 0, framed, 1, payload.length);
+        framed[framed.length - 2] = MLLP_END_1;
+        framed[framed.length - 1] = MLLP_END_2;
+        return framed;
+    }
+
+    /**
+     * Reads bytes from {@code socket} until the MLLP end-of-frame marker
+     * ({@code 0x1C 0x0D}) is detected or the socket times out.
+     */
+    private static byte[] readMllpFrame(Socket socket) throws Exception {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        int b;
+        while ((b = socket.getInputStream().read()) != -1) {
+            buf.write(b);
+            byte[] soFar = buf.toByteArray();
+            int    len   = soFar.length;
+            if (len >= 2 && soFar[len - 2] == MLLP_END_1 && soFar[len - 1] == MLLP_END_2) break;
+        }
+        return buf.toByteArray();
+    }
+
+    /**
+     * Blocks until the server closes the connection (EOF) or the socket read-timeout fires.
+     *
+     * @return {@code true} if EOF was received (clean server-side close);
+     *         {@code false} if the socket timed out before EOF.
+     */
+    private static boolean waitForChannelClose(Socket socket) {
+        try {
+            return socket.getInputStream().read() == -1;
+        } catch (java.net.SocketTimeoutException e) {
+            return false;
+        } catch (Exception e) {
+            return true; // connection-reset or similar counts as closed
+        }
+    }
+
+    /** Removes MLLP framing bytes to produce a readable string. */
+    private static String stripMllpFraming(byte[] raw) {
+        return new String(raw, StandardCharsets.UTF_8)
+                .replace(String.valueOf((char) MLLP_START), "")
+                .replace(String.valueOf((char) MLLP_END_1), "")
+                .replace(String.valueOf((char) MLLP_END_2), "");
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/util/NettyTcpServerKeepAliveFixtures.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/util/NettyTcpServerKeepAliveFixtures.java
@@ -1,0 +1,223 @@
+package org.techbd.ingest.integrationtests.util;
+
+/**
+ * Shared HL7 and CCD fixture strings for TCP keep-alive integration tests.
+ *
+ * <h3>Design rationale</h3>
+ * <p>Both {@link NettyTcpServerKeepAliveITCase} (HL7 MLLP / port 5555) and
+ * {@link NettyTcpServerTcpKeepAliveITCase} (raw TCP / port 6555) need distinct,
+ * content-rich payloads so that SQS FIFO deduplication (5-minute window, keyed on
+ * message content hash) does not silently suppress a second message that is identical
+ * to the first.  Centralising fixtures here keeps both test classes lean and makes
+ * the payload intent visible in one place.
+ *
+ * <h3>SQS FIFO deduplication note</h3>
+ * <p>SQS FIFO queues deduplicate within a 5-minute window using a
+ * {@code MessageDeduplicationId} that the server derives from the message content.
+ * If two messages carry identical bytes the second is silently discarded.  These
+ * fixtures are intentionally different in both content and message type to avoid
+ * that collision.
+ *
+ */
+public final class NettyTcpServerKeepAliveFixtures {
+
+    private NettyTcpServerKeepAliveFixtures() { /* utility class */ }
+
+    // =========================================================================
+    // HL7 fixtures  — used by NettyTcpServerKeepAliveITCase (port 5555, MLLP)
+    // =========================================================================
+
+    /**
+     * HL7 message 1: ORU^R01 from GHC.
+     *
+     * <p>ZNT segment: {@code ZNT||ORU|R01|PBRD|||...|healthelink:GHC|...}
+     * <br>Expected SQS {@code messageGroupId}: {@code "healthelink_GHC_ORU_PBRD"}
+     * (derived as {@code GHC_ORU_PBRD} from ZNT-8 suffix, ZNT-2, ZNT-4).
+     */
+    public static final String HL7_MSG1_ORU = """
+            MSH|^~\\&||GHC|||||ORU^R01|||2.5|
+            PID||5003637762^^^HEALTHELINK:FACID^MRN|5003637762^^^HEALTHELINK:FACID^MRN ||Cheng^Agnes^Brenda||19700908|F|Cheng^Agnes^^|9|3695 First Court^^Larchmont^KY^23302^USA^^^DOUGLAS||282-839-3300^P^PH||ENG|SINGLE|12|5433165929|185-10-7482|||||||||||N
+            PV1||O|||||C1^Smith^Sid^^^^^^GHC|||||||EO|||||GHC_V1|||||||||||||||||||||||||20111022094500|20111022094500|
+            ORC||GHC-P1|GHC-F1||||^^^201110100910||201110100912|||C1^Smith^Sid^^^^^^GHC|GHC||||||||GHC||||||||LAB|
+            OBR||GHC-P1|GHC-F1|RGL^Random Glucose^L|||201110101214|||||||201110100937||C1^Smith^Sid^^^^^^GHC||||||201110101227|||F|
+            OBX||NM|GLU^GLUCOSE||12.3|mmol/l|70-99||||F|||201110101214|
+            ZNT||ORU|R01|PBRD|||C10^SMITH^JOHN^EGSMC^ATT~SMITHJ^SMITH^JOHN^CHG^CON|healthelink:GHC|55003637762^healthelink:EGSMC~64654645^healthelink:CHG|68cc652a10ae317aef21b255||
+            """.replace("\n", "\r");
+
+    /**
+     * HL7 message 2: ADT^A01 from EPIC/EGSMC.
+     *
+     * <p>Structurally and content-different from {@link #HL7_MSG1_ORU}, which
+     * guarantees the SQS FIFO deduplication window does not suppress it.
+     * <br>ZNT segment: {@code ZNT||ADT|A01|SN_ADT|||...|healthelink:EGSMC|...}
+     * <br>Expected SQS {@code messageGroupId}: {@code "healthelink_EGSMC_ADT_SN_ADT"}.
+     */
+    public static final String HL7_MSG2_ADT_A01 = """
+            MSH|^~\\&|EPIC|EGSMC|||||ADT^A01|||2.3.1
+            EVN||20160102133621|||167489^Zampitello^Liza|20160102133621
+            PID||5003637762^^^HEALTHELINK:FACID^MRN|5003637762^^^HEALTHELINK:FACID^MRN ||Cheng^Agnes^Brenda||19700908|F|Cheng^Agnes^^|9|3695 First Court^^Larchmont^KY^23302^USA^^^DOUGLAS||282-839-3300^P^PH||ENG|SINGLE|12|5433165929|185-10-7482|||||||||||N
+            CON|1||||||||||||A|20240603140500|20260603140500|
+            PD1||||145425^Ingersol^Angela
+            NK1|1|Xavier^Richard^^|Mother|8953 Franklin Blvd^^Tampa^TN^10864^USA|750-923-5821||Emergency Contact 1
+            NK1|2|Xavier^Richard^^|Mother|8953 Franklin Blvd^^Tampa^TN^10864^USA|750-923-5821||Mother
+            PV1||103|ED^^^EGSMC^^^^^^^|ER||| C10^Smith^John^^^^^^EGSMC|||1|||||||||5363788347|||||||||||||||||||||||||20160102133600
+            GT1|1|153620341|DeSantis^Stuart^M^||4749 Maple Drive^^Chicago^NC^37789^USA^^^BOULDER|668-202-3982||19890718|F|P/F|MOT|181-48-1624||||Globagy.com|^^^^^USA|||None
+            IN1||5200324231|5190155816|KwalSonics Partners|||||||||||1|Cheng^Agnes^Brenda^|Self|19700908|3695 First Court^^Larchmont^KY^23302^USA^^^DOUGLAS|||1***1|||YES||||||||||1484851|148112259||||||STUDENT|F|^^^^^USA|||BOTH
+            ZNT||ADT|A01|SN_ADT|ClinicianGroupSN|CohortGroupSN_Name^CohortGroup_SN_Description||healthelink:EGSMC|5003637762^healthelink:EGSMC~64654645^healthelink:CHG|68cc652a10ae317aef21b255||
+            """.replace("\n", "\r");
+
+    // =========================================================================
+    // TCP fixtures  — used by NettyTcpServerTcpKeepAliveITCase (port 6555, raw TCP)
+    // =========================================================================
+
+    /**
+     * TCP message 1: CCD (Continuity of Care Document) — HL7 CDA / XML format.
+     *
+     * <p>Sent over the raw-TCP port 6555 ({@code responseType=tcp}).  The server
+     * stores this under the hold-flow bucket and enqueues to {@code test.fifo}.
+     * <br>Expected SQS {@code messageGroupId}: {@code "6555"} (port number, since
+     * the TCP port-config does not specify a ZNT-based group).
+     *
+     * <p>The document describes patient John Doe (DOB 1980-01-15) with a diagnosis
+     * of Hypertension, authored on 2026-04-24.
+     */
+    public static final String TCP_MSG1_CCD_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ClinicalDocument xmlns="urn:hl7-org:v3"
+                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+                <!-- Header -->
+                <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+
+                <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+
+                <id root="2.16.840.1.113883.19.5.99999.1"
+                    extension="CCD-12345"/>
+                <code code="34133-9"
+                      codeSystem="2.16.840.1.113883.6.1"
+                      displayName="Summarization of Episode Note"/>
+                <title>Continuity of Care Document</title>
+                <effectiveTime value="20260424120000"/>
+                <recordTarget>
+                    <patientRole>
+                        <id extension="123456" root="2.16.840.1.113883.4.1"/>
+                        <patient>
+                            <name>
+                                <given>John</given>
+                                <family>Doe</family>
+                            </name>
+                            <administrativeGenderCode code="M"/>
+                            <birthTime value="19800115"/>
+                        </patient>
+                    </patientRole>
+                </recordTarget>
+                <author>
+                    <time value="20260424120000"/>
+                    <assignedAuthor>
+                        <id extension="PROV001"/>
+                        <assignedPerson>
+                            <name>
+                                <given>Jane</given>
+                                <family>Smith</family>
+                            </name>
+                        </assignedPerson>
+                    </assignedAuthor>
+                </author>
+                <!-- Body -->
+                <component>
+                    <structuredBody>
+                        <!-- Problems Section -->
+                        <component>
+                            <section>
+                                <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                                <code code="11450-4"
+                                      codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="Problem List"/>
+                                <title>Problems</title>
+                                <text>
+                                    Hypertension
+                                </text>
+                                <entry>
+                                    <act classCode="ACT" moodCode="EVN">
+                                        <entryRelationship typeCode="SUBJ">
+                                            <observation classCode="OBS" moodCode="EVN">
+                                                <code code="75326-9"
+                                                      displayName="Problem"/>
+                                                <value xsi:type="CD"
+                                                       code="38341003"
+                                                       codeSystem="2.16.840.1.113883.6.96"
+                                                       displayName="Hypertension"/>
+                                            </observation>
+                                        </entryRelationship>
+                                    </act>
+                                </entry>
+                            </section>
+                        </component>
+                        <!-- Medications Section -->
+                        <component>
+                            <section>
+                                <code code="10160-0"
+                                      codeSystem="2.16.840.1.113883.6.1"
+                                      displayName="History of Medication Use"/>
+                                <title>Medications</title>
+                                <text>
+                                    Lisinopril 10mg daily
+                                </text>
+                            </section>
+                        </component>
+                    </structuredBody>
+                </component>
+            </ClinicalDocument>
+            """;
+
+    /**
+     * TCP message 2: ADT^A03 (discharge) from EPIC/EGSMC — HL7 v2.3.1 pipe-delimited.
+     *
+     * <p>Content-distinct from {@link #TCP_MSG1_CCD_XML} (different format, different
+     * message type, different patient encounter details) — SQS FIFO deduplication
+     * will not suppress it.
+     * <br>ZNT segment: {@code ZNT||ADT|A03|PBAC|||...|healthelink:EGSMC|...}
+     * <br>Expected SQS {@code messageGroupId}: {@code "6555"} (port number).
+     */
+    public static final String TCP_MSG2_ADT_A03 = """
+            MSH|^~\\&|EPIC|EGSMC|||||ADT^A03|||2.3.1
+            EVN||20160102133621|||167489^Zampitello^Liza|20160102133621
+            PID||5003637762^^^HEALTHELINK:FACID^MRN|5003637762^^^HEALTHELINK:FACID^MRN ||Cheng^Agnes^Brenda||19700908|F|Cheng^Agnes^^|9|3695 First Court^^Larchmont^KY^23302^USA^^^DOUGLAS||282-839-3300^P^PH||ENG|SINGLE|12|5433165929|185-10-7482|||||||||||N
+            CON|1||||||||||||A|20240603140500|20260603140500|
+            PD1||||145425^Ingersol^Angela
+            NK1|1|Xavier^Richard^^|Mother|8953 Franklin Blvd^^Tampa^TN^10864^USA|750-923-5821||Emergency Contact 1
+            NK1|2|Xavier^Richard^^|Mother|8953 Franklin Blvd^^Tampa^TN^10864^USA|750-923-5821||Mother
+            PV1||103|ED^^^EGSMC^^^^^^^|ER||| C10^Smith^John^^^^^^EGSMC|||1|||||||||5363788347|||||||||||||||||||||||||20160102133600|20160108133600
+            GT1|1|153620341|DeSantis^Stuart^M^||4749 Maple Drive^^Chicago^NC^37789^USA^^^BOULDER|668-202-3982||19890718|F|P/F|MOT|181-48-1624||||Globagy.com|^^^^^USA|||None
+            IN1||5200324231|5190155816|KwalSonics Partners|||||||||||1|Cheng^Agnes^Brenda^|Self|19700908|3695 First Court^^Larchmont^KY^23302^USA^^^DOUGLAS|||1***1|||YES||||||||||1484851|148112259||||||STUDENT|F|^^^^^USA|||BOTH
+            ZNT||ADT|A03|PBAC|||C10^SMITH^JOHN^EGSMC^ATT~SMITHJ^SMITH^JOHN^CHG^CON|healthelink:EGSMC|5003637762^healthelink:EGSMC~64654645^healthelink:CHG|68cc652a10ae317aef21b255||
+            """.replace("\n", "\r");
+
+    // =========================================================================
+    // Expected SQS messageGroupId constants
+    // =========================================================================
+
+    /**
+     * Expected {@code messageGroupId} for {@link #HL7_MSG1_ORU}.
+     *
+     * <p>Derived from ZNT-8 ({@code healthelink:GHC} → org=GHC),
+     * ZNT-2 ({@code ORU}), ZNT-4 ({@code PBRD}).
+     */
+    public static final String GROUP_ID_HL7_MSG1 = "healthelink_GHC_ORU_PBRD";
+
+    /**
+     * Expected {@code messageGroupId} for {@link #HL7_MSG2_ADT_A01}.
+     *
+     * <p>Derived from ZNT-8 ({@code healthelink:EGSMC} → org=EGSMC),
+     * ZNT-2 ({@code ADT}), ZNT-4 ({@code SN_ADT}).
+     */
+    public static final String GROUP_ID_HL7_MSG2 = "healthelink_EGSMC_ADT_SN_ADT";
+
+    /**
+     * Expected {@code messageGroupId} for both TCP messages (port 6555).
+     *
+     * <p>The TCP port-config ({@code responseType=tcp}) does not perform ZNT-based
+     * group-ID derivation; the server uses the destination port number instead.
+     */
+    public static final String GROUP_ID_TCP = "6555";
+}


### PR DESCRIPTION
- Persistent connections and multi-message processing on a single socket
- Channel survival past default read-timeout and closure at keep-alive timeout
- Idle HAProxy-header-only connections honoring keep-alive timeout behavior
- S3 payload persistence and SQS delivery assertions for message-processing flows