### PR TITLE
fix: update Mirth Connect channel to modify Grouper Observation Resource ID generation logic #3080

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-channel-files/mirth-connect/TechBD CCD Workflow.xml
+++ b/integration-artifacts/ccda/ccda-techbd-channel-files/mirth-connect/TechBD CCD Workflow.xml
@@ -2,8 +2,8 @@
   <id>0cefb37a-ca0a-48cc-85a1-aa0b727d26a2</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version: 0.4.45</description>
-  <revision>5</revision>
+  <description>Version: 0.4.46</description>
+  <revision>8</revision>
   <sourceConnector version="4.5.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -1145,9 +1145,12 @@ function getPatientMRN(patientRoles) {
     channelMap.put(&apos;Patient-MRN&apos;, extensionAttr);
 }
 
-function getEncounterEffectiveTime(encounterNodeList) {
-    var fallbackTime = new java.text.SimpleDateFormat(&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss.SS&apos;Z&apos;&quot;).format(new java.util.Date());
-    var effectiveTimeOut = &apos;&apos;;
+function getEncounterEffectiveTime(encounterNodeList, returnFallBackTime) {
+    var currentTime = new java.text.SimpleDateFormat(&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss.SS&apos;Z&apos;&quot;).format(new java.util.Date());
+    var fallbackTime = &apos;&apos;;
+    if (returnFallBackTime != &apos;False&apos;) {
+    		fallbackTime = currentTime;
+    }
 
     if (!encounterNodeList || encounterNodeList.length === 0) {	
         return fallbackTime;
@@ -1499,33 +1502,138 @@ function setResourceIdParameters(transformer) {
 	    logger.error(&quot;Error accessing encounter: &quot; + e);
 	}
 
-	///Grouper Observation Resource 
-	var mrn = channelMap.get(&apos;Patient-MRN&apos;) || &quot;&quot;;
-     var cin = channelMap.get(&apos;patientCIN&apos;) || &quot;&quot;;
-     var currentTimestamp = new java.text.SimpleDateFormat(&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss.SS&apos;Z&apos;&quot;).format(new java.util.Date());
-	var combinedText = mrn + cin + &apos;Grouper Observation Resource&apos; + currentTimestamp;
+	/// ** Grouper Observation Resource ** ///
+	// Get grouper Screening Code
+     // For Epic files, use the value of the header variable,&apos;X-TechBD-Screening-Code&apos;, as the Grouper Screening Code, otherwise use the LOINC code &apos;100698-0&apos;
+     // For Medent files, take the value from code.code
+     var grouperScreeningCode = channelMap.get(&apos;X-TechBD-Screening-Code&apos;);
+	var grouperScreeningEffectiveTime = &apos;&apos;;
+	
+	// Extract effectiveTime (COMMON for all vendors)
+	try {
+	    var observations = xmlDoc.*::component
+	        .*::structuredBody
+	        .*::component
+	        .*::section.(@ID == &apos;observations&apos;)
+	        .*::entry
+	        .*::observation;
+	
+	    if (observations != undefined &amp;&amp; observations.length() &gt; 0) {
+	        var obs = observations[0]; // first observation (same as [1] in XSLT)
+	
+	        if (obs.*::effectiveTime) {
+	            var effTime = obs.*::effectiveTime.@value.toString().trim();
+	
+	            // fallback to low/@value
+	            if (!effTime || effTime == &apos;&apos;) {
+	                effTime = obs.*::effectiveTime.*::low.@value.toString().trim();
+	            }
+	
+	            grouperScreeningEffectiveTime = effTime;
+	        }
+	    }
+	
+	    logger.info(&quot;Grouper Screening Effective Time: &quot; + grouperScreeningEffectiveTime);
+	
+	} catch (e) {
+	    logger.error(&quot;Error extracting grouperScreeningEffectiveTime: &quot; + e);
+	}
+
+	if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Epic&apos; || channelMap.get(&apos;ehrVendor&apos;) == &apos;Athenahealth&apos;)
+	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
+	
+	    grouperScreeningCode = &apos;100698-0&apos;;
+	    logger.info(&quot;Defaulting grouperScreeningCode to 100698-0 for Epic&quot;);
+	
+	} else if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Medent&apos;)
+	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
+	
+	    // Try to extract from CCDA observations
+	    try {
+	        var observations = xmlDoc.*::component
+	            .*::structuredBody
+	            .*::component
+	            .*::section.(@ID == &apos;observations&apos;)
+	            .*::entry
+	            .*::observation;
+	
+	        if (observations != undefined &amp;&amp; observations.length() &gt; 0) {
+	            for each (var obs in observations) {
+	                if (obs.*::code &amp;&amp; obs.*::code.@code.toString().trim() != &apos;&apos;) {
+	                    grouperScreeningCode = obs.*::code.@code.toString().trim();
+	                    logger.info(&quot;Using screening code from CCDA observation (Medent): &quot; + grouperScreeningCode);
+	                    break;
+	                }
+	            }
+	        }
+	
+	    } catch (e) {
+	        logger.error(&quot;Error extracting screening code/effectiveTime for Medent: &quot; + e);
+	    }
+	
+	    // Final fallback if still empty (matches XSLT)
+	    if (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;) {
+	        grouperScreeningCode = &apos;96777-8&apos;;
+	        logger.info(&quot;Defaulting grouperScreeningCode to 96777-8 for Medent&quot;);
+	    }
+	} else { // For general CCDA files
+		//grouperScreeningEffectiveTime = &apos;&apos;;
+	}
+	
+	grouperScreeningCode = (grouperScreeningCode || &apos;&apos;).trim();
+	
+	transformer.setParameter(&apos;grouperScreeningCode&apos;, String(grouperScreeningCode));
+	logger.info(&apos;grouperScreeningCode&apos; + &quot; : &quot; + grouperScreeningCode);
+
+	// Get encounter effective time
+	var encounterEffectiveTime = &apos;&apos;;
+	try {
+		var encounter = xmlDoc.*::componentOf.*::encompassingEncounter;
+		if (encounter != undefined &amp;&amp; encounter.length() &gt; 0) {
+		    encounterEffectiveTime = getEncounterEffectiveTime(encounter, &apos;False&apos;);	
+		} else {
+		    // Try fallback to `encounter`
+		    var encounters = xmlDoc.*::component
+	                     .*::structuredBody
+	                     .*::component
+	                     .*::section.(@ID == &apos;encounters&apos;)
+	                     .*::entry[0]
+	                     .*::encounter;
+		    if (encounters != undefined &amp;&amp; encounters.length() &gt; 0) {
+		        encounterEffectiveTime = getEncounterEffectiveTime(encounters, &apos;False&apos;);
+		    } else {
+		        logger.error(&quot;Encounter resource not found in the XML.&quot;);
+		    }
+		}
+	} catch (e) {
+	    logger.error(&quot;Error accessing encounter: &quot; + e);
+	}
+
+	// Generate the Grouper Observation Resource ID
+	var mrn = (channelMap.get(&apos;Patient-MRN&apos;) || &quot;&quot;).trim();
+	var cin = (channelMap.get(&apos;patientCIN&apos;) || &quot;&quot;).trim();
+     var finalEffectiveTime = grouperScreeningEffectiveTime;
+	
+	if (!finalEffectiveTime || finalEffectiveTime.trim() === &apos;&apos;) {
+	    finalEffectiveTime = encounterEffectiveTime || &apos;&apos;;
+	    logger.info(&quot;Using encounterEffectiveTime as fallback for generating Grouper Resource ID : &quot; + finalEffectiveTime);
+	}
+
+     logger.info(&quot;Hash Inputs → MRN: &quot; + mrn + &quot;, CIN: &quot; + cin +
+            &quot;, Code: &quot; + grouperScreeningCode +
+            &quot;, EffectiveTime: &quot; + finalEffectiveTime);
+            
+     var combinedText = mrn + cin + grouperScreeningCode + finalEffectiveTime;
      var sha256Hash = generateSHA256(new java.lang.String(combinedText)); 
     
      transformer.setParameter(&apos;grouperObservationResourceSha256Id&apos;, sha256Hash);
      logger.info(&apos;grouperObservationResourceSha256Id&apos; + &quot; : &quot; + sha256Hash);
