### PR TITLE
fix: fix MTOM content-type parsing and default /xds/XdsbRepositoryWS to standard strategy  #3068

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/commons/Constants.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/commons/Constants.java
@@ -58,4 +58,5 @@ public class Constants {
     public static final String NO_ACK_EXPECTED = "NO_ACK_EXPECTED";
     public static final String ORIGINAL_REQUEST_URL = "x-techbd-original-uri";
     public static final String RESPONSE_TYPE = "RESPONSE_TYPE";
+    public static final String ORIGINAL_REQUEST_URI="ORIGINAL_REQUEST_URI";
 }

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/InteractionsFilter.java
@@ -145,7 +145,7 @@ public class InteractionsFilter extends OncePerRequestFilter {
                                 interactionId, e);
                     }
                 }
-
+                requestToUse.setAttribute(Constants.ORIGINAL_REQUEST_URI, requestToUse.getRequestURI());
                 requestToUse.setAttribute(Constants.INTERACTION_ID, interactionId);
                 LOG.info("Incoming Request - interactionId={}", interactionId);
 

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/interceptors/WsaHeaderInterceptor.java
@@ -121,9 +121,13 @@ public class WsaHeaderInterceptor implements EndpointInterceptor, SoapEndpointIn
         if (responseType == null || responseType.isBlank()) {
             responseType = httpRequest.getHeader(Constants.RESPONSE_TYPE);
         }
-        SoapResponseStrategy strategy = strategyFactory.resolve(responseType);
-
+        String originalStringRequestUri = (String) httpRequest.getHeader(Constants.ORIGINAL_REQUEST_URI);
+        if (originalStringRequestUri == null || originalStringRequestUri.isBlank()) {
+            originalStringRequestUri = httpRequest.getRequestURI();
+        }
         RequestContext context = (RequestContext) httpRequest.getAttribute(Constants.REQUEST_CONTEXT);
