### PR TITLE
fix: update xslt files to take Location details from the section where name and address are present in the CCDA file #3093

### DIFF
--- a/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
+++ b/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
@@ -2,8 +2,8 @@
   <id>0cefb37a-ca0a-48cc-85a1-aa0b727d26a2</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version: 0.4.46</description>
-  <revision>8</revision>
+  <description>Version: 0.4.47</description>
+  <revision>9</revision>
   <sourceConnector version="4.5.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -1656,26 +1656,33 @@ function setResourceIdParameters(transformer) {
 	transformer = setBooleanHeaderFlag(&apos;X-TechBD-OPWDD&apos;, transformer); // Set OPWDD flag
 
 	// Extract `location`
-     try {
+	try {
 	    var location;
 	    var location_name;
 	    var location_address;
-	
+	    var locationSuccess = false;
+	    var isValidLocation = function(name, address) {
+					        return (
+					            name != null &amp;&amp; name.toString().trim() !== &apos;&apos; &amp;&amp;
+					            address != null &amp;&amp; address.toString().trim() !== &apos;&apos;
+					        );
+					    };
 	    // Primary location path: componentOf → encompassingEncounter → location → healthCareFacility → location
 	    if (
 	        xmlDoc.componentOf &amp;&amp;
 	        xmlDoc.componentOf.encompassingEncounter &amp;&amp;
 	        xmlDoc.componentOf.encompassingEncounter.location &amp;&amp;
-	        xmlDoc.componentOf.encompassingEncounter.location.healthCareFacility &amp;&amp;
-	        xmlDoc.componentOf.encompassingEncounter.location.healthCareFacility.location
+	        xmlDoc.componentOf.encompassingEncounter.location.length() &gt; 0 &amp;&amp;
+	        xmlDoc.componentOf.encompassingEncounter.location[0].healthCareFacility &amp;&amp;
+	        xmlDoc.componentOf.encompassingEncounter.location[0].healthCareFacility.location
 	    ) {
-	        location = xmlDoc.componentOf.encompassingEncounter.location.healthCareFacility.location;
-	        location_name = xmlDoc.componentOf.encompassingEncounter.location.healthCareFacility.location.name;
-	        location_address = xmlDoc.componentOf.encompassingEncounter.location.healthCareFacility.location.addr;
+	    	   location = xmlDoc.componentOf.encompassingEncounter.location[0].healthCareFacility.location;
+	        location_name = location.name;
+	        location_address = location.addr;
+	        if (isValidLocation(location_name, location_address)) { locationSuccess = true; }
 	    }
-	
 	    // Fallback path: structuredBody → encounters section → encounter → participant → participantRole → playingEntity → name
-	    if (!location || location.length() == 0) {
+		if (!locationSuccess || channelMap.get(&apos;ehrVendor&apos;) == &apos;Medent&apos;) {
 	        var section = xmlDoc.component.structuredBody.component.section.(@ID == &apos;encounters&apos;);
 	        if (
 	            section &amp;&amp;
@@ -1683,20 +1690,18 @@ function setResourceIdParameters(transformer) {
 	            section.entry.length() &gt; 0 &amp;&amp;
 	            section.entry[0].encounter &amp;&amp;
 	            section.entry[0].encounter.participant &amp;&amp;
-	            section.entry[0].encounter.participant.participantRole &amp;&amp;
-	            section.entry[0].encounter.participant.participantRole.playingEntity
+	            section.entry[0].encounter.participant.length() &gt; 0 &amp;&amp;
+	            section.entry[0].encounter.participant[0].participantRole &amp;&amp;
+	            section.entry[0].encounter.participant[0].participantRole.playingEntity
 	        ) {
-	            location = section.entry[0].encounter.participant.participantRole;
-	            location_name = section.entry[0].encounter.participant.participantRole.playingEntity.name;
-	            location_address = section.entry[0].encounter.participant.participantRole.addr;
+	            location = section.entry[0].encounter.participant[0].participantRole;
+	            location_name = location.playingEntity.name;
+	            location_address = location.addr;
+	        	 if (isValidLocation(location_name, location_address)) { locationSuccess = true; }
 	        }
 	    }
 	
-	    if (
-	        location &amp;&amp;
-	        location_name != undefined &amp;&amp; location_name.toString().trim() !== &quot;&quot; &amp;&amp;
-	        location_address != undefined &amp;&amp; location_address.toString().trim() !== &quot;&quot;
-	    ) {
+	    if (locationSuccess &amp;&amp; location) {
 	        transformer = generateSHA256Id(location, &quot;Location&quot;, &quot;locationResourceId&quot;, transformer);
 	    } else {
 	        logger.info(&quot;Location not found in the XML.&quot;);
@@ -2723,7 +2728,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1777453409718</time>
+        <time>1777976124987</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -2732,5 +2737,6 @@ return;</undeployScript>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
+    <channelTags/>
   </exportData>
 </channel>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -718,7 +718,7 @@
         <xsl:variable name="locationDisplayRaw">
             <xsl:choose>
                 <!-- Primary location -->
-                <xsl:when test="string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name)">
+                <xsl:when test="string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) and string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr)">
                   <xsl:value-of select="ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name"/>
                 </xsl:when>
 
@@ -1564,7 +1564,7 @@
 
   <!-- Location Template from encompassingEncounter -->
   <xsl:template name="LocationResource" match="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location">
-  <xsl:if test="string($locationResourceId)">
+  <xsl:if test="normalize-space(ccda:name) and ccda:addr[not(@nullFlavor)] and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {
@@ -1597,7 +1597,9 @@
   
   <!-- Location Template from Encounters section -->
   <xsl:template name="EncountersLocationResource" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant[position()=1]/ccda:participantRole">
-  <xsl:if test="not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) and string($locationResourceId)">
+  <xsl:if test="(not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) 
+                or not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr))
+                and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -694,7 +694,7 @@
         <xsl:variable name="locationDisplayRaw">
             <xsl:choose>
                 <!-- Primary location -->
-                <xsl:when test="string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name)">
+                <xsl:when test="string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) and string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr)">
                   <xsl:value-of select="ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name"/>
                 </xsl:when>
 
@@ -823,7 +823,7 @@
         <xsl:variable name="locationDisplayRaw">
             <xsl:choose>
                 <!-- Primary location -->
-                <xsl:when test="string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name)">
+                <xsl:when test="string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name) and string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:addr)">
                   <xsl:value-of select="ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name"/>
                 </xsl:when>
 
@@ -1668,7 +1668,7 @@
 
   <!-- Location Template from encompassingEncounter -->
   <xsl:template name="LocationResource" match="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location">
-  <xsl:if test="string($locationResourceId)">
+  <xsl:if test="normalize-space(ccda:name) and ccda:addr[not(@nullFlavor)] and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {
@@ -1701,7 +1701,9 @@
   
   <!-- Location Template from Encounters section -->
   <xsl:template name="EncountersLocationResource" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant[position()=1]/ccda:participantRole">
-  <xsl:if test="not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) and string($locationResourceId)">
+  <xsl:if test="(not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) 
+                or not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr))
+                and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {

--- a/support/specifications/develop/ccda/cda-fhir-bundle.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle.xslt
@@ -650,7 +650,7 @@
         <xsl:variable name="locationDisplayRaw">
             <xsl:choose>
                 <!-- Primary location -->
-                <xsl:when test="string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name)">
+                <xsl:when test="string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) and string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr)">
                   <xsl:value-of select="ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name"/>
                 </xsl:when>
 
@@ -793,7 +793,7 @@
         <xsl:variable name="locationDisplayRaw">
             <xsl:choose>
                 <!-- Primary location -->
-                <xsl:when test="string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name)">
+                <xsl:when test="string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name) and string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:addr)">
                   <xsl:value-of select="ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name"/>
                 </xsl:when>
 
@@ -1721,7 +1721,7 @@
 
   <!-- Location Template from encompassingEncounter -->
   <xsl:template name="LocationResource" match="/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location">
-  <xsl:if test="string($locationResourceId)">
+  <xsl:if test="normalize-space(ccda:name) and ccda:addr[not(@nullFlavor)] and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {
@@ -1755,7 +1755,9 @@
   
   <!-- Location Template from Encounters section -->
   <xsl:template name="EncountersLocationResource" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant[position()=1]/ccda:participantRole">
-  <xsl:if test="not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) and string($locationResourceId)">
+  <xsl:if test="(not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) 
+                or not(/ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter/ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr))
+                and string($locationResourceId)">
     ,{
       "fullUrl": "<xsl:value-of select='$baseFhirUrl'/>/Location/<xsl:value-of select='$locationResourceId'/>",
       "resource": {


### PR DESCRIPTION
Updated xslt files for Epic, AthenaHealth and general CCDA files to take Location details from the section where name and address are present in the CCDA file