### PR TITLE
feat: add unit tests for DataIngestion for pnr soap & mtom request #3007

### DIFF
--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/DataIngestionControllerITCase.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/DataIngestionControllerITCase.java
@@ -529,6 +529,466 @@ class DataIngestionControllerITCase extends BaseIntegrationTest {
         }
 
 
+    @Test
+@DisplayName("IT: /ingest/netspective_m/pnr → MTOM multipart response validation")
+void shouldRoutePnrBasedOnSourceId_returnMtomResponse() throws Exception {
+
+    String url = "http://localhost:" + port + "/ingest/netspective_m/pnr";
+
+    String boundary = "Boundary_12345";
+
+    String mtomRequest = """
+            --Boundary_12345
+            Content-Type: application/xop+xml; charset=UTF-8; type="application/soap+xml"
+            Content-Transfer-Encoding: binary
+            Content-ID: <rootpart@meditech.com>
+
+            <?xml version="1.0" encoding="UTF-8"?>
+            <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+                    xmlns:wsa="http://www.w3.org/2005/08/addressing">
+
+            <soap:Header>
+            <wsa:To>https://heltestmcccd.myhie.com:9135/xds/XDSbRepositoryWS</wsa:To>
+            <wsa:MessageID>f19a3e9e-324d-4c6c-8a96-6747955d86f5</wsa:MessageID>
+            <wsa:Action>urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b</wsa:Action>
+            </soap:Header>
+
+            <soap:Body>
+            <ProvideAndRegisterDocumentSetRequest xmlns="urn:ihe:iti:xds-b:2007">
+            <Document id="Document1">
+                    <xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include"
+                            href="cid:payload@meditech.com"/>
+            </Document>
+            </ProvideAndRegisterDocumentSetRequest>
+            </soap:Body>
+
+            </soap:Envelope>
+
+            --Boundary_12345
+            Content-Type: text/xml; charset=UTF-8
+            Content-Transfer-Encoding: binary
+            Content-ID: <payload@meditech.com>
+
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ClinicalDocument xmlns="urn:hl7-org:v3">
+            <id extension="1" root="test"/>
+            </ClinicalDocument>
+
+            --Boundary_12345--
+            """;
+
+    SoftAssertions softly = new SoftAssertions();
+
+    HttpHeaders headers = new HttpHeaders();
+
+    headers.set(
+            HttpHeaders.CONTENT_TYPE,
+            "multipart/related; boundary=\"" + boundary + "\"; " +
+                    "type=\"application/xop+xml\"; " +
+                    "start=\"<rootpart@meditech.com>\"; " +
+                    "start-info=\"application/soap+xml\"; " +
+                    "action=\"urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b\""
+    );
+
+    headers.set(Constants.REQ_X_FORWARDED_PORT, "9000");
+    headers.set(Constants.REQ_X_SERVER_IP, "127.0.0.1");
+    headers.add("SOAPAction",
+            "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b");
+
+    HttpEntity<String> entity =
+            new HttpEntity<>(mtomRequest, headers);
+
+    ResponseEntity<String> response =
+            restTemplate.postForEntity(url, entity, String.class);
+
+    // ── HTTP status ───────────────────────────────────────────────
+    softly.assertThat(response.getStatusCode().value())
+            .as("HTTP status should be 200")
+            .isEqualTo(200);
+
+    // ── Content-Type header assertions ────────────────────────────
+    String contentType =
+            response.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+
+    softly.assertThat(contentType)
+            .as("MTOM Content-Type header is present")
+            .isNotBlank();
+
+    softly.assertThat(contentType)
+            .as("MTOM Content-Type is multipart/related")
+            .contains("multipart/related");
+
+    softly.assertThat(contentType)
+            .as("MTOM Content-Type contains quoted boundary")
+            .containsPattern("boundary=\"[A-Za-z0-9_\\-]+\"");
+
+    softly.assertThat(contentType)
+            .as("MTOM Content-Type contains quoted type")
+            .contains("type=\"application/xop+xml\"");
+
+    softly.assertThat(contentType)
+            .as("MTOM Content-Type contains start parameter")
+            .containsPattern("start=\"<rootpart@[^\"]+>\"");
+
+    softly.assertThat(contentType)
+            .as("MTOM Content-Type contains start-info")
+            .contains("start-info=\"application/soap+xml\"");
+
+    softly.assertThat(contentType)
+            .as("MTOM Content-Type contains action")
+            .contains("action=\"urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b\"");
+
+    // ── Boundary validation ───────────────────────────────────────
+    String headerBoundary =
+            extractBoundaryFromContentType(contentType);
+
+    String bodyBoundary =
+            extractMtomBoundary(response.getBody());
+
+    softly.assertThat(bodyBoundary)
+            .as("Body boundary must match Content-Type boundary")
+            .isEqualTo(headerBoundary);
+
+    softly.assertThat(response.getBody())
+            .as("Response contains MTOM boundaries")
+            .contains("--" + bodyBoundary)
+            .contains("--" + bodyBoundary + "--");
+
+    // ── MTOM MIME validation ──────────────────────────────────────
+    softly.assertThat(response.getBody())
+            .as("Response contains XOP MIME part")
+            .contains("Content-Type: application/xop+xml");
+
+    softly.assertThat(response.getBody())
+            .as("Response contains binary encoding")
+            .contains("Content-Transfer-Encoding: binary");
+
+    softly.assertThat(response.getBody())
+            .as("Response contains root content-id")
+            .contains("Content-ID: <rootpart@");
+
+    // ── SOAP response validation ──────────────────────────────────
+    softly.assertThat(response.getBody())
+            .as("Response contains SOAP Envelope")
+            .contains("Envelope");
+
+    softly.assertThat(response.getBody())
+            .as("Response contains RegistryResponse")
+            .contains("RegistryResponse");
+
+    softly.assertThat(response.getBody())
+            .as("Response contains Success status")
+            .contains("ResponseStatusType:Success");
+
+    assertMtomMessageIdRelatesTo(
+            response.getBody(),
+            softly
+    );
+    assertionHelper().assertHoldFlow(
+        holdFlowParams(
+                mtomRequest,
+                null,
+                "netspective_m_pnr",
+                9000,
+                "/outbound",
+                "/outbound",
+                "netspective_m_pnr",
+                queueUrls.get("txd-sbx-main-queue.fifo"))
+                .toBuilder()
+                .build(),
+        softly);
+
+    softly.assertAll();
+}
+
+
+        @Test
+@DisplayName("IT: /ingest/netspective_mt/pnr → TruBridge MTOM response validation")
+void shouldProcessPnrMtomResponseTypeTruBridge_returnsTruBridgeHeaders() throws Exception {
+
+
+    String boundary = "Boundary_12345";
+
+String mtomRequest =
+        "--" + boundary + "\r\n" +
+        "Content-Type: application/xop+xml; charset=UTF-8; type=\"application/soap+xml\"\r\n" +
+        "Content-Transfer-Encoding: binary\r\n" +
+        "Content-ID: <rootpart@meditech.com>\r\n" +
+        "\r\n" +
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+        "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"\r\n" +
+        "               xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\r\n" +
+        "\r\n" +
+        "  <soap:Header>\r\n" +
+        "    <wsa:To>https://heltestmcccd.myhie.com:9135/xds/XDSbRepositoryWS</wsa:To>\r\n" +
+        "    <wsa:MessageID>f19a3e9e-324d-4c6c-8a96-6747955d86f5</wsa:MessageID>\r\n" +
+        "    <wsa:Action>urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b</wsa:Action>\r\n" +
+        "  </soap:Header>\r\n" +
+        "\r\n" +
+        "  <soap:Body>\r\n" +
+        "    <ProvideAndRegisterDocumentSetRequest xmlns=\"urn:ihe:iti:xds-b:2007\">\r\n" +
+        "      <Document id=\"Document1\">\r\n" +
+        "        <xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\"\r\n" +
+        "                     href=\"cid:payload@meditech.com\"/>\r\n" +
+        "      </Document>\r\n" +
+        "    </ProvideAndRegisterDocumentSetRequest>\r\n" +
+        "  </soap:Body>\r\n" +
+        "\r\n" +
+        "</soap:Envelope>\r\n" +
+        "\r\n" +
+        "--" + boundary + "\r\n" +
+        "Content-Type: text/xml; charset=UTF-8\r\n" +
+        "Content-Transfer-Encoding: binary\r\n" +
+        "Content-ID: <payload@meditech.com>\r\n" +
+        "\r\n" +
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+        "<ClinicalDocument xmlns=\"urn:hl7-org:v3\">\r\n" +
+        "  <id extension=\"1\" root=\"test\"/>\r\n" +
+        "</ClinicalDocument>\r\n" +
+        "\r\n" +
+        "--" + boundary + "--\r\n";
+        
+    SoftAssertions softly = new SoftAssertions();
+
+    
+
+        ResponseEntity<String> responseEntity =
+        sendMtomRequestRaw(mtomRequest, "9000", softly);
+    
+    // ── HTTP status ───────────────────────────────────────────────
+    softly.assertThat(responseEntity.getStatusCode().value())
+            .as("HTTP status should be 200")
+            .isEqualTo(200);
+
+    // ── Content-Type header assertions ────────────────────────────
+    String contentType =
+            responseEntity.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+
+    softly.assertThat(contentType)
+            .as("TruBridge MTOM Content-Type header is present")
+            .isNotBlank();
+
+    softly.assertThat(contentType)
+            .as("TruBridge MTOM Content-Type is multipart/related")
+            .contains("multipart/related");
+
+    softly.assertThat(contentType)
+            .as("TruBridge MTOM Content-Type contains unquoted boundary")
+            .containsPattern("boundary=[A-Za-z0-9_\\-]+");
+
+    softly.assertThat(contentType)
+            .as("TruBridge MTOM Content-Type contains unquoted type")
+            .contains("type=application/xop+xml");
+
+    softly.assertThat(contentType)
+            .as("TruBridge MTOM omits start/start-info/action")
+            .doesNotContain("start=")
+            .doesNotContain("start-info=")
+            .doesNotContain("action=");
+
+
+    // ── Boundary validation ───────────────────────────────────────
+    String headerBoundary =
+            extractBoundaryFromContentType(contentType);
+
+    String bodyBoundary =
+            extractMtomBoundary(responseEntity.getBody());
+
+    softly.assertThat(bodyBoundary)
+            .as("Body boundary must match Content-Type boundary")
+            .isEqualTo(headerBoundary);
+
+    softly.assertThat(responseEntity.getBody())
+            .as("Response contains MTOM boundaries")
+            .contains("--" + bodyBoundary)
+            .contains("--" + bodyBoundary + "--");
+
+    // ── MTOM MIME validation ──────────────────────────────────────
+    softly.assertThat(responseEntity.getBody())
+            .as("Response contains XOP MIME part")
+            .contains("Content-Type: application/xop+xml");
+
+    softly.assertThat(responseEntity.getBody())
+            .as("Response contains binary encoding")
+            .contains("Content-Transfer-Encoding: binary");
+
+    softly.assertThat(responseEntity.getBody())
+            .as("Response contains root content-id")
+            .contains("Content-ID: <rootpart@");
+
+    // ── SOAP response validation ──────────────────────────────────
+    softly.assertThat(responseEntity.getBody())
+            .as("Response contains SOAP Envelope")
+            .contains("Envelope");
+
+    softly.assertThat(responseEntity.getBody())
+            .as("Response contains RegistryResponse")
+            .contains("RegistryResponse");
+
+    softly.assertThat(responseEntity.getBody())
+            .as("Response contains Success status")
+            .contains("ResponseStatusType:Success");
+
+    assertMtomMessageIdRelatesTo(
+            responseEntity.getBody(),
+            softly
+    );
+
+    assertionHelper().assertHoldFlow(
+        holdFlowParams(
+                mtomRequest,
+                null,
+                "netspective_mt_pnr",
+                9000,
+                "/outbound",
+                "/outbound",
+                "netspective_mt_pnr",
+                queueUrls.get("txd-sbx-main-queue.fifo"))
+                .toBuilder()
+                .build(),
+        softly);
+    
+
+    softly.assertAll();
+}
+
+
+@Test
+@DisplayName("IT: /ingest/netspective/pnr → SOAP XML response validation")
+void shouldProcessPnrSoapXmlAck_returnsSoapXmlHeaders() throws Exception {
+
+    String url = "http://localhost:" + port + "/ingest/netspective/pnr";
+
+    String soapRequest = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <soapenv:Envelope
+            xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:wsa="http://www.w3.org/2005/08/addressing"
+            xmlns:xdsb="urn:ihe:iti:xds-b:2007"
+            xmlns:hl7="urn:hl7-org:v3">
+
+            <soapenv:Header>
+                <wsa:To>
+                    https://heltestmcccd.myhie.com:9135/xds/XDSbRepositoryWS
+                </wsa:To>
+
+                <wsa:MessageID>
+                    urn:uuid:12345678-90ab-cdef-1234-567890abcdef
+                </wsa:MessageID>
+
+                <wsa:Action>
+                    urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b
+                </wsa:Action>
+            </soapenv:Header>
+
+            <soapenv:Body>
+                <xdsb:ProvideAndRegisterDocumentSetRequest>
+                    <xdsb:Document id="Document1">
+
+                        <hl7:ClinicalDocument>
+                            <hl7:id extension="1" root="test"/>
+                        </hl7:ClinicalDocument>
+
+                    </xdsb:Document>
+                </xdsb:ProvideAndRegisterDocumentSetRequest>
+            </soapenv:Body>
+
+        </soapenv:Envelope>
+        """;
+
+    SoftAssertions softly = new SoftAssertions();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.TEXT_XML);
+
+    headers.set(Constants.REQ_X_FORWARDED_PORT, "9000");
+    headers.set(Constants.REQ_X_SERVER_IP, "127.0.0.1");
+
+    headers.add(
+            "SOAPAction",
+            "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b"
+    );
+
+    HttpEntity<String> entity =
+            new HttpEntity<>(soapRequest, headers);
+
+    ResponseEntity<String> responseEntity =
+            restTemplate.postForEntity(
+                    url,
+                    entity,
+                    String.class
+            );
+
+    // ── HTTP status ───────────────────────────────────────────────
+    softly.assertThat(responseEntity.getStatusCode().value())
+            .as("HTTP status should be 200")
+            .isEqualTo(200);
+
+    // ── Content-Type header assertions ────────────────────────────
+    String contentType =
+            responseEntity.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+
+    softly.assertThat(contentType)
+            .as("SOAP XML Content-Type header is present")
+            .isNotBlank();
+
+    softly.assertThat(contentType)
+            .as("SOAP XML Content-Type is application/soap+xml")
+            .contains("application/soap+xml");
+
+    softly.assertThat(contentType)
+            .as("SOAP XML response is not multipart")
+            .doesNotContain("multipart/related");
+
+    softly.assertThat(contentType)
+            .as("SOAP XML response does not contain MTOM boundary")
+            .doesNotContain("boundary=");
+
+    // ── SOAP response validation ──────────────────────────────────
+    String responseBody = responseEntity.getBody();
+
+    softly.assertThat(responseBody)
+            .as("Response body is present")
+            .isNotBlank();
+
+    softly.assertThat(responseBody)
+            .as("Response contains SOAP Envelope")
+            .contains("Envelope");
+
+    softly.assertThat(responseBody)
+            .as("Response contains RegistryResponse")
+            .contains("RegistryResponse");
+
+    softly.assertThat(responseBody)
+            .as("Response contains Success status")
+            .contains("ResponseStatusType:Success");
+
+    softly.assertThat(responseBody)
+            .as("Response is plain SOAP XML and not MTOM")
+            .doesNotContain("Content-ID:")
+            .doesNotContain("application/xop+xml")
+            .doesNotContain("Content-Transfer-Encoding");
+
+   
+
+    assertionHelper().assertHoldFlow(
+        holdFlowParams(
+                soapRequest,
+                null,
+                "netspective_pnr",
+                9000,
+                "/outbound",
+                "/outbound",
+                "netspective_pnr",
+                queueUrls.get("txd-sbx-main-queue.fifo"))
+                .toBuilder()
+                .build(),
+        softly);
+
+    softly.assertAll();
+}
+
+
       
 
         private String validPixSoapRequest() {
@@ -600,4 +1060,156 @@ class DataIngestionControllerITCase extends BaseIntegrationTest {
         }
         }
 
+
+        /**
+     * Extracts the boundary value from a {@code Content-Type} header string.
+     * Handles both quoted ({@code boundary="..."}) and unquoted
+     * ({@code boundary=...}) forms.
+     *
+     * @param contentType the raw Content-Type header value
+     * @return the bare boundary string (without surrounding quotes)
+     */
+    private static String extractBoundaryFromContentType(String contentType) {
+        for (String part : contentType.split(";")) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith("boundary=")) {
+                String value = trimmed.substring("boundary=".length()).trim();
+                // Strip surrounding quotes if present
+                if (value.startsWith("\"") && value.endsWith("\"")) {
+                    value = value.substring(1, value.length() - 1);
+                }
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("No boundary parameter found in Content-Type: " + contentType);
+    }
+
+    private static String extractMtomBoundary(String mtomRaw) {
+        for (String line : mtomRaw.split("\r?\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("--") && !trimmed.equals("--")) {
+                return trimmed.substring(2);
+            }
+        }
+        throw new IllegalArgumentException("Could not extract MTOM boundary from fixture");
+    }
+
+
+    /**
+     * Asserts that the MTOM response body contains a structurally valid
+     * {@code wsa:RelatesTo} element holding a UUID-formatted value.
+     * The actual UUID is generated fresh per request and is not asserted verbatim.
+     */
+    private static void assertMtomMessageIdRelatesTo(String responseBody, SoftAssertions softly) {
+        softly.assertThat(responseBody)
+                .as("Response body contains wsa:RelatesTo element")
+                .contains("wsa:RelatesTo");
+        // UUID format: 8-4-4-4-12 hex chars separated by hyphens
+        softly.assertThat(responseBody)
+                .as("Response wsa:RelatesTo contains a UUID-formatted value")
+                .containsPattern(
+                        "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+    }
+
+
+
+
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // NEW private helper — add alongside the existing sendMtomRequestEntity
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Sends an MTOM request and returns the raw {@link ResponseEntity} 
+     *
+     *
+     * <p>This uses {@code RestTemplate.execute()} with a custom response extractor
+     * that manually reads the response body and headers without invoking Spring's
+     * content-type negotiation or {@code MediaType.parseMediaType()}, allowing
+     * inspection of raw headers and body.
+     *
+     * @param mtomRaw       raw MTOM fixture body
+     * @param forwardedPort value for {@code X-Forwarded-Port} header
+     * @param softly        soft-assertion collector (status assertion added here)
+     * @return raw response entity with unparsed headers
+     */
+    private ResponseEntity<String> sendMtomRequestRaw(String mtomRaw, String forwardedPort,
+            SoftAssertions softly) throws Exception {
+        String boundary = extractMtomBoundary(mtomRaw);
+
+        HttpHeaders headers = new HttpHeaders();
+        // Send request with a quoted Content-Type — that is always valid on the request side.
+        headers.set(HttpHeaders.CONTENT_TYPE,
+                "multipart/related; type=\"application/xop+xml\"; boundary=\"" + boundary + "\"; "
+                        + "start=\"<rootpart@meditech.com>\"; start-info=\"application/soap+xml\"");
+        headers.set(Constants.REQ_X_FORWARDED_PORT, forwardedPort);
+        headers.set(Constants.REQ_X_SERVER_IP, "127.0.0.1");
+
+        // Use RestTemplate.execute() with a custom response extractor that bypasses
+        // Spring's content-type parsing. This allows us to read raw headers even if
+        // they contain non-RFC-2045–compliant token characters like "/" in unquoted values.
+        ResponseEntity<String> response = restTemplate.execute(
+                "http://localhost:" + port + "/ingest/netspective_mt/pnr",
+                org.springframework.http.HttpMethod.POST,
+                req -> {
+                    req.getHeaders().addAll(headers);
+                    req.getBody().write(mtomRaw.getBytes(StandardCharsets.UTF_8));
+                },
+                clientResponse -> {
+                    String body = new String(clientResponse.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                    HttpHeaders responseHeaders = clientResponse.getHeaders();
+                    return new ResponseEntity<>(body, responseHeaders, clientResponse.getStatusCode());
+                }
+        );
+
+        softly.assertThat(response.getStatusCode().is2xxSuccessful())
+                .as("TruBridge MTOM response must be 2xx")
+                .isTrue();
+        return response;
+    }
+
+
+
+     /**
+     * Builds a {@link FlowAssertionParams} for a hold-flow scenario.
+     *
+     * @param payload     raw XML sent
+     * @param ackFixture  expected ACK fixture (null to skip ACK XPath check)
+     * @param groupId     expected SQS {@code messageGroupId}
+     * @param portNum     listening port (used in hold key when no tenant)
+     * @param dataDir     {@code dataDir} from port-config (e.g. {@code "/http"})
+     * @param metadataDir {@code metadataDir} from port-config (e.g. {@code "/outbound"})
+     * @param tenantId    tenant segment ({@code sourceId_msgType}); null if absent
+     * @param queueUrl    SQS queue URL for this entry
+     */
+    private FlowAssertionParams holdFlowParams(
+            String payload, String ackFixture, String groupId,
+            int portNum, String dataDir, String metadataDir,
+            String tenantId, String queueUrl) {
+
+        FlowAssertionParams.Builder b = FlowAssertionParams.builder()
+                .dataBucket(HOLD_BUCKET)
+                .metadataBucket(null)           // hold: metadata in same bucket as data
+                .holdFlow(true)
+                .port(portNum)
+                .dataDir(dataDir)
+                .metadataDir(metadataDir)
+                .tenantId(tenantId)
+                .queueUrl(queueUrl)
+                .expectedMessageGroupId(groupId)
+                .expectedPayload(payload)
+                .payloadNormalizer(IngestionAssertionHelper::normalizeXml)
+                .ackExpected(true);
+
+        if (ackFixture != null) {
+            b.ackXPathAssertions((ackXml, softly) -> {
+                softly.assertThat(extractXPath(ackXml, "//sender/device/id/@root"))
+                        .isEqualTo(extractXPath(ackFixture, "//sender/device/id/@root"));
+                softly.assertThat(extractXPath(ackXml, "//receiver/device/id/@root"))
+                        .isEqualTo(extractXPath(ackFixture, "//receiver/device/id/@root"));
+            });
+        }
+        return b.build();
+    }
 }
+

--- a/nexus-ingestion-api/src/test/resources/org/techbd/ingest/portconfig/list.json
+++ b/nexus-ingestion-api/src/test/resources/org/techbd/ingest/portconfig/list.json
@@ -7,11 +7,29 @@
     {
         "sourceId":"netspective",
         "msgType":"pnr",
-        "protocol": "TCP",
+        "protocol": "HTTP",
         "route": "/hold",
         "dataDir": "/outbound",
         "metadataDir": "/outbound",
         "ackContentType": "application/soap+xml"
+    },
+    {
+        "sourceId": "netspective_m",
+        "msgType": "pnr",
+        "protocol": "HTTP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "responseType": "mtom"
+    },
+    {
+        "sourceId": "netspective_mt",
+        "msgType": "pnr",
+        "protocol": "HTTP",
+        "route": "/hold",
+        "dataDir": "/outbound",
+        "metadataDir": "/outbound",
+        "responseType": "mtom_trubridge"
     },
     {
         "port": 6555,

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1143.0</revision>
+        <revision>0.1144.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Added Integration Tests for PNR Ingestion Response Validation

1. MTOM Multipart Response Validation — netspective_m/pnr
Added integration test to validate MTOM multipart SOAP response handling for PNR ingestion requests routed through /ingest/netspective_m/pnr.

2. TruBridge MTOM Response Validation — netspective_mt/pnr
Added integration test for TruBridge-specific MTOM ACK response formatting and multipart handling.

3. SOAP XML ACK Response Validation — netspective/pnr
Added integration test to validate plain SOAP XML acknowledgment responses for PNR ingestion requests configured with ackContentType=application/soap+xml.