-
+     
+     // Set category xml
      transformer = getObservationCategoryCodes(transformer, sourceXml); //observations
      transformer = getMultipleAnswersForComponent(transformer, sourceXml); //observations
-
-     //For Epic files, use the value of the header variable,&apos;X-TechBD-Screening-Code&apos;, as the Grouper Screening Code, otherwise use the LOINC code &apos;100698-0&apos;
-     //For Medent files, take the value from code.code
-     var grouperScreeningCode = channelMap.get(&apos;X-TechBD-Screening-Code&apos;);
-     if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Epic&apos; || channelMap.get(&apos;ehrVendor&apos;) == &apos;Athenahealth&apos;)
-     	&amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
-	    grouperScreeningCode = &apos;100698-0&apos;;
-	    logger.info(&quot;Defaulting grouperScreeningCode to 100698-0 for Epic&quot;);
-	}
-	if (!grouperScreeningCode) {
-	    grouperScreeningCode = &apos;&apos;;
-	}
-     transformer.setParameter(&apos;grouperScreeningCode&apos;, String(grouperScreeningCode));
-     logger.info(&apos;grouperScreeningCode&apos; + &quot; : &quot; + grouperScreeningCode);
-
+    
+	// Set part2, OMH and OPWDD flags
 	transformer = setBooleanHeaderFlag(&apos;X-TechBD-Part2&apos;, transformer); // Set part2 flag
 	transformer = setBooleanHeaderFlag(&apos;X-TechBD-OMH&apos;, transformer);	  // Set OMH flag
 	transformer = setBooleanHeaderFlag(&apos;X-TechBD-OPWDD&apos;, transformer); // Set OPWDD flag
