### PR TITLE
feat(soap): add MTOM response strategies for responseType mtom and mtom_trubridge #3068

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/commons/Constants.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/commons/Constants.java
@@ -57,4 +57,5 @@ public class Constants {
     public static final String RAW_MULTIPART_BODY = "rawMultipartBody";
     public static final String NO_ACK_EXPECTED = "NO_ACK_EXPECTED";
     public static final String ORIGINAL_REQUEST_URL = "x-techbd-original-uri";
+    public static final String RESPONSE_TYPE = "RESPONSE_TYPE";
 }

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/WebServiceConfig.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/config/WebServiceConfig.java
@@ -28,6 +28,7 @@ import org.springframework.xml.xsd.XsdSchema;
 import org.techbd.ingest.commons.Constants;
 import org.techbd.ingest.interceptors.WsaHeaderInterceptor;
 import org.techbd.ingest.service.MessageProcessorService;
+import org.techbd.ingest.service.soap.SoapResponseStrategyFactory;
 import org.techbd.ingest.util.AppLogger;
 import org.techbd.ingest.util.SoapResponseUtil;
 
@@ -45,17 +46,20 @@ public class WebServiceConfig extends WsConfigurationSupport {
     private final MessageProcessorService messageProcessorService;
     private final AppConfig appConfig;
     private final AppLogger LOG;
+    private final SoapResponseStrategyFactory strategyFactory;
 
-    public WebServiceConfig(SoapResponseUtil soapResponseUtil, MessageProcessorService messageProcessorService, AppConfig appConfig, AppLogger appLogger) {
+    public WebServiceConfig(SoapResponseUtil soapResponseUtil, MessageProcessorService messageProcessorService, 
+        AppConfig appConfig, AppLogger appLogger, SoapResponseStrategyFactory strategyFactory) {
         this.soapResponseUtil = soapResponseUtil;
         this.messageProcessorService = messageProcessorService;
         this.appConfig = appConfig;
         this.LOG = appLogger;
+        this.strategyFactory = strategyFactory;
     }
 
     @Override
     protected void addInterceptors(List<EndpointInterceptor> interceptors) {
-        interceptors.add(new WsaHeaderInterceptor(soapResponseUtil, messageProcessorService, appConfig,LOG));
+        interceptors.add(new WsaHeaderInterceptor(soapResponseUtil, messageProcessorService, appConfig,LOG,strategyFactory));
     }
    
     /**

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/DataIngestionController.java
@@ -169,7 +169,7 @@ public class DataIngestionController extends AbstractMessageSourceProvider {
         if (resolvedBody != null && !resolvedBody.isBlank() && isSoapReq) {
             LOG.info("SOAP forwarding to /ws endpoint sourceId={} msgType={} interactionId={}",
                     sourceId, msgType, interactionId);
-            return forwarder.forward(request, resolvedBody, sourceId, msgType, interactionId);
+            return forwarder.forward(request, response, resolvedBody, sourceId, msgType, interactionId);
         }
 
         Map<String, String> result = Optional.ofNullable(file)

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
@@ -210,14 +210,24 @@ public class InteractionsFilter extends OncePerRequestFilter {
                 String mtlsName = portEntry.mtls;
                 String mtlsBucket = System.getenv(Constants.MTLS_BUCKET_NAME);
                 requestToUse.setAttribute(Constants.ACK_CONTENT_TYPE, portEntry.ackContentType);
+                if (portEntry.responseType != null && !portEntry.responseType.isBlank()) {
+                    requestToUse.setAttribute(Constants.RESPONSE_TYPE, portEntry.responseType);
+                    LOG.info("InteractionsFilter: responseType={} for port={} interactionId={}",
+                            portEntry.responseType, requestPort, interactionId);
+                }
                 LOG.info("InteractionsFilter: portEntry.mtls={}, MTLS_BUCKET={}  interactionId: {}",
                         mtlsName, mtlsBucket, interactionId);
 
                 // CRITICAL: Wrap response EARLY in filter chain to force Content-Type override
-                if (portEntry.ackContentType != null && !portEntry.ackContentType.isBlank()) {
+                if (portEntry.ackContentType != null && !portEntry.ackContentType.isBlank()
+                        && !isMtomResponseType(portEntry.responseType)) { // ← skip wrap for MTOM
                     wrappedResponse = new ContentTypeOverrideResponseWrapper(origResponse, portEntry.ackContentType);
-                    LOG.debug("InteractionsFilter: Early wrapping response with forceContentType={}  interactionId: {}",
+                    LOG.debug("InteractionsFilter: wrapping response with forceContentType={} interactionId={}",
                             portEntry.ackContentType, interactionId);
+                } else if (isMtomResponseType(portEntry.responseType)) {
+                    LOG.debug(
+                            "InteractionsFilter: skipping ContentTypeOverrideResponseWrapper for MTOM responseType={} interactionId={}",
+                            portEntry.responseType, interactionId);
                 }
 
                 // Skip mTLS check for internal forwards from SoapForwarderService
@@ -440,6 +450,13 @@ public class InteractionsFilter extends OncePerRequestFilter {
                message.contains("Unable to create envelope") ||
                message.contains("SAAJ0511") ||
                e instanceof IOException;
+    }
+
+    private boolean isMtomResponseType(String responseType) {
+        if (responseType == null || responseType.isBlank())
+            return false;
+        String n = responseType.trim().toLowerCase();
+        return n.equals("mtom") || n.equals("mtom_trubridge");
     }
 
     /**

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/SoapFaultEnhancementFilter.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/SoapFaultEnhancementFilter.java
@@ -78,6 +78,17 @@ public class SoapFaultEnhancementFilter extends OncePerRequestFilter {
             return;
         }
 
+        // ── MTOM bypass ───────────────────────────────────────────────────────
+        // MTOM strategies write directly to the response output stream inside
+        // WsaHeaderInterceptor.handleResponse(). Wrapping the response in
+        // ResponseWrapper would cause the bytes to be buffered and then written
+        // a second time by the filter, truncating or doubling the body.
+        // Skip capture entirely when responseType signals MTOM output.
+        String responseType = resolveResponseType(request);
+        if (isMtomResponseType(responseType)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         // Wrap request to capture body
         CachedBodyHttpServletRequest cachedRequest = new CachedBodyHttpServletRequest(request);
         java.util.Map<String, String> capturedHeaders = extractHeaders(request);
@@ -121,6 +132,30 @@ public class SoapFaultEnhancementFilter extends OncePerRequestFilter {
             byte[] responseBytes = responseWrapper.getCapturedBytes();
             response.getOutputStream().write(responseBytes);
         }
+    }
+
+    /**
+     * Reads responseType from request attribute (set by InteractionsFilter)
+     * or from forwarded header (set by SoapForwarderService).
+     */
+    private String resolveResponseType(HttpServletRequest request) {
+        String rt = (String) request.getAttribute(Constants.RESPONSE_TYPE);
+        if (rt == null || rt.isBlank()) {
+            rt = request.getHeader(Constants.RESPONSE_TYPE);
+        }
+        return rt;
+    }
+
+    /**
+     * Returns true for any responseType that causes the MTOM strategy to
+     * write directly to the servlet output stream.
+     */
+    private boolean isMtomResponseType(String responseType) {
+        if (responseType == null || responseType.isBlank()) {
+            return false;
+        }
+        String normalized = responseType.trim().toLowerCase();
+        return normalized.equals("mtom") || normalized.equals("mtom_trubridge");
     }
 
     /**

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.server.EndpointInterceptor;
 import org.springframework.ws.soap.SoapHeaderElement;
@@ -18,28 +19,34 @@ import org.techbd.ingest.exceptions.ErrorTraceIdGenerator;
 import org.techbd.ingest.feature.FeatureEnum;
 import org.techbd.ingest.model.RequestContext;
 import org.techbd.ingest.service.MessageProcessorService;
+import org.techbd.ingest.service.soap.SoapResponseStrategy;
+import org.techbd.ingest.service.soap.SoapResponseStrategyFactory;
 import org.techbd.ingest.util.AppLogger;
 import org.techbd.ingest.util.Hl7Util;
 import org.techbd.ingest.util.LogUtil;
 import org.techbd.ingest.util.SoapResponseUtil;
 import org.techbd.ingest.util.TemplateLogger;
-import jakarta.servlet.http.HttpServletRequest;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 public class WsaHeaderInterceptor implements EndpointInterceptor, SoapEndpointInterceptor {
 
     private final SoapResponseUtil soapResponseUtil;
     private final MessageProcessorService messageProcessorService;
     private final AppConfig appConfig;
     private final TemplateLogger LOG;
+    private final SoapResponseStrategyFactory strategyFactory;
 
     public WsaHeaderInterceptor(SoapResponseUtil soapResponseUtil,
                                 MessageProcessorService messageProcessorService,
                                 AppConfig appConfig,
-                                AppLogger appLogger) {
+                                AppLogger appLogger,
+                                SoapResponseStrategyFactory strategyFactory) {
         this.soapResponseUtil = soapResponseUtil;
         this.messageProcessorService = messageProcessorService;
         this.appConfig = appConfig;
         this.LOG = appLogger.getLogger(WsaHeaderInterceptor.class);
+        this.strategyFactory = strategyFactory;  
     }
 
     /**
@@ -104,19 +111,55 @@ public class WsaHeaderInterceptor implements EndpointInterceptor, SoapEndpointIn
         var transportContext = TransportContextHolder.getTransportContext();
         var connection = (HttpServletConnection) transportContext.getConnection();
         HttpServletRequest httpRequest = connection.getHttpServletRequest();
+        HttpServletResponse httpResponse = connection.getHttpServletResponse();
+
         String interactionId = (String) httpRequest.getAttribute(Constants.INTERACTION_ID);
 
         SoapMessage message = soapResponseUtil.buildSoapResponse(interactionId, messageContext);
+
+        String responseType = (String) httpRequest.getAttribute(Constants.RESPONSE_TYPE);
+        if (responseType == null || responseType.isBlank()) {
+            responseType = httpRequest.getHeader(Constants.RESPONSE_TYPE);
+        }
+        SoapResponseStrategy strategy = strategyFactory.resolve(responseType);
+
         RequestContext context = (RequestContext) httpRequest.getAttribute(Constants.REQUEST_CONTEXT);
         String rawSoapMessage = (String) messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE);
 
         messageContext.setProperty(Constants.INTERACTION_ID, interactionId);
-        LOG.info("handleResponse: Processing SOAP response for /ws endpoint. interactionId={}", interactionId);
+        LOG.info("handleResponse: responseType={} interactionId={}", responseType, interactionId);
+
+        strategy.writeResponse(interactionId, messageContext, httpRequest, httpResponse, message);
+
+        // ── For MTOM strategies: mark the MessageContext response as already sent ──
+        // This prevents Spring-WS from serializing the SoapMessage a second time
+        // after handleResponse returns, which would append bytes past the committed
+        // Content-Length and cause client-side truncation.
+        
+        if (isMtomResponseType(responseType)) {
+            messageContext.getResponse().writeTo(new java.io.OutputStream() {
+                @Override
+                public void write(int b) {
+                } // discard — already written
+
+                @Override
+                public void write(byte[] b, int off, int len) {
+                }
+            });
+            LOG.debug("handleResponse: suppressed Spring-WS secondary write for MTOM. interactionId={}", interactionId);
+        }
 
         messageProcessorService.processMessage(context, rawSoapMessage,
                 Hl7Util.soapMessageToString(message, interactionId));
 
         return true;
+    }
+
+    private boolean isMtomResponseType(String responseType) {
+        if (responseType == null || responseType.isBlank())
+            return false;
+        String n = responseType.trim().toLowerCase();
+        return n.equals("mtom") || n.equals("mtom_trubridge");
     }
 
     @Override

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/SoapForwarderService.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/SoapForwarderService.java
@@ -1,5 +1,6 @@
 package org.techbd.ingest.service;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -19,6 +20,7 @@ import org.techbd.ingest.util.LogUtil;
 import org.techbd.ingest.util.TemplateLogger;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.xml.soap.SOAPConstants;
 
 @Service
@@ -31,14 +33,62 @@ public class SoapForwarderService {
     public SoapForwarderService(AppLogger appLogger) {
         this.LOG = appLogger.getLogger(SoapForwarderService.class);
         this.httpClient = HttpClient.newBuilder()
-                .version(HttpClient.Version.HTTP_1_1)   // /ws is HTTP/1.1; upgrade later if needed
-                .connectTimeout(Duration.ofSeconds(30))
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(60))
                 .build();
     }
 
+    // ── Primary entry point (with HttpServletResponse for MTOM direct-write) ──
+
     /**
-     * Primary entry point — always forwards as raw bytes to /ws.
+     * Forward with HttpServletResponse — required for MTOM responses so bytes
+     * are written directly to the socket, bypassing Spring's MediaType parser
+     * which rejects unquoted type parameter values containing '/'.
+     */
+    public ResponseEntity<String> forward(HttpServletRequest request,
+            HttpServletResponse servletResponse,
+            String body, String sourceId, String msgType, String interactionId) {
+        byte[] bytes = (body != null) ? body.getBytes(StandardCharsets.UTF_8) : new byte[0];
+        return forward(request, servletResponse, bytes, sourceId, msgType, interactionId);
+    }
+
+    public ResponseEntity<String> forward(HttpServletRequest request,
+            HttpServletResponse servletResponse,
+            byte[] rawBytes, String sourceId, String msgType, String interactionId) {
+        String errorTraceId = null;
+        String bodySnippet = rawBytes.length > 0
+                ? new String(rawBytes, 0, Math.min(rawBytes.length, 4096), StandardCharsets.UTF_8)
+                : "";
+        try {
+            String contentType = request.getContentType();
+            String targetUrl = getBaseUrl(request, interactionId) + "/ws";
+            LOG.info("SoapForwarderService:: Forwarding raw to targetUrl={} ContentType={} " +
+                    "sourceId={} msgType={} interactionId={}",
+                    targetUrl, contentType, sourceId, msgType, interactionId);
+            return forwardRaw(request, servletResponse, rawBytes, contentType,
+                    targetUrl, sourceId, msgType, interactionId);
+        } catch (Exception e) {
+            errorTraceId = ErrorTraceIdGenerator.generateErrorTraceId();
+            LOG.error("SoapForwarderService:: Forward error. interactionId={} errorTraceId={} error={}",
+                    interactionId, errorTraceId, e.getMessage(), e);
+            LogUtil.logDetailedError(500, "SOAP forwarding error", interactionId, errorTraceId, e);
+            String soapVersion = determineSoapVersion(bodySnippet);
+            return ResponseEntity
+                    .status(org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR)
+                    .header("Content-Type", soapVersion.equals(SOAPConstants.SOAP_1_2_PROTOCOL)
+                            ? "application/soap+xml; charset=utf-8"
+                            : "text/xml; charset=utf-8")
+                    .body(createSoapFault(e.getMessage(), soapVersion, interactionId, errorTraceId));
+        }
+    }
+
+    // ── Legacy overloads (no HttpServletResponse) — used by XdsRepositoryController ──
+
+    /**
+     * Primary legacy entry point — always forwards as raw bytes to /ws.
      * sourceId and msgType from path are forwarded as headers.
+     * MTOM direct-write is not available in this path (no servlet response);
+     * use the HttpServletResponse overload from DataIngestionController.
      */
     public ResponseEntity<String> forward(HttpServletRequest request, byte[] rawBytes,
             String sourceId, String msgType, String interactionId) {
@@ -49,10 +99,12 @@ public class SoapForwarderService {
         try {
             String contentType = request.getContentType();
             String targetUrl = getBaseUrl(request, interactionId) + "/ws";
-            LOG.info(
-                    "SoapForwarderService:: Forwarding raw to targetUrl={} ContentType={} sourceId={} msgType={} interactionId={}",
+            LOG.info("SoapForwarderService:: Forwarding raw to targetUrl={} ContentType={} " +
+                    "sourceId={} msgType={} interactionId={}",
                     targetUrl, contentType, sourceId, msgType, interactionId);
-            return forwardRaw(request, rawBytes, contentType, targetUrl, sourceId, msgType, interactionId);
+            // null servletResponse — MTOM direct-write not available from this path
+            return forwardRaw(request, null, rawBytes, contentType,
+                    targetUrl, sourceId, msgType, interactionId);
         } catch (Exception e) {
             errorTraceId = ErrorTraceIdGenerator.generateErrorTraceId();
             LOG.error("SoapForwarderService:: Forward error. interactionId={} errorTraceId={} error={}",
@@ -84,24 +136,25 @@ public class SoapForwarderService {
         return forward(request, bytes, sourceId, msgType, interactionId);
     }
 
+    // ── Core forwarding logic ─────────────────────────────────────────────────
+
     /**
      * Pipes rawBytes directly to targetUrl using the shared HttpClient.
-     * No SAAJ parsing — byte stream delivered exactly as received.
-     * Content-Type is reconstructed from bytes if missing or not multipart/related,
-     * so /ws (Spring-WS/SAAJ) can parse the MTOM message correctly.
-     * All original request headers are forwarded except restricted ones.
      *
-     * Key changes from HttpURLConnection:
-     *  - Connection pooling: keep-alive sockets are reused across calls automatically.
-     *  - No manual disconnect() — the HttpClient lifecycle manages connections.
-     *  - Read timeout set per-request via HttpRequest.timeout().
+     * For MTOM multipart responses: if servletResponse is non-null, writes
+     * bytes directly to the socket and returns an empty ResponseEntity, bypassing
+     * Spring's MediaType.parseMediaType() which rejects unquoted type parameter
+     * values containing '/' (e.g. type=application/xop+xml).
+     *
+     * For all other responses: returns a ResponseEntity with the body as a String,
+     * preserving the existing behaviour exactly.
      */
-    private ResponseEntity<String> forwardRaw(HttpServletRequest request, byte[] rawBytes,
-            String contentType, String targetUrl,
-            String sourceId, String msgType,
-            String interactionId) throws Exception {
+    private ResponseEntity<String> forwardRaw(HttpServletRequest request,
+            HttpServletResponse servletResponse,
+            byte[] rawBytes, String contentType, String targetUrl,
+            String sourceId, String msgType, String interactionId) throws Exception {
 
-        // ── Step 1: determine outbound Content-Type ───────────────────────────
+        // ── Step 1: determine outbound Content-Type ───────────────────────
         String outboundContentType = contentType;
         if (isFromXdsRepository(request)
                 && (contentType == null || !contentType.toLowerCase().contains("multipart/related"))) {
@@ -114,10 +167,10 @@ public class SoapForwarderService {
             }
         }
 
-        // ── Step 2: build HttpRequest ─────────────────────────────────────────
+        // ── Step 2: build HttpRequest ─────────────────────────────────────
         HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
                 .uri(URI.create(targetUrl))
-                .timeout(Duration.ofSeconds(60))
+                .timeout(Duration.ofSeconds(120))
                 .POST(HttpRequest.BodyPublishers.ofByteArray(rawBytes));
 
         // Content-Type (possibly reconstructed)
@@ -138,6 +191,12 @@ public class SoapForwarderService {
         String ackContentType = (String) request.getAttribute(Constants.ACK_CONTENT_TYPE);
         if (ackContentType != null) {
             reqBuilder.header(Constants.ACK_CONTENT_TYPE, ackContentType);
+        }
+        String responseType = (String) request.getAttribute(Constants.RESPONSE_TYPE);
+        if (responseType != null && !responseType.isBlank()) {
+            reqBuilder.header(Constants.RESPONSE_TYPE, responseType);
+            LOG.info("SoapForwarderService:: Forwarding responseType={} interactionId={}",
+                    responseType, interactionId);
         }
         if (sourceId != null && !sourceId.isBlank()) {
             reqBuilder.header(Constants.HEADER_SOURCE_ID, sourceId);
@@ -195,13 +254,66 @@ public class SoapForwarderService {
         LOG.info("SoapForwarderService:: Raw forward response. status={} contentType={} interactionId={}",
                 status, respContentType, interactionId);
 
-        String responseBody = new String(response.body(), StandardCharsets.UTF_8);
+        byte[] responseBodyBytes = response.body();
 
+        // ── Step 4: MTOM direct-write — bypass Spring's MediaType parser ──
+        // Spring's MediaType.parseMediaType() rejects unquoted type parameter
+        // values containing '/' (RFC 7230 token rule). For MTOM responses the
+        // type parameter value is "application/xop+xml" which contains '/'.
+        // Writing directly to the servlet response avoids this entirely.
+        if (respContentType != null
+                && respContentType.toLowerCase().contains("multipart/related")
+                && servletResponse != null) {
+
+            try {
+                servletResponse.setStatus(status);
+                // Use setHeader (not setContentType) to bypass Tomcat's
+                // own MediaType validation in the connector layer.
+                servletResponse.setHeader("Content-Type", respContentType);
+                servletResponse.setContentLengthLong(responseBodyBytes.length);
+                servletResponse.getOutputStream().write(responseBodyBytes);
+                servletResponse.getOutputStream().flush();
+
+                LOG.info("SoapForwarderService:: Wrote MTOM response directly to servlet output. " +
+                        "bytes={} interactionId={}", responseBodyBytes.length, interactionId);
+
+                // Return empty ResponseEntity — response already committed.
+                // Spring will not attempt further writes.
+                return ResponseEntity.status(status).build();
+
+            } catch (IOException e) {
+                if (isBrokenPipe(e)) {
+                    LOG.warn("SoapForwarderService:: Client disconnected during MTOM write " +
+                            "(caller timed out). interactionId={}", interactionId);
+                    return ResponseEntity.status(status).build();
+                }
+                throw e;
+            }
+        }
+
+        // ── Step 5: non-MTOM — existing path unchanged ────────────────────
+        String responseBody = new String(responseBodyBytes, StandardCharsets.UTF_8);
         return ResponseEntity.status(status)
                 .header("Content-Type", respContentType != null
                         ? respContentType
                         : "text/xml; charset=utf-8")
                 .body(responseBody);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private boolean isBrokenPipe(Throwable e) {
+        while (e != null) {
+            String msg = e.getMessage();
+            String cls = e.getClass().getName();
+            if ((msg != null && (msg.contains("Broken pipe")
+                    || msg.contains("Connection reset")))
+                    || cls.contains("ClientAbortException")) {
+                return true;
+            }
+            e = e.getCause();
+        }
+        return false;
     }
 
     private boolean isFromXdsRepository(HttpServletRequest request) {

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategy.java
@@ -1,0 +1,36 @@
+package org.techbd.ingest.service.soap;
+
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.TemplateLogger;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Default strategy — preserves the existing behaviour exactly.
+ *
+ * Spring-WS has already written the SOAP response; nothing extra is done here.
+ * Content-Type remains {@code application/soap+xml} as set by the framework.
+ */
+public class DefaultSoapResponseStrategy implements SoapResponseStrategy {
+
+    private final TemplateLogger log;
+
+    public DefaultSoapResponseStrategy(AppLogger appLogger) {
+        this.log = appLogger.getLogger(DefaultSoapResponseStrategy.class);
+    }
+
+    @Override
+    public void writeResponse(
+            String interactionId,
+            MessageContext messageContext,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse,
+            SoapMessage builtResponse) {
+
+        // Intentionally a no-op: Spring-WS handles serialisation in its normal pipeline.
+        log.debug("DefaultSoapResponseStrategy:: no-op for interactionId={}", interactionId);
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategy.java
@@ -1,0 +1,155 @@
+package org.techbd.ingest.service.soap;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * MTOM strategy — wraps the SOAP/XOP response in a multipart/related envelope.
+ *
+ * Wire format (SOAP 1.2):
+ * <pre>
+ *   Content-Type: multipart/related;
+ *     boundary="uuid:...";
+ *     type="application/xop+xml";
+ *     start="&lt;rootpart@...&gt;";
+ *     start-info="application/soap+xml";
+ *     action="urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b"
+ * </pre>
+ *
+ * Wire format (SOAP 1.1, per W3C SOAP11-MTOM binding):
+ * <pre>
+ *   Content-Type: multipart/related;
+ *     boundary="uuid:...";
+ *     type="application/xop+xml";
+ *     start="&lt;rootpart@...&gt;";
+ *     start-info="text/xml";
+ *     action="urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b"
+ * </pre>
+ */
+public class MtomSoapResponseStrategy implements SoapResponseStrategy {
+
+    private static final String IHE_PNR_ACTION =
+            "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
+
+    private static final String SOAP_12_MEDIA_TYPE = "application/soap+xml";
+    private static final String SOAP_11_MEDIA_TYPE = "text/xml";
+
+    private final SoapResponseUtil soapResponseUtil;
+    private final TemplateLogger log;
+
+    public MtomSoapResponseStrategy(SoapResponseUtil soapResponseUtil, AppLogger appLogger) {
+        this.soapResponseUtil = soapResponseUtil;
+        this.log = appLogger.getLogger(MtomSoapResponseStrategy.class);
+    }
+
+    @Override
+    public void writeResponse(
+            String interactionId,
+            MessageContext messageContext,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse,
+            SoapMessage builtResponse) {
+
+        try {
+            boolean isSoap11 = isSoap11(httpRequest);
+            String soapMediaType = isSoap11 ? SOAP_11_MEDIA_TYPE : SOAP_12_MEDIA_TYPE;
+
+            String boundary = soapResponseUtil.generateMimeBoundary();
+            String startCid = "<rootpart@" + soapResponseUtil.generateUuid() + ">";
+            String soapXml = soapResponseUtil.serializeSoapMessage(builtResponse, interactionId);
+
+            String multipart = buildMultipartBody(boundary, startCid, soapXml, soapMediaType);
+
+            String contentType = "multipart/related;"
+                    + " boundary=\"" + boundary + "\";"
+                    + " type=\"application/xop+xml\";"
+                    + " start=\"" + startCid + "\";"
+                    + " start-info=\"" + soapMediaType + "\";"
+                    + " action=\"" + IHE_PNR_ACTION + "\"";
+
+            // Use setHeader (not setContentType) to bypass any MediaType
+            // validation in the Tomcat connector layer.
+            httpResponse.setHeader("Content-Type", contentType);
+            httpRequest.setAttribute(Constants.ACK_CONTENT_TYPE, contentType);
+
+            byte[] responseBytes = multipart.getBytes(StandardCharsets.UTF_8);
+            httpResponse.setContentLengthLong(responseBytes.length);
+            httpResponse.flushBuffer();
+            httpResponse.getOutputStream().write(responseBytes);
+            httpResponse.getOutputStream().flush();
+
+            log.info("MtomSoapResponseStrategy:: MTOM response written. " +
+                    "boundary={} interactionId={} soapMediaType={}",
+                    boundary, interactionId, soapMediaType);
+
+        } catch (IOException e) {
+            if (isBrokenPipe(e)) {
+                log.warn("MtomSoapResponseStrategy:: Client disconnected before MTOM response " +
+                        "could be written (caller timed out). interactionId={}", interactionId);
+                return;
+            }
+            log.error("MtomSoapResponseStrategy:: Failed to write MTOM response. " +
+                    "interactionId={} error={}", interactionId, e.getMessage(), e);
+            throw new RuntimeException("Failed to write MTOM response", e);
+        }
+    }
+
+    private String buildMultipartBody(String boundary, String startCid, String soapXml,
+                                      String soapMediaType) {
+        return "--" + boundary + "\r\n"
+                + "Content-Type: application/xop+xml; charset=UTF-8; type=\"" + soapMediaType + "\"\r\n"
+                + "Content-Transfer-Encoding: 8bit\r\n"
+                + "Content-ID: " + startCid + "\r\n"
+                + "\r\n"
+                + soapXml + "\r\n"
+                + "--" + boundary + "--\r\n";
+    }
+
+    /**
+     * Returns {@code true} when the incoming request is SOAP 1.1.
+     *
+     * <p>Detection strategy (first match wins):
+     * <ol>
+     *   <li>Request {@code Content-Type} contains {@code text/xml} — canonical SOAP 1.1 indicator.</li>
+     *   <li>Request {@code SOAPAction} header is present — SOAP 1.1 exclusively uses this header.</li>
+     *   <li>Request {@code Content-Type} contains {@code application/soap+xml} — SOAP 1.2, so returns false.</li>
+     * </ol>
+     */
+    private boolean isSoap11(HttpServletRequest httpRequest) {
+        String contentType = httpRequest.getContentType();
+        if (contentType != null) {
+            if (contentType.contains("text/xml")) {
+                return true;
+            }
+            if (contentType.contains("application/soap+xml")) {
+                return false;
+            }
+        }
+        // SOAPAction header is SOAP 1.1-only
+        return httpRequest.getHeader("SOAPAction") != null;
+    }
+
+    private boolean isBrokenPipe(Throwable e) {
+        while (e != null) {
+            String msg = e.getMessage();
+            String cls = e.getClass().getName();
+            if ((msg != null && (msg.contains("Broken pipe")
+                    || msg.contains("Connection reset")))
+                    || cls.contains("ClientAbortException")) {
+                return true;
+            }
+            e = e.getCause();
+        }
+        return false;
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategy.java
@@ -1,0 +1,34 @@
+package org.techbd.ingest.service.soap;
+
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Strategy for writing the SOAP response depending on the requested wire format.
+ *
+ * Implementations:
+ *   - DefaultSoapResponseStrategy   → application/soap+xml  (existing behaviour)
+ *   - MtomSoapResponseStrategy      → multipart/related MTOM
+ *   - TruBridgeMtomSoapResponseStrategy → TruBridge MTOM wire format
+ */
+public interface SoapResponseStrategy {
+
+    /**
+     * Write (or mutate) the outbound SOAP response.
+     *
+     * @param interactionId  correlation ID for logging
+     * @param messageContext Spring-WS message context (request + response in-flight)
+     * @param httpRequest    raw servlet request (headers, attributes)
+     * @param httpResponse   raw servlet response (may be used to set headers directly)
+     * @param builtResponse  the SOAP message already built by SoapResponseUtil.buildSoapResponse()
+     */
+    void writeResponse(
+            String interactionId,
+            MessageContext messageContext,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse,
+            SoapMessage builtResponse);
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactory.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactory.java
@@ -1,0 +1,65 @@
+package org.techbd.ingest.service.soap;
+
+import org.springframework.stereotype.Component;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+
+/**
+ * Resolves the correct {@link SoapResponseStrategy} based on the 
+ * responsetype specified in portconfig
+ * Resolution rules:
+ * <pre>
+ *   absent / null / unsupported  →  DefaultSoapResponseStrategy   (no-op, existing behaviour)
+ *   "mtom"                       →  MtomSoapResponseStrategy
+ *   "mtom_trubridge"             →  TruBridgeMtomSoapResponseStrategy
+ * </pre>
+ *
+ * Strategies are singletons reused across requests.
+ */
+@Component
+public class SoapResponseStrategyFactory {
+
+    /** Header name carrying the desired response mode. */
+    public static final String RESPONSE_TYPE_HEADER = "X-Response-Type";
+
+    public static final String MTOM            = "mtom";
+    public static final String MTOM_TRUBRIDGE  = "mtom_trubridge";
+
+    private final DefaultSoapResponseStrategy      defaultStrategy;
+    private final MtomSoapResponseStrategy         mtomStrategy;
+    private final TruBridgeMtomSoapResponseStrategy truBridgeStrategy;
+    private final TemplateLogger                   log;
+
+    public SoapResponseStrategyFactory(SoapResponseUtil soapResponseUtil, AppLogger appLogger) {
+        this.log              = appLogger.getLogger(SoapResponseStrategyFactory.class);
+        this.defaultStrategy  = new DefaultSoapResponseStrategy(appLogger);
+        this.mtomStrategy     = new MtomSoapResponseStrategy(soapResponseUtil, appLogger);
+        this.truBridgeStrategy = new TruBridgeMtomSoapResponseStrategy(soapResponseUtil, appLogger);
+    }
+
+    /**
+     * Returns the strategy matching {@code responseType} (case-insensitive).
+     * Falls back to {@link DefaultSoapResponseStrategy} for any unrecognised value.
+     */
+    public SoapResponseStrategy resolve(String responseType) {
+        if (responseType == null || responseType.isBlank()) {
+            log.info("SoapResponseStrategyFactory:: no responseType — using default strategy");
+            return defaultStrategy;
+        }
+        return switch (responseType.trim().toLowerCase()) {
+            case MTOM           -> {
+                log.info("SoapResponseStrategyFactory:: resolved MtomSoapResponseStrategy");
+                yield mtomStrategy;
+            }
+            case MTOM_TRUBRIDGE -> {
+                log.info("SoapResponseStrategyFactory:: resolved TruBridgeMtomSoapResponseStrategy");
+                yield truBridgeStrategy;
+            }
+            default -> {
+                log.warn("SoapResponseStrategyFactory:: unknown responseType='{}' — falling back to default", responseType);
+                yield defaultStrategy;
+            }
+        };
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategy.java
@@ -1,0 +1,149 @@
+package org.techbd.ingest.service.soap;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * TruBridge MTOM strategy — TruBridge-specific wire format.
+ *
+ * Differences from standard MTOM:
+ * <ul>
+ *   <li>Content-Type omits {@code start}, {@code start-info}, and {@code action}</li>
+ *   <li>Adds {@code Content-Transfer-Encoding: binary} top-level header</li>
+ * </ul>
+ *
+ * Wire format:
+ * <pre>
+ *   Content-Type: multipart/related; boundary=...; type=application/xop+xml
+ *   Content-Transfer-Encoding: binary
+ * </pre>
+ *
+ * The inner MIME part {@code type} parameter reflects the incoming SOAP version:
+ * {@code text/xml} for SOAP 1.1, {@code application/soap+xml} for SOAP 1.2.
+ *
+ * WS-Addressing headers (Action, MessageID, RelatesTo, To) are already added
+ * by {@link org.techbd.ingest.util.SoapResponseUtil#buildSoapResponse} before
+ * this strategy is called.
+ */
+public class TruBridgeMtomSoapResponseStrategy implements SoapResponseStrategy {
+
+    private static final String SOAP_12_MEDIA_TYPE = "application/soap+xml";
+    private static final String SOAP_11_MEDIA_TYPE = "text/xml";
+
+    private final SoapResponseUtil soapResponseUtil;
+    private final TemplateLogger log;
+
+    public TruBridgeMtomSoapResponseStrategy(SoapResponseUtil soapResponseUtil, AppLogger appLogger) {
+        this.soapResponseUtil = soapResponseUtil;
+        this.log = appLogger.getLogger(TruBridgeMtomSoapResponseStrategy.class);
+    }
+
+    @Override
+    public void writeResponse(
+            String interactionId,
+            MessageContext messageContext,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse,
+            SoapMessage builtResponse) {
+
+        try {
+            boolean isSoap11 = isSoap11(httpRequest);
+            String soapMediaType = isSoap11 ? SOAP_11_MEDIA_TYPE : SOAP_12_MEDIA_TYPE;
+
+            String boundary = soapResponseUtil.generateMimeBoundary();
+            String startCid = "<rootpart@" + soapResponseUtil.generateUuid() + ">";
+            String soapXml = soapResponseUtil.serializeSoapMessage(builtResponse, interactionId);
+
+            String multipart = buildMultipartBody(boundary, startCid, soapXml, soapMediaType);
+
+            // TruBridge wire format: unquoted parameter values, no start/start-info/action
+            String contentType = "multipart/related;"
+                    + " boundary=" + boundary + ";"
+                    + " type=application/xop+xml";
+
+            // Use setHeader (not setContentType) to bypass Tomcat's MediaType
+            // validation which rejects unquoted '/' in parameter values.
+            httpResponse.setHeader("Content-Type", contentType);
+            httpResponse.setHeader("Content-Transfer-Encoding", "binary");
+            httpRequest.setAttribute(Constants.ACK_CONTENT_TYPE, contentType);
+
+            byte[] responseBytes = multipart.getBytes(StandardCharsets.UTF_8);
+            httpResponse.setContentLengthLong(responseBytes.length);
+            httpResponse.flushBuffer();
+            httpResponse.getOutputStream().write(responseBytes);
+            httpResponse.getOutputStream().flush();
+
+            log.info("TruBridgeMtomSoapResponseStrategy:: TruBridge MTOM response written. " +
+                    "boundary={} interactionId={} soapMediaType={}", boundary, interactionId, soapMediaType);
+
+        } catch (IOException e) {
+            if (isBrokenPipe(e)) {
+                log.warn("TruBridgeMtomSoapResponseStrategy:: Client disconnected before response " +
+                        "could be written (caller timed out). interactionId={}", interactionId);
+                return;
+            }
+            log.error("TruBridgeMtomSoapResponseStrategy:: Failed to write TruBridge MTOM response. " +
+                    "interactionId={} error={}", interactionId, e.getMessage(), e);
+            throw new RuntimeException("Failed to write TruBridge MTOM response", e);
+        }
+    }
+
+    private String buildMultipartBody(String boundary, String startCid, String soapXml,
+                                      String soapMediaType) {
+        return "--" + boundary + "\r\n"
+                + "Content-Type: application/xop+xml; charset=UTF-8; type=\"" + soapMediaType + "\"\r\n"
+                + "Content-Transfer-Encoding: binary\r\n"
+                + "Content-ID: " + startCid + "\r\n"
+                + "\r\n"
+                + soapXml + "\r\n"
+                + "--" + boundary + "--\r\n";
+    }
+
+    /**
+     * Returns {@code true} when the incoming request is SOAP 1.1.
+     *
+     * <p>Detection strategy (first match wins):
+     * <ol>
+     *   <li>Request {@code Content-Type} contains {@code text/xml} — canonical SOAP 1.1 indicator.</li>
+     *   <li>Request {@code SOAPAction} header is present — SOAP 1.1 exclusively uses this header.</li>
+     *   <li>Request {@code Content-Type} contains {@code application/soap+xml} — SOAP 1.2, so returns false.</li>
+     * </ol>
+     */
+    private boolean isSoap11(HttpServletRequest httpRequest) {
+        String contentType = httpRequest.getContentType();
+        if (contentType != null) {
+            if (contentType.contains("text/xml")) {
+                return true;
+            }
+            if (contentType.contains("application/soap+xml")) {
+                return false;
+            }
+        }
+        // SOAPAction header is SOAP 1.1-only
+        return httpRequest.getHeader("SOAPAction") != null;
+    }
+
+    private boolean isBrokenPipe(Throwable e) {
+        while (e != null) {
+            String msg = e.getMessage();
+            String cls = e.getClass().getName();
+            if ((msg != null && (msg.contains("Broken pipe")
+                    || msg.contains("Connection reset")))
+                    || cls.contains("ClientAbortException")) {
+                return true;
+            }
+            e = e.getCause();
+        }
+        return false;
+    }
+}

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/util/SoapResponseUtil.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/util/SoapResponseUtil.java
@@ -20,7 +20,9 @@ import org.techbd.ingest.feature.FeatureEnum;
 import org.techbd.ingest.model.RequestContext;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.UUID;
 import jakarta.servlet.http.HttpServletRequest;
 
 @Component
@@ -123,5 +125,52 @@ public class SoapResponseUtil {
             }
         }
         return null;
+    }
+
+    /**
+     * Generates a random MIME boundary token (UUID-based, no hyphens).
+     * Safe for use as a multipart boundary.
+     */
+    public String generateMimeBoundary() {
+        return "MIMEBoundary_" + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    /**
+     * Generates a plain UUID string (with hyphens).
+     * Used for Content-ID and MessageID generation in MTOM strategies.
+     */
+    public String generateUuid() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Serializes a {@link SoapMessage} to its canonical XML string representation.
+     * Used by MTOM strategies to obtain the SOAP envelope bytes.
+     *
+     * @param message       the SOAP message to serialize
+     * @param interactionId for logging
+     * @return XML string
+     */
+    public String serializeSoapMessage(SoapMessage message, String interactionId) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            message.writeTo(baos);
+            return baos.toString(java.nio.charset.StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error("SoapResponseUtil:: Failed to serialize SOAP message. interactionId={} error={}",
+                    interactionId, e.getMessage(), e);
+            throw new RuntimeException("Failed to serialize SOAP message", e);
+        }
+    }
+
+    /**
+     * Extracts the inbound WS-Addressing MessageID from the SOAP request header.
+     * Returns a fallback string if not found.
+     *
+     * @param soapRequest the inbound SOAP message
+     * @return the MessageID value, or a fallback URN
+     */
+    public String extractInboundMessageId(SoapMessage soapRequest) {
+        return extractRelatesTo(soapRequest); // reuse existing private method logic
     }
 }

--- a/nexus-ingestion-api/src/main/resources/list.json
+++ b/nexus-ingestion-api/src/main/resources/list.json
@@ -5,15 +5,53 @@
         "protocol": "TCP"
     },
     {
-        "sourceId":"netspective",
-        "msgType":"pnr",
-        "protocol": "TCP",
+        "sourceId": "netspective",
+        "msgType": "pnr",
+        "protocol": "HTTP",
         "route": "/hold",
         "dataDir": "/outbound",
         "metadataDir": "/outbound",
         "ackContentType": "application/soap+xml"
     },
-       {
+    {
+        "sourceId": "netspective_m",
+        "msgType": "pnr",
+        "protocol": "HTTP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "responseType": "mtom"
+    },
+    {
+        "sourceId": "netspective_mt",
+        "msgType": "pnr",
+        "protocol": "HTTP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "responseType": "mtom_trubridge"
+    },
+    {
+        "sourceId": "netspective_ma",
+        "msgType": "pnr",
+        "protocol": "HTTP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "responseType": "mtom",
+        "ackContentType": "application/soap+xml"
+    },
+    {
+        "sourceId": "netspective_mta",
+        "msgType": "pnr",
+        "protocol": "HTTP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "responseType": "mtom_trubridge",
+        "ackContentType": "application/soap+xml"
+    },
+    {
         "port": 5555,
         "responseType": "mllp",
         "protocol": "TCP",
@@ -21,7 +59,7 @@
         "dataDir": "/outbound",
         "metadataDir": "/outbound",
         "queue": "test.fifo",
-         "keepAliveTimeout": 20
+        "keepAliveTimeout": 20
     },
     {
         "port": 5555,
@@ -31,7 +69,7 @@
         "dataDir": "/http",
         "metadataDir": "/outbound",
         "queue": "test.fifo",
-         "keepAliveTimeout": 20
+        "keepAliveTimeout": 20
     },
     {
         "port": 5556,
@@ -41,17 +79,17 @@
         "dataDir": "/outbound",
         "metadataDir": "/outbound",
         "queue": "test.fifo",
-         "keepAliveTimeout": 20
+        "keepAliveTimeout": 20
     },
     {
-        "sourceId":"netspective",
-        "msgType":"pix",
+        "sourceId": "netspective",
+        "msgType": "pix",
         "protocol": "TCP",
         "route": "/",
         "queue": "txd-sbx-util-queue.fifo",
         "dataDir": "/outbound",
         "metadataDir": "/outbound",
-         "ackContentType": "application/soap+xml"
+        "ackContentType": "application/soap+xml"
     },
     {
         "port": 3575,
@@ -109,18 +147,17 @@
     },
     {
         "port": 9000,
-        "responseType": "",
+        "responseType": "mtom",
         "protocol": "HTTP",
         "whitelistIps": [
             "0.0.0.0/0"
         ],
-        
         "execType": "sync",
         "trafficTo": "util"
     },
     {
         "port": 9001,
-        "responseType": "",
+        "responseType": "mtom_trubridge",
         "protocol": "HTTP",
         "whitelistIps": [
             "0.0.0.0/0"

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/DataIngestionControllerTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/controller/DataIngestionControllerTest.java
@@ -209,4 +209,48 @@ class DataIngestionControllerTest {
         verify(messageProcessorService)
                 .processMessage(any(RequestContext.class), eq(rawData));
     }
+     @Test
+    void testIngest_soapBody_forwardedWithServletResponse() throws Exception {
+        // Arrange: SOAP body + pnr msgType triggers forwarding
+        String soapBody = "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"/>";
+
+        when(servletRequest.getContentType()).thenReturn("application/soap+xml");
+        when(servletRequest.getAttribute(Constants.INTERACTION_ID)).thenReturn("FWD-1");
+        when(servletRequest.getAttribute(Constants.ALLOWED_ROUTES)).thenReturn(null);
+
+        HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+
+        ResponseEntity<String> mockForwarderResponse =
+                ResponseEntity.ok("forwarded");
+
+        // The new overload accepts HttpServletResponse
+        when(forwarder.forward(
+                eq(servletRequest),
+                eq(servletResponse),
+                eq(soapBody),
+                eq("src1"),
+                eq("pnr"),
+                eq("FWD-1")))
+                .thenReturn(mockForwarderResponse);
+
+        ResponseEntity<String> result = controller.ingest(
+                "src1",
+                "pnr",
+                null,
+                soapBody,
+                Map.of(),
+                servletRequest,
+                servletResponse);
+
+        assertThat(result.getStatusCodeValue()).isEqualTo(200);
+        assertThat(result.getBody()).isEqualTo("forwarded");
+
+        verify(forwarder).forward(
+                eq(servletRequest),
+                eq(servletResponse),
+                eq(soapBody),
+                eq("src1"),
+                eq("pnr"),
+                eq("FWD-1"));
+    }
 }

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/interceptors/WsaHeaderInterceptorTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/interceptors/WsaHeaderInterceptorTest.java
@@ -3,76 +3,65 @@ package org.techbd.ingest.interceptors;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mock;
-import org.techbd.ingest.config.AppConfig;
-import org.techbd.ingest.service.MessageProcessorService;
-import org.techbd.ingest.util.AppLogger;
-import org.techbd.ingest.util.SoapResponseUtil;
-import org.techbd.ingest.util.TemplateLogger;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
-
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ws.context.MessageContext;
-import org.springframework.ws.soap.SoapMessage;
-import org.springframework.ws.soap.SoapHeaderElement;
+import org.springframework.ws.soap.SoapBody;
+import org.springframework.ws.soap.SoapFault;
 import org.springframework.ws.soap.SoapFaultDetail;
 import org.springframework.ws.soap.SoapFaultDetailElement;
+import org.springframework.ws.soap.SoapHeaderElement;
+import org.springframework.ws.soap.SoapMessage;
 import org.springframework.ws.transport.context.TransportContext;
 import org.springframework.ws.transport.context.TransportContextHolder;
 import org.springframework.ws.transport.http.HttpServletConnection;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.config.AppConfig;
+import org.techbd.ingest.exceptions.ErrorTraceIdGenerator;
+import org.techbd.ingest.feature.FeatureEnum;
+import org.techbd.ingest.model.RequestContext;
+import org.techbd.ingest.service.MessageProcessorService;
+import org.techbd.ingest.service.soap.DefaultSoapResponseStrategy;
+import org.techbd.ingest.service.soap.SoapResponseStrategy;
+import org.techbd.ingest.service.soap.SoapResponseStrategyFactory;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.LogUtil;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.techbd.ingest.model.RequestContext;
-import org.techbd.ingest.commons.Constants;
-import org.techbd.ingest.exceptions.ErrorTraceIdGenerator;
-import org.techbd.ingest.util.LogUtil;
-import org.techbd.ingest.feature.FeatureEnum;
-import java.io.ByteArrayOutputStream;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.Iterator;
-import javax.xml.namespace.QName;
-import java.util.Arrays;
-import org.springframework.ws.soap.SoapBody;
-import org.springframework.ws.soap.SoapFault;
-
 @ExtendWith(MockitoExtension.class)
-public class WsaHeaderInterceptorTest {
-    @Mock
-    private SoapResponseUtil soapResponseUtil;
+class WsaHeaderInterceptorTest {
 
-    @Mock
-    private MessageProcessorService messageProcessorService;
-
-    @Mock
-    private AppConfig appConfig;
-
-    @Mock
-    private AppLogger appLogger;
-
-    @Mock
-    private TemplateLogger templateLogger;
-
-    @Mock
-    private MessageContext messageContext;
-
-    @Mock
-    private SoapMessage soapMessage;
-
-    @Mock
-    private HttpServletRequest request;
-
-    @Mock
-    private HttpServletResponse response;
+    @Mock private SoapResponseUtil soapResponseUtil;
+    @Mock private MessageProcessorService messageProcessorService;
+    @Mock private AppConfig appConfig;
+    @Mock private AppLogger appLogger;
+    @Mock private TemplateLogger templateLogger;
+    @Mock private SoapResponseStrategyFactory strategyFactory;
+    @Mock private MessageContext messageContext;
+    @Mock private SoapMessage soapMessage;
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
 
     private WsaHeaderInterceptor interceptor;
 
@@ -83,16 +72,17 @@ public class WsaHeaderInterceptorTest {
                 soapResponseUtil,
                 messageProcessorService,
                 appConfig,
-                appLogger);
+                appLogger,
+                strategyFactory);
     }
+
+    // ── handleRequest ─────────────────────────────────────────────────────────
 
     @Test
     void shouldHandleRequest_forWsEndpoint() throws Exception {
-
         mockTransportContext("/ws");
 
         when(messageContext.getRequest()).thenReturn(soapMessage);
-
         doAnswer(invocation -> {
             ByteArrayOutputStream os = invocation.getArgument(0);
             os.write("<soap>req</soap>".getBytes());
@@ -109,7 +99,6 @@ public class WsaHeaderInterceptorTest {
 
     @Test
     void shouldSkipHandleRequest_whenNotWsEndpoint() throws Exception {
-
         mockTransportContext("/other");
 
         boolean result = interceptor.handleRequest(messageContext, new Object());
@@ -119,38 +108,165 @@ public class WsaHeaderInterceptorTest {
     }
 
     @Test
-    void shouldHandleResponse_successfully() throws Exception {
-
+    void shouldUseRawSoapFromRequest_whenAvailable() throws Exception {
         mockTransportContext("/ws");
 
+        when(messageContext.getRequest()).thenReturn(soapMessage);
+        doAnswer(invocation -> {
+            ByteArrayOutputStream os = invocation.getArgument(0);
+            os.write("<soap>original</soap>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any());
+
+        when(request.getAttribute(Constants.RAW_SOAP_ATTRIBUTE))
+                .thenReturn("<soap>from-request</soap>");
+
+        boolean result = interceptor.handleRequest(messageContext, new Object());
+
+        assertTrue(result);
+        verify(messageContext).setProperty(
+                Constants.RAW_SOAP_ATTRIBUTE,
+                "<soap>from-request</soap>");
+    }
+
+    @Test
+    void shouldReturnFalse_andLogWarning_whenExceptionOccursInIsWsEndpoint() throws Exception {
+        TransportContext transportContext = mock(TransportContext.class);
+        when(transportContext.getConnection()).thenThrow(new RuntimeException("boom"));
+        TransportContextHolder.setTransportContext(transportContext);
+
+        boolean result = interceptor.handleRequest(messageContext, new Object());
+
+        assertTrue(result);
+        verify(templateLogger).warn(contains("Error checking request URI"), eq("boom"));
+    }
+
+    // ── handleResponse ────────────────────────────────────────────────────────
+
+    @Test
+    void shouldHandleResponse_successfully_defaultStrategy() throws Exception {
+        mockTransportContext("/ws");
+
+        // Stub ALL getAttribute calls made by handleResponse
         when(request.getAttribute(Constants.INTERACTION_ID)).thenReturn("INT-1");
-
-        when(soapResponseUtil.buildSoapResponse(any(), any()))
-                .thenReturn(soapMessage);
-
-        when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE))
-                .thenReturn("<req/>");
-
+        when(request.getAttribute(Constants.RESPONSE_TYPE)).thenReturn(null);
         when(request.getAttribute(Constants.REQUEST_CONTEXT))
                 .thenReturn(mock(RequestContext.class));
+        when(request.getHeader(Constants.RESPONSE_TYPE)).thenReturn(null);
+
+        when(soapResponseUtil.buildSoapResponse(any(), any())).thenReturn(soapMessage);
+        when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
+
+        SoapResponseStrategy defaultStrategy = mock(DefaultSoapResponseStrategy.class);
+        when(strategyFactory.resolve(isNull())).thenReturn(defaultStrategy);
 
         boolean result = interceptor.handleResponse(messageContext, new Object());
 
         assertTrue(result);
-
-        verify(messageProcessorService).processMessage(
-                any(),
-                eq("<req/>"),
-                any());
+        verify(strategyFactory).resolve(isNull());
+        verify(defaultStrategy).writeResponse(eq("INT-1"), any(), any(), any(), any());
+        verify(messageProcessorService).processMessage(any(), eq("<req/>"), any());
     }
 
     @Test
-    void shouldHandleFault_andLogError() throws Exception {
+    void shouldHandleResponse_mtomStrategy_suppressesSpringWrite() throws Exception {
+        mockTransportContext("/ws");
 
+        when(request.getAttribute(Constants.INTERACTION_ID)).thenReturn("INT-MTOM");
+        when(request.getAttribute(Constants.RESPONSE_TYPE)).thenReturn("mtom");
+        when(request.getAttribute(Constants.REQUEST_CONTEXT))
+                .thenReturn(mock(RequestContext.class));
+
+        when(soapResponseUtil.buildSoapResponse(any(), any())).thenReturn(soapMessage);
+        when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
+
+        SoapResponseStrategy mtomStrategy = mock(SoapResponseStrategy.class);
+        when(strategyFactory.resolve("mtom")).thenReturn(mtomStrategy);
+
+        // messageContext.getResponse() used to drain Spring-WS buffer
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+        doAnswer(invocation -> null).when(soapMessage).writeTo(any(OutputStream.class));
+
+        boolean result = interceptor.handleResponse(messageContext, new Object());
+
+        assertTrue(result);
+        verify(mtomStrategy).writeResponse(eq("INT-MTOM"), any(), any(), any(), any());
+        // Verify Spring-WS secondary write was drained to no-op stream
+        // Note: writeTo is called twice - once for MTOM suppression, once for soapMessageToString
+        verify(soapMessage, times(2)).writeTo(any(OutputStream.class));
+    }
+
+    @Test
+    void shouldHandleResponse_mtomTrubridge_suppressesSpringWrite() throws Exception {
+        mockTransportContext("/ws");
+
+        when(request.getAttribute(Constants.INTERACTION_ID)).thenReturn("INT-TB");
+        when(request.getAttribute(Constants.RESPONSE_TYPE)).thenReturn("mtom_trubridge");
+        when(request.getAttribute(Constants.REQUEST_CONTEXT))
+                .thenReturn(mock(RequestContext.class));
+
+        when(soapResponseUtil.buildSoapResponse(any(), any())).thenReturn(soapMessage);
+        when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
+
+        SoapResponseStrategy tbStrategy = mock(SoapResponseStrategy.class);
+        when(strategyFactory.resolve("mtom_trubridge")).thenReturn(tbStrategy);
+
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+        doAnswer(invocation -> null).when(soapMessage).writeTo(any(OutputStream.class));
+
+        boolean result = interceptor.handleResponse(messageContext, new Object());
+
+        assertTrue(result);
+        verify(tbStrategy).writeResponse(eq("INT-TB"), any(), any(), any(), any());
+        // Note: writeTo is called twice - once for MTOM suppression, once for soapMessageToString
+        verify(soapMessage, times(2)).writeTo(any(OutputStream.class));
+    }
+
+    @Test
+    void shouldHandleResponse_fallsBackToHeader_whenAttributeNull() throws Exception {
+        mockTransportContext("/ws");
+
+        when(request.getAttribute(Constants.INTERACTION_ID)).thenReturn("INT-H");
+        when(request.getAttribute(Constants.RESPONSE_TYPE)).thenReturn(null);
+        when(request.getHeader(Constants.RESPONSE_TYPE)).thenReturn("mtom");
+        when(request.getAttribute(Constants.REQUEST_CONTEXT))
+                .thenReturn(mock(RequestContext.class));
+
+        when(soapResponseUtil.buildSoapResponse(any(), any())).thenReturn(soapMessage);
+        when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
+
+        SoapResponseStrategy mtomStrategy = mock(SoapResponseStrategy.class);
+        when(strategyFactory.resolve("mtom")).thenReturn(mtomStrategy);
+
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+        doAnswer(invocation -> null).when(soapMessage).writeTo(any(OutputStream.class));
+
+        boolean result = interceptor.handleResponse(messageContext, new Object());
+
+        assertTrue(result);
+        verify(strategyFactory).resolve("mtom");
+    }
+
+    @Test
+    void shouldSkipHandleResponse_whenNotWsEndpoint() throws Exception {
+        mockTransportContext("/not-ws");
+
+        boolean result = interceptor.handleResponse(messageContext, new Object());
+
+        assertTrue(result);
+        verifyNoInteractions(soapResponseUtil);
+        verifyNoInteractions(messageProcessorService);
+        verifyNoInteractions(strategyFactory);
+    }
+
+    // ── handleFault ───────────────────────────────────────────────────────────
+
+    @Test
+    void shouldHandleFault_andLogError() throws Exception {
         mockTransportContext("/ws");
 
         when(messageContext.getResponse()).thenReturn(soapMessage);
-        when(messageContext.getProperty("interactionId")).thenReturn("INT-2");
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-2");
 
         doAnswer(invocation -> {
             ByteArrayOutputStream os = invocation.getArgument(0);
@@ -159,15 +275,13 @@ public class WsaHeaderInterceptorTest {
         }).when(soapMessage).writeTo(any());
 
         try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
-                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+             MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
 
-            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
-                    .thenReturn("TRACE-1");
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId).thenReturn("TRACE-1");
 
             boolean result = interceptor.handleFault(messageContext, new Object());
 
             assertTrue(result);
-
             verify(templateLogger).error(
                     contains("SOAP Fault encountered"),
                     eq("INT-2"),
@@ -177,102 +291,21 @@ public class WsaHeaderInterceptorTest {
     }
 
     @Test
-    void shouldHandleAfterCompletion_success() throws Exception {
+    void shouldSkipHandleFault_whenNotWsEndpoint() throws Exception {
+        mockTransportContext("/not-ws");
 
-        mockTransportContext("/ws");
+        boolean result = interceptor.handleFault(messageContext, new Object());
 
-        when(messageContext.getProperty("interactionId")).thenReturn("INT-3");
-
-        interceptor.afterCompletion(messageContext, new Object(), null);
-
-        verify(templateLogger).info(
-                contains("completed"),
-                eq("INT-3"),
-                eq("SUCCESS"));
-    }
-
-    @Test
-    void shouldHandleAfterCompletion_withException() throws Exception {
-
-        mockTransportContext("/ws");
-
-        when(messageContext.getProperty("interactionId")).thenReturn("INT-4");
-
-        Exception ex = new RuntimeException("boom");
-
-        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
-                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
-
-            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
-                    .thenReturn("TRACE-2");
-
-            interceptor.afterCompletion(messageContext, new Object(), ex);
-
-            verify(templateLogger).error(
-                    contains("completed with ERROR"),
-                    eq("INT-4"),
-                    eq("TRACE-2"),
-                    eq("boom"),
-                    eq(ex));
-        }
-    }
-
-    @Test
-    void shouldReturnTrue_whenFeatureEnabled() {
-
-        SoapHeaderElement header = mock(SoapHeaderElement.class);
-
-        when(header.getName()).thenReturn(
-                new QName("ns", "Header", "p"));
-
-        try (MockedStatic<FeatureEnum> featureMock = mockStatic(FeatureEnum.class)) {
-
-            featureMock.when(() -> FeatureEnum.isEnabled(FeatureEnum.IGNORE_MUST_UNDERSTAND_HEADERS)).thenReturn(true);
-
-            assertTrue(interceptor.understands(header));
-        }
-    }
-
-    @Test
-    void shouldExtractFaultString() throws Exception {
-
-        Method method = WsaHeaderInterceptor.class
-                .getDeclaredMethod("extractFaultString", String.class);
-
-        method.setAccessible(true);
-
-        String xml = "<fault><faultstring>Error123</faultstring></fault>";
-
-        String result = (String) method.invoke(interceptor, xml);
-
-        assertEquals("Error123", result);
-    }
-
-    @Test
-    void shouldReturnFalse_whenNoDetailElements() throws Exception {
-
-        SoapFaultDetail detail = mock(SoapFaultDetail.class);
-
-        when(detail.getDetailEntries())
-                .thenReturn(Collections.emptyIterator());
-
-        Method method = WsaHeaderInterceptor.class
-                .getDeclaredMethod("hasDetailElement", SoapFaultDetail.class, String.class);
-
-        method.setAccessible(true);
-
-        boolean result = (boolean) method.invoke(interceptor, detail, "ErrorTraceId");
-
-        assertFalse(result);
+        assertTrue(result);
+        verify(messageContext, never()).getResponse();
+        verify(templateLogger, never()).error(any(), any(), any(), any());
     }
 
     @Test
     void shouldInjectErrorTraceIdIntoFault_whenNotPresent() throws Exception {
-
         mockTransportContext("/ws");
 
-        when(messageContext.getProperty(Constants.INTERACTION_ID))
-                .thenReturn("INT-1");
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-1");
 
         SoapBody soapBody = mock(SoapBody.class);
         SoapFault soapFault = mock(SoapFault.class);
@@ -291,11 +324,16 @@ public class WsaHeaderInterceptorTest {
                 .thenReturn(interactionElement)
                 .thenReturn(traceElement);
 
-        try (MockedStatic<ErrorTraceIdGenerator> mockTrace = mockStatic(ErrorTraceIdGenerator.class);
-                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+        doAnswer(invocation -> {
+            ByteArrayOutputStream os = invocation.getArgument(0);
+            os.write("<fault><faultstring>Error</faultstring></fault>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any());
 
-            mockTrace.when(ErrorTraceIdGenerator::generateErrorTraceId)
-                    .thenReturn("TRACE-1");
+        try (MockedStatic<ErrorTraceIdGenerator> mockTrace = mockStatic(ErrorTraceIdGenerator.class);
+             MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            mockTrace.when(ErrorTraceIdGenerator::generateErrorTraceId).thenReturn("TRACE-1");
 
             interceptor.handleFault(messageContext, new Object());
 
@@ -306,11 +344,9 @@ public class WsaHeaderInterceptorTest {
 
     @Test
     void shouldSkipInjection_whenAlreadyPresent() throws Exception {
-
         mockTransportContext("/ws");
 
-        when(messageContext.getProperty(Constants.INTERACTION_ID))
-                .thenReturn("INT-1");
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-1");
 
         SoapBody soapBody = mock(SoapBody.class);
         SoapFault soapFault = mock(SoapFault.class);
@@ -324,82 +360,119 @@ public class WsaHeaderInterceptorTest {
         Iterator<SoapFaultDetailElement> iterator = Arrays.asList(
                 mockDetailElement("InteractionId"),
                 mockDetailElement("ErrorTraceId")).iterator();
-
         when(faultDetail.getDetailEntries()).thenReturn(iterator);
 
-        interceptor.handleFault(messageContext, new Object());
+        doAnswer(invocation -> {
+            ByteArrayOutputStream os = invocation.getArgument(0);
+            os.write("<fault><faultstring>Error</faultstring></fault>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any());
 
-        // No new elements added
-        verify(faultDetail, never()).addFaultDetailElement(any());
+        try (MockedStatic<ErrorTraceIdGenerator> mockTrace = mockStatic(ErrorTraceIdGenerator.class);
+             MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            mockTrace.when(ErrorTraceIdGenerator::generateErrorTraceId).thenReturn("TRACE-1");
+
+            interceptor.handleFault(messageContext, new Object());
+
+            verify(faultDetail, never()).addFaultDetailElement(any());
+        }
     }
 
     @Test
-    void shouldExtractFaultString_fromSoap12() throws Exception {
+    void shouldHandleException_inHandleFaultOuterCatch() throws Exception {
+        mockTransportContext("/ws");
 
-        String xml = "<soap:Text xml:lang=\"en\">Invalid request</soap:Text>";
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-1");
+        when(messageContext.getResponse()).thenReturn(soapMessage);
+        doThrow(new RuntimeException("write-fail")).when(soapMessage).writeTo(any());
 
-        String result = invokeExtractFaultString(xml);
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+             MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
 
-        assertEquals("Invalid request", result);
-    }
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId).thenReturn("TRACE-2");
 
-    @Test
-    void shouldReturnUnknown_whenNoFaultStringPresent() throws Exception {
-
-        String xml = "<soap>No fault here</soap>";
-
-        String result = invokeExtractFaultString(xml);
-
-        assertEquals("Unknown fault", result);
-    }
-
-    @Test
-    void shouldReturnUnknown_whenIncompleteFaultString() throws Exception {
-
-        String xml = "<faultstring>Error only start tag";
-
-        String result = invokeExtractFaultString(xml);
-
-        assertEquals("Unknown fault", result);
-    }
-
-    @Test
-    void shouldReturnFailureMessage_whenExceptionOccurs() throws Exception {
-
-        String result = invokeExtractFaultString(null);
-
-        assertEquals("Failed to extract fault string", result);
-    }
-
-    @Test
-    void shouldReturnTrue_whenNamespaceMatchesConfigured() {
-
-        SoapHeaderElement header = mock(SoapHeaderElement.class);
-        QName qName = new QName("http://test.com", "TestHeader");
-        when(header.getName()).thenReturn(qName);
-
-        AppConfig.Soap soap = mock(AppConfig.Soap.class);
-        AppConfig.Soap.Wsa wsa = mock(AppConfig.Soap.Wsa.class);
-
-        when(appConfig.getSoap()).thenReturn(soap);
-        when(soap.getWsa()).thenReturn(wsa);
-        when(wsa.getUnderstoodNamespaces())
-                .thenReturn("http://test.com,http://other.com");
-
-        try (MockedStatic<FeatureEnum> mockFeature = mockStatic(FeatureEnum.class)) {
-
-            mockFeature.when(() -> FeatureEnum.isEnabled(FeatureEnum.IGNORE_MUST_UNDERSTAND_HEADERS)).thenReturn(false);
-
-            boolean result = interceptor.understands(header);
+            boolean result = interceptor.handleFault(messageContext, new Object());
 
             assertTrue(result);
+            verify(templateLogger).error(
+                    contains("Exception while processing SOAP fault"),
+                    eq("INT-1"),
+                    eq("TRACE-2"),
+                    contains("write-fail"),
+                    any(Exception.class));
+        }
+    }
+
+    @Test
+    void shouldGenerateErrorTraceId_whenNull_inOuterCatch() throws Exception {
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-1");
+        when(messageContext.getResponse()).thenThrow(new RuntimeException("early-fail"));
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+             MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId).thenReturn("TRACE-NULL");
+
+            boolean result = interceptor.handleFault(messageContext, new Object());
+
+            assertTrue(result);
+            verify(templateLogger).error(
+                    contains("Exception while processing SOAP fault"),
+                    eq("INT-1"),
+                    eq("TRACE-NULL"),
+                    contains("early-fail"),
+                    any(Exception.class));
+        }
+    }
+
+    // ── afterCompletion ───────────────────────────────────────────────────────
+
+    @Test
+    void shouldHandleAfterCompletion_success() throws Exception {
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-3");
+        when(request.getAttribute(Constants.ACK_CONTENT_TYPE)).thenReturn(null);
+
+        interceptor.afterCompletion(messageContext, new Object(), null);
+
+        verify(templateLogger).info(
+                contains("completed"),
+                eq("INT-3"),
+                eq("SUCCESS"));
+    }
+
+    @Test
+    void shouldHandleAfterCompletion_withException() throws Exception {
+        mockTransportContext("/ws");
+
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-4");
+        when(request.getAttribute(Constants.ACK_CONTENT_TYPE)).thenReturn(null);
+
+        Exception ex = new RuntimeException("boom");
+
+        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
+             MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
+
+            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId).thenReturn("TRACE-2");
+
+            interceptor.afterCompletion(messageContext, new Object(), ex);
+
+            verify(templateLogger).error(
+                    contains("completed with ERROR"),
+                    eq("INT-4"),
+                    eq("TRACE-2"),
+                    eq("boom"),
+                    eq(ex));
         }
     }
 
     @Test
     void shouldSkipAfterCompletion_whenNotWsEndpoint() throws Exception {
-
-        mockTransportContext("/not-ws"); // IMPORTANT
+        mockTransportContext("/not-ws");
 
         interceptor.afterCompletion(messageContext, new Object(), null);
 
@@ -408,25 +481,19 @@ public class WsaHeaderInterceptorTest {
 
     @Test
     void shouldOverrideContentType_whenAckContentTypePresent() throws Exception {
-
         mockTransportContext("/ws");
 
-        when(messageContext.getProperty(Constants.INTERACTION_ID))
-                .thenReturn("INT-1");
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-1");
+        when(request.getAttribute(Constants.ACK_CONTENT_TYPE)).thenReturn("application/xml");
 
-        when(request.getAttribute(Constants.ACK_CONTENT_TYPE))
-                .thenReturn("application/xml");
-
-        HttpServletConnection connection = (HttpServletConnection) TransportContextHolder.getTransportContext()
-                .getConnection();
-
+        HttpServletConnection connection =
+                (HttpServletConnection) TransportContextHolder.getTransportContext().getConnection();
         when(connection.getHttpServletResponse()).thenReturn(response);
 
         interceptor.afterCompletion(messageContext, new Object(), null);
 
         verify(response).setHeader("Content-Type", "application/xml");
         verify(response).setContentType("application/xml");
-
         verify(templateLogger).info(
                 contains("Overriding response content type"),
                 eq("application/xml"),
@@ -435,22 +502,15 @@ public class WsaHeaderInterceptorTest {
 
     @Test
     void shouldLogWarning_whenOverrideContentTypeFails() throws Exception {
-
         mockTransportContext("/ws");
 
-        when(messageContext.getProperty(Constants.INTERACTION_ID))
-                .thenReturn("INT-1");
+        when(messageContext.getProperty(Constants.INTERACTION_ID)).thenReturn("INT-1");
+        when(request.getAttribute(Constants.ACK_CONTENT_TYPE)).thenReturn("application/xml");
 
-        when(request.getAttribute(Constants.ACK_CONTENT_TYPE))
-                .thenReturn("application/xml");
-
-        HttpServletConnection connection = (HttpServletConnection) TransportContextHolder.getTransportContext()
-                .getConnection();
-
+        HttpServletConnection connection =
+                (HttpServletConnection) TransportContextHolder.getTransportContext().getConnection();
         when(connection.getHttpServletResponse()).thenReturn(response);
-
-        doThrow(new RuntimeException("fail"))
-                .when(response).setHeader(any(), any());
+        doThrow(new RuntimeException("fail")).when(response).setHeader(any(), any());
 
         interceptor.afterCompletion(messageContext, new Object(), null);
 
@@ -460,182 +520,109 @@ public class WsaHeaderInterceptorTest {
                 contains("fail"));
     }
 
-    @Test
-    void shouldSkipHandleFault_whenNotWsEndpoint() throws Exception {
-
-        mockTransportContext("/not-ws");
-
-        boolean result = interceptor.handleFault(messageContext, new Object());
-
-        assertTrue(result);
-        verify(messageContext, never()).getResponse();
-        verify(templateLogger, never()).error(any(), any(), any(), any());
-    }
+    // ── understands ───────────────────────────────────────────────────────────
 
     @Test
-    void shouldSkipHandleResponse_whenNotWsEndpoint() throws Exception {
+    void shouldReturnTrue_whenFeatureEnabled() {
+        SoapHeaderElement header = mock(SoapHeaderElement.class);
+        when(header.getName()).thenReturn(new QName("ns", "Header", "p"));
 
-        mockTransportContext("/not-ws");
+        try (MockedStatic<FeatureEnum> featureMock = mockStatic(FeatureEnum.class)) {
+            featureMock.when(() -> FeatureEnum.isEnabled(
+                    FeatureEnum.IGNORE_MUST_UNDERSTAND_HEADERS)).thenReturn(true);
 
-        boolean result = interceptor.handleResponse(messageContext, new Object());
-
-        assertTrue(result);
-
-        verifyNoInteractions(soapResponseUtil);
-        verifyNoInteractions(messageProcessorService);
-        verify(messageContext, never()).getProperty(any());
-    }
-
-    @Test
-    void shouldUseRawSoapFromRequest_whenAvailable() throws Exception {
-
-        mockTransportContext("/ws");
-
-        when(messageContext.getRequest()).thenReturn(soapMessage);
-
-        doAnswer(invocation -> {
-            ByteArrayOutputStream os = invocation.getArgument(0);
-            os.write("<soap>original</soap>".getBytes());
-            return null;
-        }).when(soapMessage).writeTo(any());
-
-        when(request.getAttribute(Constants.RAW_SOAP_ATTRIBUTE))
-                .thenReturn("<soap>from-request</soap>");
-
-        boolean result = interceptor.handleRequest(messageContext, new Object());
-
-        assertTrue(result);
-
-        verify(messageContext).setProperty(
-                Constants.RAW_SOAP_ATTRIBUTE,
-                "<soap>from-request</soap>");
-
-        verify(templateLogger, never()).info(any(), any());
-    }
-
-    @Test
-    void shouldReturnFalse_andLogWarning_whenExceptionOccursInIsWsEndpoint() throws Exception {
-
-        TransportContext transportContext = mock(TransportContext.class);
-
-        when(transportContext.getConnection())
-                .thenThrow(new RuntimeException("boom"));
-
-        TransportContextHolder.setTransportContext(transportContext);
-
-        boolean result = interceptor.handleRequest(messageContext, new Object());
-
-        assertTrue(result);
-
-        verify(templateLogger).warn(
-                contains("Error checking request URI"),
-                eq("boom"));
-    }
-
-    @Test
-    void shouldHandleException_inHandleFaultOuterCatch() throws Exception {
-
-        mockTransportContext("/ws");
-
-        when(messageContext.getProperty(Constants.INTERACTION_ID))
-                .thenReturn("INT-1");
-
-        when(messageContext.getResponse()).thenReturn(soapMessage);
-
-        doThrow(new RuntimeException("write-fail"))
-                .when(soapMessage).writeTo(any());
-
-        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
-                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
-
-            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
-                    .thenReturn("TRACE-2");
-
-            boolean result = interceptor.handleFault(messageContext, new Object());
-
-            assertTrue(result);
-
-            verify(templateLogger).error(
-                    contains("Exception while processing SOAP fault"),
-                    eq("INT-1"),
-                    eq("TRACE-2"),
-                    contains("write-fail"),
-                    any(Exception.class));
-
-            logMock.verify(() -> LogUtil.logDetailedError(
-                    eq(500),
-                    contains("Exception while processing SOAP fault"),
-                    eq("INT-1"),
-                    eq("TRACE-2"),
-                    any(Exception.class)));
+            assertTrue(interceptor.understands(header));
         }
     }
 
     @Test
-    void shouldGenerateErrorTraceId_whenNull_inOuterCatch() throws Exception {
+    void shouldReturnTrue_whenNamespaceMatchesConfigured() {
+        SoapHeaderElement header = mock(SoapHeaderElement.class);
+        QName qName = new QName("http://test.com", "TestHeader");
+        when(header.getName()).thenReturn(qName);
 
-        mockTransportContext("/ws");
+        AppConfig.Soap soap = mock(AppConfig.Soap.class);
+        AppConfig.Soap.Wsa wsa = mock(AppConfig.Soap.Wsa.class);
+        when(appConfig.getSoap()).thenReturn(soap);
+        when(soap.getWsa()).thenReturn(wsa);
+        when(wsa.getUnderstoodNamespaces()).thenReturn("http://test.com,http://other.com");
 
-        when(messageContext.getProperty(Constants.INTERACTION_ID))
-                .thenReturn("INT-1");
+        try (MockedStatic<FeatureEnum> mockFeature = mockStatic(FeatureEnum.class)) {
+            mockFeature.when(() -> FeatureEnum.isEnabled(
+                    FeatureEnum.IGNORE_MUST_UNDERSTAND_HEADERS)).thenReturn(false);
 
-        when(messageContext.getResponse())
-                .thenThrow(new RuntimeException("early-fail"));
-
-        try (MockedStatic<ErrorTraceIdGenerator> traceMock = mockStatic(ErrorTraceIdGenerator.class);
-                MockedStatic<LogUtil> logMock = mockStatic(LogUtil.class)) {
-
-            traceMock.when(ErrorTraceIdGenerator::generateErrorTraceId)
-                    .thenReturn("TRACE-NULL");
-
-            boolean result = interceptor.handleFault(messageContext, new Object());
-
-            assertTrue(result);
-
-            verify(templateLogger).error(
-                    contains("Exception while processing SOAP fault"),
-                    eq("INT-1"),
-                    eq("TRACE-NULL"), // <-- generated in catch block
-                    contains("early-fail"),
-                    any(Exception.class));
-
-            logMock.verify(() -> LogUtil.logDetailedError(
-                    eq(500),
-                    contains("Exception while processing SOAP fault"),
-                    eq("INT-1"),
-                    eq("TRACE-NULL"),
-                    any(Exception.class)));
+            assertTrue(interceptor.understands(header));
         }
     }
 
-    private String invokeExtractFaultString(String xml) throws Exception {
+    // ── private method tests ──────────────────────────────────────────────────
+
+    @Test
+    void shouldExtractFaultString() throws Exception {
         Method method = WsaHeaderInterceptor.class
                 .getDeclaredMethod("extractFaultString", String.class);
-
         method.setAccessible(true);
 
-        return (String) method.invoke(interceptor, xml);
+        String xml = "<fault><faultstring>Error123</faultstring></fault>";
+        assertEquals("Error123", method.invoke(interceptor, xml));
     }
+
+    @Test
+    void shouldExtractFaultString_fromSoap12() throws Exception {
+        Method method = WsaHeaderInterceptor.class
+                .getDeclaredMethod("extractFaultString", String.class);
+        method.setAccessible(true);
+
+        String xml = "<soap:Text xml:lang=\"en\">Invalid request</soap:Text>";
+        assertEquals("Invalid request", method.invoke(interceptor, xml));
+    }
+
+    @Test
+    void shouldReturnUnknown_whenNoFaultStringPresent() throws Exception {
+        Method method = WsaHeaderInterceptor.class
+                .getDeclaredMethod("extractFaultString", String.class);
+        method.setAccessible(true);
+
+        assertEquals("Unknown fault", method.invoke(interceptor, "<soap>No fault</soap>"));
+    }
+
+    @Test
+    void shouldReturnFailureMessage_whenExceptionOccurs() throws Exception {
+        Method method = WsaHeaderInterceptor.class
+                .getDeclaredMethod("extractFaultString", String.class);
+        method.setAccessible(true);
+
+        assertEquals("Failed to extract fault string", method.invoke(interceptor, (Object) null));
+    }
+
+    @Test
+    void shouldReturnFalse_whenNoDetailElements() throws Exception {
+        SoapFaultDetail detail = mock(SoapFaultDetail.class);
+        when(detail.getDetailEntries()).thenReturn(Collections.emptyIterator());
+
+        Method method = WsaHeaderInterceptor.class
+                .getDeclaredMethod("hasDetailElement",
+                        org.springframework.ws.soap.SoapFaultDetail.class, String.class);
+        method.setAccessible(true);
+
+        assertFalse((boolean) method.invoke(interceptor, detail, "ErrorTraceId"));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
 
     private SoapFaultDetailElement mockDetailElement(String name) {
         SoapFaultDetailElement element = mock(SoapFaultDetailElement.class);
-        QName qName = new QName("ns", name);
-        when(element.getName()).thenReturn(qName);
+        when(element.getName()).thenReturn(new QName("ns", name));
         return element;
     }
 
     private void mockTransportContext(String uri) {
-
         HttpServletConnection connection = mock(HttpServletConnection.class);
-
         when(connection.getHttpServletRequest()).thenReturn(request);
-
         when(request.getRequestURI()).thenReturn(uri);
 
         TransportContext transportContext = mock(TransportContext.class);
         when(transportContext.getConnection()).thenReturn(connection);
-
         TransportContextHolder.setTransportContext(transportContext);
     }
-
 }

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategyTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategyTest.java
@@ -1,0 +1,56 @@
+package org.techbd.ingest.service.soap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.TemplateLogger;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultSoapResponseStrategyTest {
+
+    @Mock private AppLogger appLogger;
+    @Mock private TemplateLogger templateLogger;
+    @Mock private MessageContext messageContext;
+    @Mock private SoapMessage soapMessage;
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+
+    private DefaultSoapResponseStrategy strategy;
+
+    @BeforeEach
+    void setup() {
+        when(appLogger.getLogger(any())).thenReturn(templateLogger);
+        strategy = new DefaultSoapResponseStrategy(appLogger);
+    }
+
+    @Test
+    void writeResponse_isNoOp_doesNotTouchResponse() throws Exception {
+        // DefaultSoapResponseStrategy is intentionally a no-op.
+        // It must not write to response, set headers, or throw.
+        assertDoesNotThrow(() ->
+                strategy.writeResponse("INT-1", messageContext, request, response, soapMessage));
+
+        verifyNoInteractions(response);
+        verifyNoInteractions(messageContext);
+        verifyNoInteractions(soapMessage);
+        verifyNoInteractions(request);
+    }
+
+    @Test
+    void writeResponse_withNullInteractionId_doesNotThrow() {
+        assertDoesNotThrow(() ->
+                strategy.writeResponse(null, messageContext, request, response, soapMessage));
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategyTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategyTest.java
@@ -1,0 +1,239 @@
+package org.techbd.ingest.service.soap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class MtomSoapResponseStrategyTest {
+
+    @Mock private SoapResponseUtil soapResponseUtil;
+    @Mock private AppLogger appLogger;
+    @Mock private TemplateLogger templateLogger;
+    @Mock private MessageContext messageContext;
+    @Mock private SoapMessage soapMessage;
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+
+    private MtomSoapResponseStrategy strategy;
+
+    @BeforeEach
+    void setup() {
+        when(appLogger.getLogger(any())).thenReturn(templateLogger);
+        strategy = new MtomSoapResponseStrategy(soapResponseUtil, appLogger);
+    }
+
+    // ── SOAP 1.2 (default / application/soap+xml) ─────────────────────────────
+
+    @Test
+    void writeResponse_soap12_setsCorrectContentTypeHeader() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BOUNDARY_123");
+        when(soapResponseUtil.generateUuid()).thenReturn("uuid-456");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<soap:Envelope/>");
+        when(request.getContentType()).thenReturn("application/soap+xml");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-1", messageContext, request, response, soapMessage);
+
+        verify(response).setHeader(eq("Content-Type"), contains("multipart/related"));
+        verify(response).setHeader(eq("Content-Type"), contains("boundary=\"BOUNDARY_123\""));
+        verify(response).setHeader(eq("Content-Type"), contains("type=\"application/xop+xml\""));
+        verify(response).setHeader(eq("Content-Type"), contains("start-info=\"application/soap+xml\""));
+        verify(response).setHeader(eq("Content-Type"),
+                contains("action=\"urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b\""));
+    }
+
+    @Test
+    void writeResponse_soap12_innerPartTypeIsApplicationSoapXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("TESTBOUNDARY");
+        when(soapResponseUtil.generateUuid()).thenReturn("test-uuid");
+        when(soapResponseUtil.serializeSoapMessage(any(), any()))
+                .thenReturn("<soap:Envelope>body</soap:Envelope>");
+        when(request.getContentType()).thenReturn("application/soap+xml");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-1", messageContext, request, response, soapMessage);
+
+        String body = captured.toString();
+        assertTrue(body.contains("--TESTBOUNDARY"));
+        assertTrue(body.contains("<soap:Envelope>body</soap:Envelope>"));
+        assertTrue(body.contains("Content-Type: application/xop+xml; charset=UTF-8; type=\"application/soap+xml\""));
+        assertTrue(body.contains("--TESTBOUNDARY--"));
+    }
+
+    // ── SOAP 1.1 (text/xml via Content-Type) ──────────────────────────────────
+
+    @Test
+    void writeResponse_soap11_viaContentType_outerStartInfoIsTextXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BOUNDARY_11");
+        when(soapResponseUtil.generateUuid()).thenReturn("uuid-11");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<s11:Envelope/>");
+        when(request.getContentType()).thenReturn("text/xml");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-11", messageContext, request, response, soapMessage);
+
+        verify(response).setHeader(eq("Content-Type"), contains("start-info=\"text/xml\""));
+        // action and other outer params must still be present
+        verify(response).setHeader(eq("Content-Type"),
+                contains("action=\"urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b\""));
+    }
+
+    @Test
+    void writeResponse_soap11_viaContentType_innerPartTypeIsTextXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BND11");
+        when(soapResponseUtil.generateUuid()).thenReturn("uuid-11");
+        when(soapResponseUtil.serializeSoapMessage(any(), any()))
+                .thenReturn("<s11:Envelope>11</s11:Envelope>");
+        when(request.getContentType()).thenReturn("text/xml");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-11", messageContext, request, response, soapMessage);
+
+        String body = captured.toString();
+        assertTrue(body.contains("Content-Type: application/xop+xml; charset=UTF-8; type=\"text/xml\""),
+                "Inner MIME part must use text/xml for SOAP 1.1");
+        assertFalse(body.contains("type=\"application/soap+xml\""),
+                "Inner MIME part must NOT use application/soap+xml for SOAP 1.1");
+    }
+
+    @Test
+    void writeResponse_soap11_viaContentType_notContainApplicationSoapXmlInStartInfo() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+        when(request.getContentType()).thenReturn("text/xml");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-11", messageContext, request, response, soapMessage);
+
+        // Capture the exact Content-Type header value set on the response
+        org.mockito.ArgumentCaptor<String> captor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(eq("Content-Type"), captor.capture());
+        assertFalse(captor.getValue().contains("start-info=\"application/soap+xml\""),
+                "start-info must NOT be application/soap+xml for SOAP 1.1");
+    }
+
+    // ── SOAP 1.1 (text/xml via SOAPAction header, no Content-Type) ────────────
+
+    @Test
+    void writeResponse_soap11_viaSoapActionHeader_usesTextXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BSOAP");
+        when(soapResponseUtil.generateUuid()).thenReturn("u-soap");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+        // No Content-Type — detection falls through to SOAPAction header
+        when(request.getContentType()).thenReturn(null);
+        when(request.getHeader("SOAPAction")).thenReturn("\"urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b\"");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-SA", messageContext, request, response, soapMessage);
+
+        verify(response).setHeader(eq("Content-Type"), contains("start-info=\"text/xml\""));
+        String body = captured.toString();
+        assertTrue(body.contains("type=\"text/xml\""),
+                "Inner MIME part must use text/xml when SOAPAction header is present");
+    }
+
+    // ── SOAP 1.2 (no Content-Type, no SOAPAction) — defaults to SOAP 1.2 ──────
+
+    @Test
+    void writeResponse_noContentTypeNoSoapAction_defaultsToSoap12() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BD");
+        when(soapResponseUtil.generateUuid()).thenReturn("ud");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+        when(request.getContentType()).thenReturn(null);
+        when(request.getHeader("SOAPAction")).thenReturn(null);
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-D", messageContext, request, response, soapMessage);
+
+        verify(response).setHeader(eq("Content-Type"), contains("start-info=\"application/soap+xml\""));
+    }
+
+    // ── Shared behaviour ──────────────────────────────────────────────────────
+
+    @Test
+    void writeResponse_setsAckContentTypeAttribute() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-1", messageContext, request, response, soapMessage);
+
+        verify(request).setAttribute(eq(Constants.ACK_CONTENT_TYPE), anyString());
+    }
+
+    @Test
+    void writeResponse_swallowsBrokenPipeException() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        when(response.getOutputStream()).thenThrow(new IOException("Broken pipe"));
+
+        assertDoesNotThrow(() ->
+                strategy.writeResponse("INT-1", messageContext, request, response, soapMessage));
+    }
+
+    @Test
+    void writeResponse_rethrowsNonBrokenPipeIOException() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        when(response.getOutputStream()).thenThrow(new IOException("Disk full"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                strategy.writeResponse("INT-1", messageContext, request, response, soapMessage));
+        assertTrue(ex.getMessage().contains("Failed to write MTOM response"));
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private ServletOutputStream outputStreamOf(ByteArrayOutputStream baos) {
+        return new ServletOutputStream() {
+            @Override public void write(int b) { baos.write(b); }
+            @Override public void write(byte[] b, int off, int len) { baos.write(b, off, len); }
+            @Override public boolean isReady() { return true; }
+            @Override public void setWriteListener(WriteListener wl) {}
+        };
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactoryTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactoryTest.java
@@ -1,0 +1,88 @@
+package org.techbd.ingest.service.soap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+
+@ExtendWith(MockitoExtension.class)
+class SoapResponseStrategyFactoryTest {
+
+    @Mock private SoapResponseUtil soapResponseUtil;
+    @Mock private AppLogger appLogger;
+    @Mock private TemplateLogger templateLogger;
+
+    private SoapResponseStrategyFactory factory;
+
+    @BeforeEach
+    void setup() {
+        when(appLogger.getLogger(any())).thenReturn(templateLogger);
+        factory = new SoapResponseStrategyFactory(soapResponseUtil, appLogger);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "\t"})
+    void shouldResolveDefaultStrategy_whenResponseTypeAbsentOrBlank(String responseType) {
+        SoapResponseStrategy strategy = factory.resolve(responseType);
+        assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
+    }
+
+    @Test
+    void shouldResolveDefaultStrategy_whenResponseTypeUnknown() {
+        SoapResponseStrategy strategy = factory.resolve("unknown_type");
+        assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
+    }
+
+    @Test
+    void shouldResolveMtomStrategy_whenResponseTypeMtom() {
+        SoapResponseStrategy strategy = factory.resolve("mtom");
+        assertInstanceOf(MtomSoapResponseStrategy.class, strategy);
+    }
+
+    @Test
+    void shouldResolveMtomStrategy_caseInsensitive() {
+        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("MTOM"));
+        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("Mtom"));
+        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("  mtom  "));
+    }
+
+    @Test
+    void shouldResolveTruBridgeStrategy_whenResponseTypeMtomTrubridge() {
+        SoapResponseStrategy strategy = factory.resolve("mtom_trubridge");
+        assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class, strategy);
+    }
+
+    @Test
+    void shouldResolveTruBridgeStrategy_caseInsensitive() {
+        assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class,
+                factory.resolve("MTOM_TRUBRIDGE"));
+        assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class,
+                factory.resolve("Mtom_TruBridge"));
+        assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class,
+                factory.resolve("  mtom_trubridge  "));
+    }
+
+    @Test
+    void shouldReturnSameInstance_forRepeatedCalls() {
+        // Strategies are singletons — same instance returned each call
+        SoapResponseStrategy first  = factory.resolve("mtom");
+        SoapResponseStrategy second = factory.resolve("mtom");
+        assertSame(first, second);
+
+        SoapResponseStrategy tb1 = factory.resolve("mtom_trubridge");
+        SoapResponseStrategy tb2 = factory.resolve("mtom_trubridge");
+        assertSame(tb1, tb2);
+    }
+}

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategyTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategyTest.java
@@ -1,0 +1,269 @@
+package org.techbd.ingest.service.soap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.SoapMessage;
+import org.techbd.ingest.commons.Constants;
+import org.techbd.ingest.util.AppLogger;
+import org.techbd.ingest.util.SoapResponseUtil;
+import org.techbd.ingest.util.TemplateLogger;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class TruBridgeMtomSoapResponseStrategyTest {
+
+    @Mock private SoapResponseUtil soapResponseUtil;
+    @Mock private AppLogger appLogger;
+    @Mock private TemplateLogger templateLogger;
+    @Mock private MessageContext messageContext;
+    @Mock private SoapMessage soapMessage;
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+
+    private TruBridgeMtomSoapResponseStrategy strategy;
+
+    @BeforeEach
+    void setup() {
+        when(appLogger.getLogger(any())).thenReturn(templateLogger);
+        strategy = new TruBridgeMtomSoapResponseStrategy(soapResponseUtil, appLogger);
+    }
+
+    // ── TruBridge wire-format invariants (same regardless of SOAP version) ────
+
+    @Test
+    void writeResponse_setsUnquotedContentTypeHeader() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("TBBOUNDARY");
+        when(soapResponseUtil.generateUuid()).thenReturn("tb-uuid");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage);
+
+        // TruBridge wire format: unquoted boundary and type values
+        verify(response).setHeader(eq("Content-Type"), contains("boundary=TBBOUNDARY"));
+        verify(response).setHeader(eq("Content-Type"), contains("type=application/xop+xml"));
+    }
+
+    @Test
+    void writeResponse_outerContentType_doesNotContainStartOrStartInfoOrAction() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage);
+
+        org.mockito.ArgumentCaptor<String> captor =
+                org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(eq("Content-Type"), captor.capture());
+        String ct = captor.getValue();
+        assertFalse(ct.contains("start="),      "Outer Content-Type must not contain 'start='");
+        assertFalse(ct.contains("start-info="), "Outer Content-Type must not contain 'start-info='");
+        assertFalse(ct.contains("action="),     "Outer Content-Type must not contain 'action='");
+    }
+
+    @Test
+    void writeResponse_setsBinaryTransferEncodingHeader() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage);
+
+        verify(response).setHeader("Content-Transfer-Encoding", "binary");
+    }
+
+    @Test
+    void writeResponse_bodyContainsMimeBoundaryAndSoapXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("TBBND");
+        when(soapResponseUtil.generateUuid()).thenReturn("tb-u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any()))
+                .thenReturn("<soap:Envelope>tb</soap:Envelope>");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage);
+
+        String body = captured.toString();
+        assertTrue(body.contains("--TBBND"));
+        assertTrue(body.contains("<soap:Envelope>tb</soap:Envelope>"));
+        assertTrue(body.contains("Content-Transfer-Encoding: binary"));
+        assertTrue(body.contains("--TBBND--"));
+    }
+
+    // ── SOAP 1.2 (application/soap+xml) ──────────────────────────────────────
+
+    @Test
+    void writeResponse_soap12_innerPartTypeIsApplicationSoapXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BND12");
+        when(soapResponseUtil.generateUuid()).thenReturn("uuid-12");
+        when(soapResponseUtil.serializeSoapMessage(any(), any()))
+                .thenReturn("<s12:Envelope>12</s12:Envelope>");
+        when(request.getContentType()).thenReturn("application/soap+xml");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-12", messageContext, request, response, soapMessage);
+
+        String body = captured.toString();
+        assertTrue(body.contains("Content-Type: application/xop+xml; charset=UTF-8; type=\"application/soap+xml\""),
+                "Inner MIME part must use application/soap+xml for SOAP 1.2");
+        assertFalse(body.contains("type=\"text/xml\""),
+                "Inner MIME part must NOT use text/xml for SOAP 1.2");
+    }
+
+    // ── SOAP 1.1 (text/xml via Content-Type) ──────────────────────────────────
+
+    @Test
+    void writeResponse_soap11_viaContentType_innerPartTypeIsTextXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BND11");
+        when(soapResponseUtil.generateUuid()).thenReturn("uuid-11");
+        when(soapResponseUtil.serializeSoapMessage(any(), any()))
+                .thenReturn("<s11:Envelope>11</s11:Envelope>");
+        when(request.getContentType()).thenReturn("text/xml");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-11", messageContext, request, response, soapMessage);
+
+        String body = captured.toString();
+        assertTrue(body.contains("Content-Type: application/xop+xml; charset=UTF-8; type=\"text/xml\""),
+                "Inner MIME part must use text/xml for SOAP 1.1");
+        assertFalse(body.contains("type=\"application/soap+xml\""),
+                "Inner MIME part must NOT use application/soap+xml for SOAP 1.1");
+    }
+
+    // ── SOAP 1.1 (text/xml via SOAPAction header, no Content-Type) ────────────
+
+    @Test
+    void writeResponse_soap11_viaSoapActionHeader_innerPartTypeIsTextXml() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BNDSA");
+        when(soapResponseUtil.generateUuid()).thenReturn("uuid-sa");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+        when(request.getContentType()).thenReturn(null);
+        when(request.getHeader("SOAPAction")).thenReturn("\"urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b\"");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-SA", messageContext, request, response, soapMessage);
+
+        String body = captured.toString();
+        assertTrue(body.contains("type=\"text/xml\""),
+                "Inner MIME part must use text/xml when SOAPAction header signals SOAP 1.1");
+    }
+
+    // ── SOAP 1.2 (no Content-Type, no SOAPAction) — defaults to SOAP 1.2 ──────
+
+    @Test
+    void writeResponse_noContentTypeNoSoapAction_defaultsToSoap12() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("BD");
+        when(soapResponseUtil.generateUuid()).thenReturn("ud");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+        when(request.getContentType()).thenReturn(null);
+        when(request.getHeader("SOAPAction")).thenReturn(null);
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-D", messageContext, request, response, soapMessage);
+
+        String body = captured.toString();
+        assertTrue(body.contains("type=\"application/soap+xml\""),
+                "Must default to application/soap+xml when no SOAP version signals are present");
+    }
+
+    // ── Shared behaviour ──────────────────────────────────────────────────────
+
+    @Test
+    void writeResponse_setsAckContentTypeAttribute() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(outputStreamOf(captured));
+
+        strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage);
+
+        verify(request).setAttribute(eq(Constants.ACK_CONTENT_TYPE), anyString());
+    }
+
+    @Test
+    void writeResponse_swallowsBrokenPipeException() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        when(response.getOutputStream()).thenThrow(new IOException("Broken pipe"));
+
+        assertDoesNotThrow(() ->
+                strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage));
+    }
+
+    @Test
+    void writeResponse_swallowsClientAbortException() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        IOException clientAbort = new IOException("Connection reset by peer") {
+            @Override public String toString() {
+                return "org.apache.catalina.connector.ClientAbortException: " + getMessage();
+            }
+        };
+        when(response.getOutputStream()).thenThrow(clientAbort);
+
+        assertDoesNotThrow(() ->
+                strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage));
+    }
+
+    @Test
+    void writeResponse_rethrowsNonBrokenPipeIOException() throws Exception {
+        when(soapResponseUtil.generateMimeBoundary()).thenReturn("B");
+        when(soapResponseUtil.generateUuid()).thenReturn("u");
+        when(soapResponseUtil.serializeSoapMessage(any(), any())).thenReturn("<env/>");
+
+        when(response.getOutputStream()).thenThrow(new IOException("Disk full"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage));
+        assertTrue(ex.getMessage().contains("Failed to write TruBridge MTOM response"));
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private ServletOutputStream outputStreamOf(ByteArrayOutputStream baos) {
+        return new ServletOutputStream() {
+            @Override public void write(int b) { baos.write(b); }
+            @Override public void write(byte[] b, int off, int len) { baos.write(b, off, len); }
+            @Override public boolean isReady() { return true; }
+            @Override public void setWriteListener(WriteListener wl) {}
+        };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1132.0</revision>
+        <revision>0.1133.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Add standard MTOM strategy
  - Content-Type parameters with start/start-info/action headers
  - MIME multipart body with XOP include references

- Add TruBridge MTOM strategy
  - Omits start, start-info, and action parameters
   - MIME multipart body with XOP include references
- Add unit tests for SOAP response strategies