+        boolean isPixRequest = null != context ?context.isPixRequest() : false;
+        SoapResponseStrategy strategy = strategyFactory.resolve(responseType,interactionId,originalStringRequestUri,isPixRequest);
         String rawSoapMessage = (String) messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE);
 
         messageContext.setProperty(Constants.INTERACTION_ID, interactionId);

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/SoapForwarderService.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/SoapForwarderService.java
@@ -281,7 +281,9 @@ public class SoapForwarderService {
                 LOG.info("SoapForwarderService:: Wrote MTOM response directly to servlet output. " +
                         "bytes={} interactionId={}", responseBodyBytes.length, interactionId);
 
-                // Return a ResponseEntity with a Spring-parseable Content-Type sentinel.
+                // fix for org.springframework.http.InvalidMediaTypeException: Invalid mime type
+                //  \""multipart/related; boundary=MIMEBoundary_90d0920f01da467d8d4e54c4c3aedc5f;
+                // Return a ResponseEntity with a Spring-parseable Content-Type 
                 // The response is already committed — Spring cannot write any body.
                 // We set Content-Type here only so Spring's HttpEntityMethodProcessor
                 // does not fall back to reading the servlet response Content-Type

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/SoapForwarderService.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/SoapForwarderService.java
@@ -192,6 +192,11 @@ public class SoapForwarderService {
         if (ackContentType != null) {
             reqBuilder.header(Constants.ACK_CONTENT_TYPE, ackContentType);
         }
+
+        String originalRequestUri = (String) request.getAttribute(Constants.ORIGINAL_REQUEST_URI);
+        if (originalRequestUri != null) {
+            reqBuilder.header(Constants.ORIGINAL_REQUEST_URI, originalRequestUri);
+        }
         String responseType = (String) request.getAttribute(Constants.RESPONSE_TYPE);
         if (responseType != null && !responseType.isBlank()) {
             reqBuilder.header(Constants.RESPONSE_TYPE, responseType);
@@ -267,28 +272,38 @@ public class SoapForwarderService {
 
             try {
                 servletResponse.setStatus(status);
-                // Use setHeader (not setContentType) to bypass Tomcat's
-                // own MediaType validation in the connector layer.
                 servletResponse.setHeader("Content-Type", respContentType);
                 servletResponse.setContentLengthLong(responseBodyBytes.length);
                 servletResponse.getOutputStream().write(responseBodyBytes);
                 servletResponse.getOutputStream().flush();
+                servletResponse.flushBuffer();
 
                 LOG.info("SoapForwarderService:: Wrote MTOM response directly to servlet output. " +
                         "bytes={} interactionId={}", responseBodyBytes.length, interactionId);
 
-                // Return empty ResponseEntity — response already committed.
-                // Spring will not attempt further writes.
-                return ResponseEntity.status(status).build();
+                // Return a ResponseEntity with a Spring-parseable Content-Type sentinel.
+                // The response is already committed — Spring cannot write any body.
+                // We set Content-Type here only so Spring's HttpEntityMethodProcessor
+                // does not fall back to reading the servlet response Content-Type
+                // (which contains unquoted 'type=application/xop+xml' and causes
+                // InvalidMediaTypeException in MediaType.parseMediaType()).
+                // "application/octet-stream" is valid, parseable, and never reaches
+                // the client because the response is already committed.
+                return ResponseEntity.status(status)
+                        .header("Content-Type", "application/octet-stream")
+                        .build();
 
             } catch (IOException e) {
                 if (isBrokenPipe(e)) {
-                    LOG.warn("SoapForwarderService:: Client disconnected during MTOM write " +
-                            "(caller timed out). interactionId={}", interactionId);
-                    return ResponseEntity.status(status).build();
+                    LOG.warn("SoapForwarderService:: Client disconnected during MTOM write. interactionId={}",
+                            interactionId);
+                    return ResponseEntity.status(status)
+                            .header("Content-Type", "application/octet-stream")
+                            .build();
                 }
                 throw e;
             }
+
         }
 
         // ── Step 5: non-MTOM — existing path unchanged ────────────────────

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategy.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategy.java
@@ -109,7 +109,7 @@ public class MtomSoapResponseStrategy implements SoapResponseStrategy {
                                       String soapMediaType) {
         return "--" + boundary + "\r\n"
                 + "Content-Type: application/xop+xml; charset=UTF-8; type=\"" + soapMediaType + "\"\r\n"
-                + "Content-Transfer-Encoding: 8bit\r\n"
+                + "Content-Transfer-Encoding: binary\r\n"
                 + "Content-ID: " + startCid + "\r\n"
                 + "\r\n"
                 + soapXml + "\r\n"

--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactory.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactory.java
@@ -42,22 +42,30 @@ public class SoapResponseStrategyFactory {
      * Returns the strategy matching {@code responseType} (case-insensitive).
      * Falls back to {@link DefaultSoapResponseStrategy} for any unrecognised value.
      */
-    public SoapResponseStrategy resolve(String responseType) {
+    public SoapResponseStrategy resolve(String responseType,String interactionId,String requestUri,boolean isPixRequest) {
+        if (isPixRequest) {
+            log.info("[SOAP_RESPONSE_STRATEGY]:: PIX request — using default strategy for interactionId={}", interactionId);
+            return defaultStrategy;
+        }
+        if(requestUri != null && requestUri.equalsIgnoreCase("/xds/XDSbRepositoryWS")) {
+           log.info("[SOAP_RESPONSE_STRATEGY]:: XDSbRepositoryWS — using default strategy for interactionId={}", interactionId);
+            return defaultStrategy;
+        }
         if (responseType == null || responseType.isBlank()) {
-            log.info("SoapResponseStrategyFactory:: no responseType — using default strategy");
+            log.info("[SOAP_RESPONSE_STRATEGY]:: no responseType — using default strategy for interactionId={}", interactionId);
             return defaultStrategy;
         }
         return switch (responseType.trim().toLowerCase()) {
             case MTOM           -> {
-                log.info("SoapResponseStrategyFactory:: resolved MtomSoapResponseStrategy");
+                log.info("[SOAP_RESPONSE_STRATEGY]:: resolved MtomSoapResponseStrategy for interactionId={}", interactionId);
                 yield mtomStrategy;
             }
             case MTOM_TRUBRIDGE -> {
-                log.info("SoapResponseStrategyFactory:: resolved TruBridgeMtomSoapResponseStrategy");
+                log.info("[SOAP_RESPONSE_STRATEGY]:: resolved TruBridgeMtomSoapResponseStrategy for interactionId={}", interactionId);
                 yield truBridgeStrategy;
             }
             default -> {
-                log.warn("SoapResponseStrategyFactory:: unknown responseType='{}' — falling back to default", responseType);
+                log.warn("[SOAP_RESPONSE_STRATEGY]:: unknown responseType='{}' — falling back to default for interactionId={}", responseType, interactionId);
                 yield defaultStrategy;
             }
         };

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/interceptors/WsaHeaderInterceptorTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/interceptors/WsaHeaderInterceptorTest.java
@@ -158,12 +158,12 @@ class WsaHeaderInterceptorTest {
         when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
 
         SoapResponseStrategy defaultStrategy = mock(DefaultSoapResponseStrategy.class);
-        when(strategyFactory.resolve(isNull())).thenReturn(defaultStrategy);
+        when(strategyFactory.resolve(isNull(), eq("INT-1"), eq("/ws"), eq(false))).thenReturn(defaultStrategy);
 
         boolean result = interceptor.handleResponse(messageContext, new Object());
 
         assertTrue(result);
-        verify(strategyFactory).resolve(isNull());
+        verify(strategyFactory).resolve(isNull(), eq("INT-1"), eq("/ws"),eq(false));
         verify(defaultStrategy).writeResponse(eq("INT-1"), any(), any(), any(), any());
         verify(messageProcessorService).processMessage(any(), eq("<req/>"), any());
     }
@@ -181,19 +181,26 @@ class WsaHeaderInterceptorTest {
         when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
 
         SoapResponseStrategy mtomStrategy = mock(SoapResponseStrategy.class);
-        when(strategyFactory.resolve("mtom")).thenReturn(mtomStrategy);
+        when(strategyFactory.resolve("mtom", "INT-MTOM", "/ws", false)).thenReturn(mtomStrategy);
+        when(mtomStrategy.writeResponse(any(), any(), any(), any(), any()))
+                .thenReturn("<soap>response</soap>".getBytes());
 
         // messageContext.getResponse() used to drain Spring-WS buffer
         when(messageContext.getResponse()).thenReturn(soapMessage);
-        doAnswer(invocation -> null).when(soapMessage).writeTo(any(OutputStream.class));
+        doAnswer(invocation -> {
+            OutputStream os = invocation.getArgument(0);
+            os.write("<soap>response</soap>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any(OutputStream.class));
 
         boolean result = interceptor.handleResponse(messageContext, new Object());
 
         assertTrue(result);
         verify(mtomStrategy).writeResponse(eq("INT-MTOM"), any(), any(), any(), any());
-        // Verify Spring-WS secondary write was drained to no-op stream
-        // Note: writeTo is called twice - once for MTOM suppression, once for soapMessageToString
-        verify(soapMessage, times(2)).writeTo(any(OutputStream.class));
+        // writeTo is called once: for MTOM suppression (draining Spring-WS buffer).
+        // soapMessageToString is NOT called for MTOM because ackPayload uses
+        // actualResponseBytes.
+        verify(soapMessage, times(1)).writeTo(any(OutputStream.class));
     }
 
     @Test
@@ -209,7 +216,9 @@ class WsaHeaderInterceptorTest {
         when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
 
         SoapResponseStrategy tbStrategy = mock(SoapResponseStrategy.class);
-        when(strategyFactory.resolve("mtom_trubridge")).thenReturn(tbStrategy);
+        when(strategyFactory.resolve("mtom_trubridge", "INT-TB", "/ws", false)).thenReturn(tbStrategy);
+        when(tbStrategy.writeResponse(any(), any(), any(), any(), any()))
+                .thenReturn("<soap>response</soap>".getBytes());
 
         when(messageContext.getResponse()).thenReturn(soapMessage);
         doAnswer(invocation -> null).when(soapMessage).writeTo(any(OutputStream.class));
@@ -218,8 +227,8 @@ class WsaHeaderInterceptorTest {
 
         assertTrue(result);
         verify(tbStrategy).writeResponse(eq("INT-TB"), any(), any(), any(), any());
-        // Note: writeTo is called twice - once for MTOM suppression, once for soapMessageToString
-        verify(soapMessage, times(2)).writeTo(any(OutputStream.class));
+        // writeTo is called once: for MTOM suppression only.
+        verify(soapMessage, times(1)).writeTo(any(OutputStream.class));
     }
 
     @Test
@@ -236,16 +245,24 @@ class WsaHeaderInterceptorTest {
         when(messageContext.getProperty(Constants.RAW_SOAP_ATTRIBUTE)).thenReturn("<req/>");
 
         SoapResponseStrategy mtomStrategy = mock(SoapResponseStrategy.class);
-        when(strategyFactory.resolve("mtom")).thenReturn(mtomStrategy);
+        when(strategyFactory.resolve("mtom", "INT-H", "/ws", false)).thenReturn(mtomStrategy);
+        // Stub writeResponse to avoid NPE when building ackPayload
+        when(mtomStrategy.writeResponse(any(), any(), any(), any(), any()))
+                .thenReturn("<soap>response</soap>".getBytes());
 
         when(messageContext.getResponse()).thenReturn(soapMessage);
-        doAnswer(invocation -> null).when(soapMessage).writeTo(any(OutputStream.class));
+        doAnswer(invocation -> {
+            OutputStream os = invocation.getArgument(0);
+            os.write("<soap>response</soap>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any(OutputStream.class));
 
         boolean result = interceptor.handleResponse(messageContext, new Object());
 
         assertTrue(result);
-        verify(strategyFactory).resolve("mtom");
+        verify(strategyFactory).resolve("mtom", "INT-H", "/ws", false);
     }
+
 
     @Test
     void shouldSkipHandleResponse_whenNotWsEndpoint() throws Exception {

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategyTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/DefaultSoapResponseStrategyTest.java
@@ -3,6 +3,7 @@ package org.techbd.ingest.service.soap;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,8 @@ import org.techbd.ingest.util.TemplateLogger;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayOutputStream;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultSoapResponseStrategyTest {
@@ -37,14 +40,19 @@ class DefaultSoapResponseStrategyTest {
 
     @Test
     void writeResponse_isNoOp_doesNotTouchResponse() throws Exception {
-        // DefaultSoapResponseStrategy is intentionally a no-op.
-        // It must not write to response, set headers, or throw.
+        // DefaultSoapResponseStrategy captures the SOAP response for logging purposes.
+        // It does not write to the HttpServletResponse (that is handled by Spring-WS).
+        doAnswer(invocation -> {
+            ByteArrayOutputStream os = invocation.getArgument(0);
+            os.write("<soap>response</soap>".getBytes());
+            return null;
+        }).when(soapMessage).writeTo(any(ByteArrayOutputStream.class));
+
         assertDoesNotThrow(() ->
                 strategy.writeResponse("INT-1", messageContext, request, response, soapMessage));
 
         verifyNoInteractions(response);
         verifyNoInteractions(messageContext);
-        verifyNoInteractions(soapMessage);
         verifyNoInteractions(request);
     }
 

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategyTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/MtomSoapResponseStrategyTest.java
@@ -209,8 +209,10 @@ class MtomSoapResponseStrategyTest {
 
         when(response.getOutputStream()).thenThrow(new IOException("Broken pipe"));
 
-        assertDoesNotThrow(() ->
+        // The strategy logs a warning and throws RuntimeException with "Client disconnected" message
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
                 strategy.writeResponse("INT-1", messageContext, request, response, soapMessage));
+        assertTrue(ex.getMessage().contains("Client disconnected"));
     }
 
     @Test

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactoryTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/SoapResponseStrategyFactoryTest.java
@@ -35,54 +35,86 @@ class SoapResponseStrategyFactoryTest {
     @NullAndEmptySource
     @ValueSource(strings = {"  ", "\t"})
     void shouldResolveDefaultStrategy_whenResponseTypeAbsentOrBlank(String responseType) {
-        SoapResponseStrategy strategy = factory.resolve(responseType);
+        SoapResponseStrategy strategy = factory.resolve(responseType, "INT-1","/ws",false);
         assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
     }
 
     @Test
     void shouldResolveDefaultStrategy_whenResponseTypeUnknown() {
-        SoapResponseStrategy strategy = factory.resolve("unknown_type");
+        SoapResponseStrategy strategy = factory.resolve("unknown_type", "INT-1", "/ws",false);
         assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
     }
 
     @Test
     void shouldResolveMtomStrategy_whenResponseTypeMtom() {
-        SoapResponseStrategy strategy = factory.resolve("mtom");
+        SoapResponseStrategy strategy = factory.resolve("mtom", "INT-1", "/ws",false);
         assertInstanceOf(MtomSoapResponseStrategy.class, strategy);
     }
 
     @Test
     void shouldResolveMtomStrategy_caseInsensitive() {
-        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("MTOM"));
-        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("Mtom"));
-        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("  mtom  "));
+        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("MTOM", "INT-1", "/ws",false));
+        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("Mtom", "INT-1", "/ws",false));
+        assertInstanceOf(MtomSoapResponseStrategy.class, factory.resolve("  mtom  ", "INT-1", "/ws",false));
     }
 
     @Test
     void shouldResolveTruBridgeStrategy_whenResponseTypeMtomTrubridge() {
-        SoapResponseStrategy strategy = factory.resolve("mtom_trubridge");
+        SoapResponseStrategy strategy = factory.resolve("mtom_trubridge", "INT-1", "/ws",false);
         assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class, strategy);
     }
 
     @Test
     void shouldResolveTruBridgeStrategy_caseInsensitive() {
         assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class,
-                factory.resolve("MTOM_TRUBRIDGE"));
+                factory.resolve("MTOM_TRUBRIDGE", "INT-1", "/ws",false));
         assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class,
-                factory.resolve("Mtom_TruBridge"));
+                factory.resolve("Mtom_TruBridge", "INT-1", "/ws",false));
         assertInstanceOf(TruBridgeMtomSoapResponseStrategy.class,
-                factory.resolve("  mtom_trubridge  "));
+                factory.resolve("  mtom_trubridge  ", "INT-1", "/ws",false));
     }
 
     @Test
     void shouldReturnSameInstance_forRepeatedCalls() {
         // Strategies are singletons — same instance returned each call
-        SoapResponseStrategy first  = factory.resolve("mtom");
-        SoapResponseStrategy second = factory.resolve("mtom");
+        SoapResponseStrategy first  = factory.resolve("mtom", "INT-1", "/ws",false);
+        SoapResponseStrategy second = factory.resolve("mtom", "INT-1", "/ws",false);
         assertSame(first, second);
 
-        SoapResponseStrategy tb1 = factory.resolve("mtom_trubridge");
-        SoapResponseStrategy tb2 = factory.resolve("mtom_trubridge");
+        SoapResponseStrategy tb1 = factory.resolve("mtom_trubridge", "INT-1", "/ws",false);
+        SoapResponseStrategy tb2 = factory.resolve("mtom_trubridge", "INT-1", "/ws",false);
         assertSame(tb1, tb2);
+    }
+
+    @Test
+    void shouldResolveDefaultStrategy_whenRequestUriIsXDSbRepositoryWS() {
+        // When requestUri matches XDSbRepositoryWS, should return default strategy regardless of responseType
+        SoapResponseStrategy strategy = factory.resolve("mtom", "INT-1", "/xds/XDSbRepositoryWS",false);
+        assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
+    }
+
+    @Test
+    void shouldResolveDefaultStrategy_whenRequestUriIsXDSbRepositoryAndResponseTypeMtom() {
+        // requestUri check should be case-insensitive
+        SoapResponseStrategy strategy = factory.resolve("mtom", "INT-1", "/XDS/XDSbRepositoryWS",false);
+        assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
+    }
+    @Test
+    void shouldResolveDefaultStrategy_whenRequestUriIsXDSbRepositoryAndResponseTypeMtomTruBridge() {
+        // requestUri check should be case-insensitive
+        SoapResponseStrategy strategy = factory.resolve("mtom_trubridge", "INT-1", "/XDS/XDSbRepositoryWS",false);
+        assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
+    }
+    @Test
+    void shouldResolveDefaultStrategy_whenRequestIsPix() {
+        // requestUri check should be case-insensitive
+        SoapResponseStrategy strategy = factory.resolve("mtom_trubridge", "INT-1", "/ws",true);
+        assertInstanceOf(DefaultSoapResponseStrategy.class, strategy);
+    }
+    @Test
+    void shouldResolveMtomStrategy_whenRequestUriIsNotXDSbRepositoryWS() {
+        // When requestUri is different, should resolve based on responseType
+        SoapResponseStrategy strategy = factory.resolve("mtom", "INT-1", "/other/Service",false);
+        assertInstanceOf(MtomSoapResponseStrategy.class, strategy);
     }
 }

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategyTest.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/service/soap/TruBridgeMtomSoapResponseStrategyTest.java
@@ -222,8 +222,10 @@ class TruBridgeMtomSoapResponseStrategyTest {
 
         when(response.getOutputStream()).thenThrow(new IOException("Broken pipe"));
 
-        assertDoesNotThrow(() ->
+        // The strategy logs a warning and throws RuntimeException with "Client disconnected" message
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
                 strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage));
+        assertTrue(ex.getMessage().contains("Client disconnected"));
     }
 
     @Test
@@ -239,8 +241,10 @@ class TruBridgeMtomSoapResponseStrategyTest {
         };
         when(response.getOutputStream()).thenThrow(clientAbort);
 
-        assertDoesNotThrow(() ->
+        // The strategy logs a warning and throws RuntimeException with "Client disconnected" message
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
                 strategy.writeResponse("INT-TB", messageContext, request, response, soapMessage));
+        assertTrue(ex.getMessage().contains("Client disconnected"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1134.0</revision>
+        <revision>0.1135.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- default /xds/XdsbRepositoryWS requests to standard response handling
- default PIX requests to standard response handling
- fix invalid multipart/related MTOM Content-Type parsing causing InvalidMediaTypeException