### PR TITLE
fix: update xslt files to fix issue with location display in Encounter resource while converting CCDA files to FHIR bundles #3093

### DIFF
--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -722,6 +722,12 @@
                   <xsl:value-of select="ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name"/>
                 </xsl:when>
 
+                <xsl:when test="not(string($locationResourceId)) 
+                                and string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) 
+                                and not(string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr))">
+                  <xsl:value-of select="ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name"/>
+                </xsl:when>
+
                 <!-- Fallback location -->
                 <xsl:otherwise>
                   <xsl:value-of select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name"/>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -698,6 +698,12 @@
                   <xsl:value-of select="ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name"/>
                 </xsl:when>
 
+                <xsl:when test="not(string($locationResourceId)) 
+                                and string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name) 
+                                and not(string(ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:addr))">
+                  <xsl:value-of select="ccda:location[position()=1]/ccda:healthCareFacility/ccda:location/ccda:name"/>
+                </xsl:when>
+
                 <!-- Fallback location -->
                 <xsl:otherwise>
                   <xsl:value-of select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[position()=1]/ccda:encounter/ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name"/>
@@ -823,7 +829,13 @@
         <xsl:variable name="locationDisplayRaw">
             <xsl:choose>
                 <!-- Primary location -->
-                <xsl:when test="string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name) and string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:addr)">
+                <xsl:when test="string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name) and string(ccda:participant[position()=1]/ccda:participantRole/ccda:addr)">
+                  <xsl:value-of select="ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name"/>
+                </xsl:when>
+
+                <xsl:when test="not(string($locationResourceId)) 
+                                and string(ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name) 
+                                and not(string(ccda:participant[position()=1]/ccda:participantRole/ccda:addr))">
                   <xsl:value-of select="ccda:participant[position()=1]/ccda:participantRole/ccda:playingEntity/ccda:name"/>
                 </xsl:when>
 


### PR DESCRIPTION
Updated xslt files for Epic and AthenaHealth to fix issue with location display in Encounter resource while converting CCDA files to FHIR bundles.