### PR TITLE
fix: handle empty XDS SOAP request by returning a SOAP fault response (3007)

### DIFF
--- a/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/XdsRepositoryController.java
+++ b/nexus-ingestion-api/src/main/java/org/techbd/ingest/controller/XdsRepositoryController.java
@@ -16,6 +16,7 @@ import org.techbd.ingest.util.AppLogger;
 import org.techbd.ingest.util.TemplateLogger;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
 
 @RestController
 @RequestMapping("/xds")
@@ -54,8 +55,26 @@ public class XdsRepositoryController extends AbstractMessageSourceProvider {
         byte[] rawBytes = request.getInputStream().readAllBytes();
 
         if (rawBytes == null || rawBytes.length == 0) {
+                    LOG.warn("Empty XDS SOAP request. interactionId={}", interactionId);
+
             LOG.warn("Empty XDS SOAP request. interactionId={}", interactionId);
-            return forwarder.forward(request, new byte[0], interactionId);
+
+            String soapFault = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                    <soap:Body>
+                        <soap:Fault>
+                            <faultcode>soap:Client</faultcode>
+                            <faultstring>Empty SOAP request body</faultstring>
+                        </soap:Fault>
+                    </soap:Body>
+                </soap:Envelope>
+                """;
+
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .header("Content-Type", "text/xml; charset=utf-8")
+                    .body(soapFault);
         }
         LOG.info("Forwarding XDS SOAP request to /ws. interactionId={}",interactionId);
         return forwarder.forward(request, rawBytes, interactionId);

--- a/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/XdsRepositoryControllerITCase.java
+++ b/nexus-ingestion-api/src/test/java/org/techbd/ingest/integrationtests/controller/XdsRepositoryControllerITCase.java
@@ -161,7 +161,7 @@ class XdsRepositoryControllerITCase extends BaseIntegrationTest {
                     String.class);
 
             assertThat(response.getStatusCode())
-            .isEqualTo(HttpStatus.ACCEPTED);
+            .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         /**


### PR DESCRIPTION
handle empty XDS SOAP request by returning a SOAP fault response