### PR TITLE
revert: restore SHIN-NY IG  configuration to v1.8.1 and PROD baseFHIRURL #3090

### DIFF
--- a/fhir-validation-service/src/main/resources/application.yml
+++ b/fhir-validation-service/src/main/resources/application.yml
@@ -27,14 +27,14 @@ org:
         # Example: shinny-v1-2-3 for version 1.2.3
         # Any new version for test-shinny should follow the naming convention: test-shinny-v<version> in kebab-case
         # Example: test-shinny-v1-3-0 for version 1.3.0
-          test-shinny-v1-9-0:
+          test-shinny-v1-8-1:
             profile-base-url: http://test.shinny.org/us/ny/hrsn
-            package-path: ig-packages/shin-ny-ig/test-shinny/v1.9.0
+            package-path: ig-packages/shin-ny-ig/test-shinny/v1.8.1
             # NOTE: When updating this IG version:
             # 1. Update BaseIgValidationTest.getIgPackages()
             # 2. Download latest examples to hub-prime/src/test/resources/org/techbd/ig-examples/test-shinny-examples
             # 3. Verify OrchestrationEngineTest and IgPublicationIssuesTest pass
-            ig-version: 1.9.0
+            ig-version: 1.8.1
           shinny-v1-8-1:
             profile-base-url: http://shinny.org/us/ny/hrsn
             package-path: ig-packages/shin-ny-ig/shinny/v1.8.1

--- a/hub-core-lib/src/main/resources/nexus-core-lib/application-devl.yml
+++ b/hub-core-lib/src/main/resources/nexus-core-lib/application-devl.yml
@@ -1,6 +1,6 @@
 org:
   techbd:
-    baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+    baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
     defaultDatalakeApiUrl: https://uzrlhp39e0.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle
     dataLedgerApiUrl: https://gbp2obo8d0.execute-api.us-east-1.amazonaws.com/development/DataLedger 
     dataLedgerTracking: false

--- a/hub-core-lib/src/main/resources/nexus-core-lib/application-phiqa.yml
+++ b/hub-core-lib/src/main/resources/nexus-core-lib/application-phiqa.yml
@@ -1,6 +1,6 @@
 org:
     techbd:
-        baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+        baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
         defaultDatalakeApiUrl: https://qa.hrsn.nyehealth.org/HRSNBundle
         defaultDataLakeApiAuthn:
             mTlsStrategy: aws-secrets

--- a/hub-core-lib/src/main/resources/nexus-core-lib/application-sandbox.yml
+++ b/hub-core-lib/src/main/resources/nexus-core-lib/application-sandbox.yml
@@ -1,6 +1,6 @@
 org:
   techbd:
-    baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+    baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
     defaultDatalakeApiUrl: https://uzrlhp39e0.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle
     dataLedgerApiUrl: https://gbp2obo8d0.execute-api.us-east-1.amazonaws.com/development/DataLedger 
     dataLedgerTracking: false

--- a/hub-core-lib/src/main/resources/nexus-core-lib/application-stage.yml
+++ b/hub-core-lib/src/main/resources/nexus-core-lib/application-stage.yml
@@ -1,6 +1,6 @@
 org:
   techbd:
-    baseFHIRURL: http://test.shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
+    baseFHIRURL: http://shinny.org/us/ny/hrsn #This is the default FHIR url used in generating FHIR from CSV
     defaultDatalakeApiUrl: https://uzrlhp39e0.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle
     dataLedgerApiUrl: https://gbp2obo8d0.execute-api.us-east-1.amazonaws.com/development/DataLedger 
     dataLedgerTracking: true

--- a/hub-core-lib/src/main/resources/nexus-core-lib/application.yml
+++ b/hub-core-lib/src/main/resources/nexus-core-lib/application.yml
@@ -16,14 +16,14 @@ org:
         # Example: shinny-v1-2-3 for version 1.2.3
         # Any new version for test-shinny should follow the naming convention: test-shinny-v<version> in kebab-case
         # Example: test-shinny-v1-3-0 for version 1.3.0
-          test-shinny-v1-9-0:
+          test-shinny-v1-8-1:
             profile-base-url: http://test.shinny.org/us/ny/hrsn
-            package-path: ig-packages/shin-ny-ig/test-shinny/v1.9.0
+            package-path: ig-packages/shin-ny-ig/test-shinny/v1.8.1
             # NOTE: When updating this IG version:
             # 1. Update BaseIgValidationTest.getIgPackages()
             # 2. Download latest examples to hub-prime/src/test/resources/org/techbd/ig-examples/test-shinny-examples
             # 3. Verify OrchestrationEngineTest and IgPublicationIssuesTest pass
-            ig-version: 1.9.0
+            ig-version: 1.8.1
           shinny-v1-8-1:
             profile-base-url: http://shinny.org/us/ny/hrsn
             package-path: ig-packages/shin-ny-ig/shinny/v1.8.1

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1140.0</revision>
+        <revision>0.1141.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Reverted ig-version from 1.9.0 to 1.8.1
- Reverted package-path from v1.9.0 to v1.8.1
- Updated baseFHIRURL from http://test.shinny.org/us/ny/hrsn to http://shinny.org/us/ny/hrsn
- Applied changes in relevant application.yml files