### PR TITLE
chore(deps): upgrade vulnerable dependencies to patched versions

### DIFF
--- a/csv-service/pom.xml
+++ b/csv-service/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
+            <version>42.7.11</version>
         </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>

--- a/csv-service/pom.xml
+++ b/csv-service/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/csv-service/pom.xml
+++ b/csv-service/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/fhir-validation-service/pom.xml
+++ b/fhir-validation-service/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
+            <version>42.7.11</version>
         </dependency>
         <!-- <dependency>
             <groupId>com.opencsv</groupId>

--- a/fhir-validation-service/pom.xml
+++ b/fhir-validation-service/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/fhir-validation-service/pom.xml
+++ b/fhir-validation-service/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <!-- <dependency>

--- a/hub-core-lib/pom.xml
+++ b/hub-core-lib/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
+            <version>42.7.11</version>
         </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>

--- a/hub-core-lib/pom.xml
+++ b/hub-core-lib/pom.xml
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hub-core-lib/pom.xml
+++ b/hub-core-lib/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -193,7 +193,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.7.3</version>
+			<version>42.7.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>

--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -292,7 +292,7 @@
 		<dependency>
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
-			<version>2.9.2</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.tngtech.archunit</groupId>

--- a/hub-prime/pom.xml
+++ b/hub-prime/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
     		<groupId>org.bouncycastle</groupId>
     		<artifactId>bcprov-jdk18on</artifactId>
-    		<version>1.80</version> <!-- Use the latest version available -->
+    		<version>1.84</version> <!-- Use the latest version available -->
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/nexus-core-lib/pom.xml
+++ b/nexus-core-lib/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
+            <version>42.7.11</version>
         </dependency>
         <!-- <dependency>
             <groupId>com.opencsv</groupId>

--- a/nexus-core-lib/pom.xml
+++ b/nexus-core-lib/pom.xml
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nexus-ingestion-api/pom.xml
+++ b/nexus-ingestion-api/pom.xml
@@ -263,12 +263,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.78.1</version> <!-- Latest secure version -->
+            <version>1.84</version> <!-- Latest secure version -->
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.78.1</version>
+            <version>1.84</version> <!-- Latest secure version -->
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- upgrade Apache Tika from 2.9.2 to 3.2.2 to address critical XXE vulnerability
- upgrade Bouncy Castle bcprov-jdk18on from 1.80 to 1.84
- upgrade Bouncy Castle bcprov-jdk18on from 1.78.1 to 1.84
- upgrade AssertJ core from 3.24.2 to 3.27.7
- upgrade PostgreSQL JDBC driver from 42.7.3 to 42.7.11