### PR TITLE
fix: Store correct MTOM response in S3 ACK instead of SOAP envelope #3068

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
@@ -107,7 +107,7 @@ public class WsaHeaderInterceptor implements EndpointInterceptor, SoapEndpointIn
         if (!isWsEndpoint(messageContext)) {
             return true; // Continue chain but skip processing
         }
-
+        String ackPayload;
         var transportContext = TransportContextHolder.getTransportContext();
         var connection = (HttpServletConnection) transportContext.getConnection();
         HttpServletRequest httpRequest = connection.getHttpServletRequest();
@@ -129,7 +129,7 @@ public class WsaHeaderInterceptor implements EndpointInterceptor, SoapEndpointIn
         messageContext.setProperty(Constants.INTERACTION_ID, interactionId);
         LOG.info("handleResponse: responseType={} interactionId={}", responseType, interactionId);
 
-        strategy.writeResponse(interactionId, messageContext, httpRequest, httpResponse, message);
+        byte[] actualResponseBytes =strategy.writeResponse(interactionId, messageContext, httpRequest, httpResponse, message);
 
         // ── For MTOM strategies: mark the MessageContext response as already sent ──
         // This prevents Spring-WS from serializing the SoapMessage a second time
@@ -148,10 +148,13 @@ public class WsaHeaderInterceptor implements EndpointInterceptor, SoapEndpointIn
             });
             LOG.debug("handleResponse: suppressed Spring-WS secondary write for MTOM. interactionId={}", interactionId);
         }
-
-        messageProcessorService.processMessage(context, rawSoapMessage,
-                Hl7Util.soapMessageToString(message, interactionId));
-
+            if (isMtomResponseType(responseType)) {
+                ackPayload = new String(actualResponseBytes, StandardCharsets.UTF_8);
+            } else {
+                ackPayload = Hl7Util.soapMessageToString(message, interactionId);
+            }
+            messageProcessorService.processMessage(context, rawSoapMessage,
+                    ackPayload);
         return true;
     }
 

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategy.java
@@ -1,5 +1,7 @@
 package org.techbd.ingest.service.soap;
 
+import java.io.ByteArrayOutputStream;
+
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.soap.SoapMessage;
 import org.techbd.ingest.util.AppLogger;
@@ -23,14 +25,31 @@ public class DefaultSoapResponseStrategy implements SoapResponseStrategy {
     }
 
     @Override
-    public void writeResponse(
+    public byte[] writeResponse(
             String interactionId,
             MessageContext messageContext,
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse,
             SoapMessage builtResponse) {
 
-        // Intentionally a no-op: Spring-WS handles serialisation in its normal pipeline.
-        log.debug("DefaultSoapResponseStrategy:: no-op for interactionId={}", interactionId);
+        // Intentionally a no-op: Spring-WS handles serialisation in its normal
+        // pipeline.
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            builtResponse.writeTo(baos);
+
+            byte[] bytes = baos.toByteArray();
+
+            log.debug("DefaultSoapResponseStrategy:: SOAP response captured. size={} interactionId={}",
+                    bytes.length, interactionId);
+
+            return bytes;
+
+        } catch (Exception e) {
+            log.error("DefaultSoapResponseStrategy:: Failed to serialize SOAP response. interactionId={} error={}",
+                    interactionId, e.getMessage(), e);
+
+            throw new RuntimeException("Failed to serialize SOAP response", e);
+        }
     }
 }

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategy.java
@@ -53,7 +53,7 @@ public class MtomSoapResponseStrategy implements SoapResponseStrategy {
     }
 
     @Override
-    public void writeResponse(
+    public byte[] writeResponse(
             String interactionId,
             MessageContext messageContext,
             HttpServletRequest httpRequest,
@@ -91,12 +91,13 @@ public class MtomSoapResponseStrategy implements SoapResponseStrategy {
             log.info("MtomSoapResponseStrategy:: MTOM response written. " +
                     "boundary={} interactionId={} soapMediaType={}",
                     boundary, interactionId, soapMediaType);
+            return responseBytes;
 
         } catch (IOException e) {
             if (isBrokenPipe(e)) {
                 log.warn("MtomSoapResponseStrategy:: Client disconnected before MTOM response " +
                         "could be written (caller timed out). interactionId={}", interactionId);
-                return;
+                throw new RuntimeException("Client disconnected during MTOM write", e);
             }
             log.error("MtomSoapResponseStrategy:: Failed to write MTOM response. " +
                     "interactionId={} error={}", interactionId, e.getMessage(), e);

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategy.java
@@ -25,7 +25,7 @@ public interface SoapResponseStrategy {
      * @param httpResponse   raw servlet response (may be used to set headers directly)
      * @param builtResponse  the SOAP message already built by SoapResponseUtil.buildSoapResponse()
      */
-    void writeResponse(
+    byte[] writeResponse(
             String interactionId,
             MessageContext messageContext,
             HttpServletRequest httpRequest,

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategy.java
@@ -49,7 +49,7 @@ public class TruBridgeMtomSoapResponseStrategy implements SoapResponseStrategy {
     }
 
     @Override
-    public void writeResponse(
+    public byte[] writeResponse(
             String interactionId,
             MessageContext messageContext,
             HttpServletRequest httpRequest,
@@ -85,12 +85,13 @@ public class TruBridgeMtomSoapResponseStrategy implements SoapResponseStrategy {
 
             log.info("TruBridgeMtomSoapResponseStrategy:: TruBridge MTOM response written. " +
                     "boundary={} interactionId={} soapMediaType={}", boundary, interactionId, soapMediaType);
+            return responseBytes;
 
         } catch (IOException e) {
             if (isBrokenPipe(e)) {
                 log.warn("TruBridgeMtomSoapResponseStrategy:: Client disconnected before response " +
                         "could be written (caller timed out). interactionId={}", interactionId);
-                return;
+                throw new RuntimeException("Client disconnected during MTOM write", e);
             }
             log.error("TruBridgeMtomSoapResponseStrategy:: Failed to write TruBridge MTOM response. " +
                     "interactionId={} error={}", interactionId, e.getMessage(), e);

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1133.0</revision>
+        <revision>0.1134.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Summary
This change ensures that the ACK message stored in S3 matches the actual response sent to the client. #3068

## Changes
- Modified SoapResponseStrategy to return response bytes
- For MTOM responses, stored the generated multipart payload in S3
- For non-MTOM responses, continued storing SOAP envelope

## Result
- MTOM ACK in S3 now contains full multipart/related payload
- SOAP ACK behavior remains unchanged