@@ -2582,7 +2690,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1775474522298</time>
+        <time>1777453409718</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -2591,6 +2699,5 @@ return;</undeployScript>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <channelTags/>
   </exportData>
 </channel>

--- a/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
+++ b/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
@@ -2,8 +2,8 @@
   <id>0cefb37a-ca0a-48cc-85a1-aa0b727d26a2</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version: 0.4.45</description>
-  <revision>5</revision>
+  <description>Version: 0.4.46</description>
+  <revision>8</revision>
   <sourceConnector version="4.5.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -1157,9 +1157,12 @@ function getPatientMRN(patientRoles) {
     channelMap.put(&apos;Patient-MRN&apos;, extensionAttr);
 }
 
-function getEncounterEffectiveTime(encounterNodeList) {
-    var fallbackTime = new java.text.SimpleDateFormat(&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss.SS&apos;Z&apos;&quot;).format(new java.util.Date());
-    var effectiveTimeOut = &apos;&apos;;
+function getEncounterEffectiveTime(encounterNodeList, returnFallBackTime) {
+    var currentTime = new java.text.SimpleDateFormat(&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss.SS&apos;Z&apos;&quot;).format(new java.util.Date());
+    var fallbackTime = &apos;&apos;;
+    if (returnFallBackTime != &apos;False&apos;) {
+    		fallbackTime = currentTime;
+    }
 
     if (!encounterNodeList || encounterNodeList.length === 0) {	
         return fallbackTime;
@@ -1516,33 +1519,138 @@ function setResourceIdParameters(transformer) {
 	    logger.error(&quot;Error accessing encounter: &quot; + e);
 	}
 
-	///Grouper Observation Resource 
-	var mrn = channelMap.get(&apos;Patient-MRN&apos;) || &quot;&quot;;
-     var cin = channelMap.get(&apos;patientCIN&apos;) || &quot;&quot;;
-     var currentTimestamp = new java.text.SimpleDateFormat(&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss.SS&apos;Z&apos;&quot;).format(new java.util.Date());
-	var combinedText = mrn + cin + &apos;Grouper Observation Resource&apos; + currentTimestamp;
+	/// ** Grouper Observation Resource ** ///
+	// Get grouper Screening Code
+     // For Epic files, use the value of the header variable,&apos;X-TechBD-Screening-Code&apos;, as the Grouper Screening Code, otherwise use the LOINC code &apos;100698-0&apos;
+     // For Medent files, take the value from code.code
+     var grouperScreeningCode = channelMap.get(&apos;X-TechBD-Screening-Code&apos;);
+	var grouperScreeningEffectiveTime = &apos;&apos;;
+	
+	// Extract effectiveTime (COMMON for all vendors)
+	try {
+	    var observations = xmlDoc.*::component
+	        .*::structuredBody
+	        .*::component
+	        .*::section.(@ID == &apos;observations&apos;)
+	        .*::entry
+	        .*::observation;
+	
+	    if (observations != undefined &amp;&amp; observations.length() &gt; 0) {
+	        var obs = observations[0]; // first observation (same as [1] in XSLT)
+	
+	        if (obs.*::effectiveTime) {
+	            var effTime = obs.*::effectiveTime.@value.toString().trim();
+	
+	            // fallback to low/@value
+	            if (!effTime || effTime == &apos;&apos;) {
+	                effTime = obs.*::effectiveTime.*::low.@value.toString().trim();
+	            }
+	
+	            grouperScreeningEffectiveTime = effTime;
+	        }
+	    }
+	
+	    logger.info(&quot;Grouper Screening Effective Time: &quot; + grouperScreeningEffectiveTime);
+	
+	} catch (e) {
+	    logger.error(&quot;Error extracting grouperScreeningEffectiveTime: &quot; + e);
+	}
+
+	if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Epic&apos; || channelMap.get(&apos;ehrVendor&apos;) == &apos;Athenahealth&apos;)
+	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
+	
+	    grouperScreeningCode = &apos;100698-0&apos;;
+	    logger.info(&quot;Defaulting grouperScreeningCode to 100698-0 for Epic&quot;);
+	
+	} else if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Medent&apos;)
+	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
+	
+	    // Try to extract from CCDA observations
+	    try {
+	        var observations = xmlDoc.*::component
+	            .*::structuredBody
+	            .*::component
+	            .*::section.(@ID == &apos;observations&apos;)
+	            .*::entry
+	            .*::observation;
+	
+	        if (observations != undefined &amp;&amp; observations.length() &gt; 0) {
+	            for each (var obs in observations) {
+	                if (obs.*::code &amp;&amp; obs.*::code.@code.toString().trim() != &apos;&apos;) {
+	                    grouperScreeningCode = obs.*::code.@code.toString().trim();
+	                    logger.info(&quot;Using screening code from CCDA observation (Medent): &quot; + grouperScreeningCode);
+	                    break;
+	                }
+	            }
+	        }
+	
+	    } catch (e) {
+	        logger.error(&quot;Error extracting screening code/effectiveTime for Medent: &quot; + e);
+	    }
+	
+	    // Final fallback if still empty (matches XSLT)
+	    if (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;) {
+	        grouperScreeningCode = &apos;96777-8&apos;;
+	        logger.info(&quot;Defaulting grouperScreeningCode to 96777-8 for Medent&quot;);
+	    }
+	} else { // For general CCDA files
+		//grouperScreeningEffectiveTime = &apos;&apos;;
+	}
+	
+	grouperScreeningCode = (grouperScreeningCode || &apos;&apos;).trim();
+	
+	transformer.setParameter(&apos;grouperScreeningCode&apos;, String(grouperScreeningCode));
+	logger.info(&apos;grouperScreeningCode&apos; + &quot; : &quot; + grouperScreeningCode);
+
+	// Get encounter effective time
+	var encounterEffectiveTime = &apos;&apos;;
+	try {
+		var encounter = xmlDoc.*::componentOf.*::encompassingEncounter;
+		if (encounter != undefined &amp;&amp; encounter.length() &gt; 0) {
+		    encounterEffectiveTime = getEncounterEffectiveTime(encounter, &apos;False&apos;);	
+		} else {
+		    // Try fallback to `encounter`
+		    var encounters = xmlDoc.*::component
+	                     .*::structuredBody
+	                     .*::component
+	                     .*::section.(@ID == &apos;encounters&apos;)
+	                     .*::entry[0]
+	                     .*::encounter;
+		    if (encounters != undefined &amp;&amp; encounters.length() &gt; 0) {
+		        encounterEffectiveTime = getEncounterEffectiveTime(encounters, &apos;False&apos;);
+		    } else {
+		        logger.error(&quot;Encounter resource not found in the XML.&quot;);
+		    }
+		}
+	} catch (e) {
+	    logger.error(&quot;Error accessing encounter: &quot; + e);
+	}
+
+	// Generate the Grouper Observation Resource ID
+	var mrn = (channelMap.get(&apos;Patient-MRN&apos;) || &quot;&quot;).trim();
+	var cin = (channelMap.get(&apos;patientCIN&apos;) || &quot;&quot;).trim();
+     var finalEffectiveTime = grouperScreeningEffectiveTime;
+	
+	if (!finalEffectiveTime || finalEffectiveTime.trim() === &apos;&apos;) {
+	    finalEffectiveTime = encounterEffectiveTime || &apos;&apos;;
+	    logger.info(&quot;Using encounterEffectiveTime as fallback for generating Grouper Resource ID : &quot; + finalEffectiveTime);
+	}
+
+     logger.info(&quot;Hash Inputs → MRN: &quot; + mrn + &quot;, CIN: &quot; + cin +
+            &quot;, Code: &quot; + grouperScreeningCode +
+            &quot;, EffectiveTime: &quot; + finalEffectiveTime);
+            
+     var combinedText = mrn + cin + grouperScreeningCode + finalEffectiveTime;
      var sha256Hash = generateSHA256(new java.lang.String(combinedText)); 
     
      transformer.setParameter(&apos;grouperObservationResourceSha256Id&apos;, sha256Hash);
      logger.info(&apos;grouperObservationResourceSha256Id&apos; + &quot; : &quot; + sha256Hash);
-
+     
+     // Set category xml
      transformer = getObservationCategoryCodes(transformer, sourceXml); //observations
      transformer = getMultipleAnswersForComponent(transformer, sourceXml); //observations
-
-     //For Epic files, use the value of the header variable,&apos;X-TechBD-Screening-Code&apos;, as the Grouper Screening Code, otherwise use the LOINC code &apos;100698-0&apos;
-     //For Medent files, take the value from code.code
-     var grouperScreeningCode = channelMap.get(&apos;X-TechBD-Screening-Code&apos;);
-     if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Epic&apos; || channelMap.get(&apos;ehrVendor&apos;) == &apos;Athenahealth&apos;)
-     	&amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
-	    grouperScreeningCode = &apos;100698-0&apos;;
-	    logger.info(&quot;Defaulting grouperScreeningCode to 100698-0 for Epic&quot;);
-	}
-	if (!grouperScreeningCode) {
-	    grouperScreeningCode = &apos;&apos;;
-	}
-     transformer.setParameter(&apos;grouperScreeningCode&apos;, String(grouperScreeningCode));
-     logger.info(&apos;grouperScreeningCode&apos; + &quot; : &quot; + grouperScreeningCode);
-
+    
+	// Set part2, OMH and OPWDD flags
 	transformer = setBooleanHeaderFlag(&apos;X-TechBD-Part2&apos;, transformer); // Set part2 flag
 	transformer = setBooleanHeaderFlag(&apos;X-TechBD-OMH&apos;, transformer);	  // Set OMH flag
 	transformer = setBooleanHeaderFlag(&apos;X-TechBD-OPWDD&apos;, transformer); // Set OPWDD flag
@@ -2615,7 +2723,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1775474522298</time>
+        <time>1777453409718</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -2624,6 +2732,5 @@ return;</undeployScript>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <channelTags/>
   </exportData>
 </channel>


### PR DESCRIPTION
Updated the Mirth Connect channel to modify the Grouper Observation Resource ID generation logic to follow the structure:
`<FacilityID> + '-' + Hash(MRN + CIN + ScreeningCode + EffectiveTime)`