### PR TITLE
fix: resolve datalake URI race condition and update timeout configuration #1515

### DIFF
--- a/integration-artifacts/Router/RouterChannel.xml
+++ b/integration-artifacts/Router/RouterChannel.xml
@@ -1,21 +1,23 @@
-<channel version="4.6.1">
-  <id>35ee3e0b-ad66-44c5-bf30-6ebe8ff7c7ec</id>
+<channel version="26.3.1">
+  <id>520ded48-a0be-4492-8cba-4fad5a227afd</id>
   <nextMetaDataId>3</nextMetaDataId>
   <name>RouterChannel</name>
-  <description>Version: 0.2.13
-Error response message update</description>
-  <revision>30</revision>
-  <sourceConnector version="4.6.1">
+  <description>Version: 0.2.14
+Increased timeout configuration to 300000 ms for long-running request handling.
+</description>
+  <revision>14</revision>
+  <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.6.1">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.6.1">
-  <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>true</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
+          <mutualTlsMigrated>true</mutualTlsMigrated>
+          <clientCertValidationEnabled>false</clientCertValidationEnabled>
+          <clientCertOptionalEnabled>false</clientCertOptionalEnabled>
+          <serverCertValidationEnabled>true</serverCertValidationEnabled>
           <verifyHostname>false</verifyHostname>
           <keystorePath/>
           <keystorePassword/>
@@ -33,13 +35,19 @@ Error response message update</description>
           <myCertificateAlias>bridgelink</myCertificateAlias>
           <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
           <truststoreUid/>
+          <softFailIfResponderUnavailable>false</softFailIfResponderUnavailable>
+          <pinnedLeafPins/>
+          <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="4.6.1">
+      <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
         <port>9000</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="4.6.1">
+      <sourceConnectorProperties version="26.3.1">
         <responseVariable>d1</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -66,7 +74,8 @@ Error response message update</description>
       <useResponseHeadersVariable>false</useResponseHeadersVariable>
       <charset>UTF-8</charset>
       <contextPath></contextPath>
-      <timeout>30000</timeout>
+      <timeout>300000</timeout>
+      <requestHeaderSize>8192</requestHeaderSize>
       <staticResources>
         <com.mirth.connect.connectors.http.HttpStaticResource>
           <contextPath>/healthcheck</contextPath>
@@ -76,9 +85,9 @@ Error response message update</description>
         </com.mirth.connect.connectors.http.HttpStaticResource>
       </staticResources>
     </properties>
-    <transformer version="4.6.1">
+    <transformer version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>mTLS filter disabled guard</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -95,7 +104,7 @@ if (String(mtlsEnabled) !== &apos;true&apos;) {
 	return;
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>pass original headers</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -109,7 +118,7 @@ logger.info(&quot;Request URL inside RouterChannel: &quot; + requestedPath);
 var contentType = $(&apos;headers&apos;).getHeader(&apos;Content-Type&apos;);
 channelMap.put(&quot;contentType&quot;, contentType);</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>redirection</name>
           <sequenceNumber>2</sequenceNumber>
           <enabled>true</enabled>
@@ -170,22 +179,22 @@ logger.info(fhirJson);</script>
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>RAW</inboundDataType>
       <outboundDataType>RAW</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </outboundProperties>
     </transformer>
-    <filter version="4.6.1">
+    <filter version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="4.6.1">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
           <name>MTLS-client-cert-validation</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -235,6 +244,10 @@ var remoteAddress = sourceMap.get(&apos;remoteAddress&apos;) || &apos;&apos;;&#x
 
 var group1 = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Group-Interaction-ID&apos;);
 
+var group2 = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Interaction-ID&apos;);
+channelMap.put(&apos;group2&apos;, group2);
+logger.info(&quot;Interaction-ID inside RouterChannel filter: &quot; + group2 + &apos;contextPath&apos; + contextPath );
+
 var sourceType = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Source-Type&apos;);
 
 if(sourceType == &quot;CSV&quot;) { // TODO: Add a dedicated condition to handle the health check when the filter is enabled.
@@ -251,14 +264,18 @@ if(sourceType == &quot;CSV&quot;) { // TODO: Add a dedicated condition to handle
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="4.6.1">
+    <connector version="26.3.1">
       <metaDataId>1</metaDataId>
       <name>response_operationoutcome</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="4.6.1">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.1">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>true</sslEnabled>
             <mutualTlsEnabled>false</mutualTlsEnabled>
+            <mutualTlsMigrated>true</mutualTlsMigrated>
+            <clientCertValidationEnabled>false</clientCertValidationEnabled>
+            <clientCertOptionalEnabled>false</clientCertOptionalEnabled>
+            <serverCertValidationEnabled>true</serverCertValidationEnabled>
             <verifyHostname>false</verifyHostname>
             <keystorePath/>
             <keystorePassword/>
@@ -276,9 +293,12 @@ if(sourceType == &quot;CSV&quot;) { // TODO: Add a dedicated condition to handle
             <myCertificateAlias/>
             <truststoreSettingFromSystem>true</truststoreSettingFromSystem>
             <truststoreUid>Util-sbx-bl-net.JKS</truststoreUid>
+            <softFailIfResponderUnavailable>false</softFailIfResponderUnavailable>
+            <pinnedLeafPins/>
+            <subjectSanFilterPatterns/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="4.6.1">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -298,9 +318,13 @@ if(sourceType == &quot;CSV&quot;) { // TODO: Add a dedicated condition to handle
           <queueBufferSize>1000</queueBufferSize>
           <reattachAttachments>true</reattachAttachments>
           <pluginProperties>
-            <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="4.6.1">
+            <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
               <mutualTlsEnabled>false</mutualTlsEnabled>
+              <mutualTlsMigrated>false</mutualTlsMigrated>
+              <clientCertValidationEnabled>false</clientCertValidationEnabled>
+              <clientCertOptionalEnabled>false</clientCertOptionalEnabled>
+              <serverCertValidationEnabled>false</serverCertValidationEnabled>
               <verifyHostname>false</verifyHostname>
               <keystorePath/>
               <keystorePassword/>
@@ -318,6 +342,7 @@ if(sourceType == &quot;CSV&quot;) { // TODO: Add a dedicated condition to handle
               <myCertificateAlias/>
               <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
               <truststoreUid/>
+              <softFailIfResponderUnavailable>false</softFailIfResponderUnavailable>
             </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
           </pluginProperties>
         </destinationConnectorProperties>
@@ -481,11 +506,11 @@ if(sourceType == &quot;CSV&quot;) { // TODO: Add a dedicated condition to handle
         <contentType>${contentType}</contentType>
         <dataTypeBinary>false</dataTypeBinary>
         <charset>UTF-8</charset>
-        <socketTimeout>30000</socketTimeout>
+        <socketTimeout>300000</socketTimeout>
       </properties>
-      <transformer version="4.6.1">
+      <transformer version="26.3.1">
         <elements>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.6.1">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
             <name>pass headers to destination</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -569,39 +594,39 @@ return &apos;&apos;;</script>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="4.6.1">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="4.6.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="4.6.1">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="4.6.1">
+      <filter version="26.3.1">
         <elements/>
       </filter>
       <transportName>HTTP Sender</transportName>
@@ -826,7 +851,7 @@ return;</deployScript>
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="4.6.1">
+  <properties version="26.3.1">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>METADATA</messageStorageMode>
     <encryptData>false</encryptData>
@@ -849,7 +874,7 @@ return;</undeployScript>
         <mappingName>message_type</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="4.6.1">
+    <attachmentProperties version="26.3.1">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -864,7 +889,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1776695155212</time>
+        <time>1779255534618</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -875,15 +900,14 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>092dd061-ffe4-41e2-a257-e835d1d3a567</id>
-        <name>0_2_12</name>
+        <id>06df9290-6959-4fbc-a8ff-08c06e15feca</id>
+        <name>0_2_14</name>
         <channelIds>
-          <string>35ee3e0b-ad66-44c5-bf30-6ebe8ff7c7ec</string>
-          <string>2d6fac85-49e1-4aa8-b39f-b4e39f12597e</string>
+          <string>520ded48-a0be-4492-8cba-4fad5a227afd</string>
         </channelIds>
         <backgroundColor>
-          <red>128</red>
-          <green>0</green>
+          <red>255</red>
+          <green>255</green>
           <blue>0</blue>
           <alpha>255</alpha>
         </backgroundColor>

--- a/integration-artifacts/ccda/ccda-techbd-channel-files/nexus-sandbox/TechBD CCD Workflow.xml
+++ b/integration-artifacts/ccda/ccda-techbd-channel-files/nexus-sandbox/TechBD CCD Workflow.xml
@@ -1,19 +1,19 @@
-<channel version="26.3.0">
+<channel version="26.3.1">
   <id>c09ea42f-cb4b-4f67-92cd-830a1ab4c51c</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version 0.5.31
-Resolved race condition issue by replacing globalMap usage for FHIR Bundle Submission URL with channelMap-based request isolation.</description>
-  <revision>4</revision>
-  <sourceConnector version="26.3.0">
+  <description>Version 0.5.32
+Resolved race condition issue by replacing globalMap with channelMap for DataLake URL request isolation.</description>
+  <revision>9</revision>
+  <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.0">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.0">
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
   <authType>NONE</authType>
         </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
           <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -42,11 +42,11 @@ Resolved race condition issue by replacing globalMap usage for FHIR Bundle Submi
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="26.3.0">
+      <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
         <port>9002</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="26.3.0">
+      <sourceConnectorProperties version="26.3.1">
         <responseVariable>finalResponse</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -109,9 +109,9 @@ Resolved race condition issue by replacing globalMap usage for FHIR Bundle Submi
         </com.mirth.connect.connectors.http.HttpStaticResource>
       </staticResources>
     </properties>
-    <transformer version="26.3.0">
+    <transformer version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>DB Save</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -250,7 +250,7 @@ function saveCcdaPayload(interactionId, tenantId, requestUri, payloadJson, opera
 	}
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>Common JS functions</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -867,7 +867,7 @@ function convertCcdaToFhirBundle(phiFilteredXml) {
     return cleanedJsonString;
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>Validate HTTP Request and collect headers</name>
           <sequenceNumber>2</sequenceNumber>
           <enabled>true</enabled>
@@ -979,7 +979,7 @@ try {
     }
 
     channelMap.put(&quot;DATALAKE_API_URL&quot;, datalakeApiUrl);
-    globalMap.put(&quot;datalakeApiUrl&quot;, datalakeApiUrl);
+
     logger.info(&quot;✔ Datalake API URL loaded from Lookup Manager(config)&quot;);
 
 } catch (e) {
@@ -1000,7 +1000,7 @@ try {
         // Header provided - use it as override
         headerDataLakeApiUrl = headerDataLakeApiUrl.trim();
         channelMap.put(&quot;DATALAKE_API_URL&quot;, headerDataLakeApiUrl);
-        globalMap.put(&quot;datalakeApiUrl&quot;, headerDataLakeApiUrl);
+        
         logger.info(&quot;✔DataLake API URL overridden from request header: &quot; + headerDataLakeApiUrl);
     } 
 
@@ -1407,7 +1407,7 @@ logger.info(&quot;jdbcPassword loaded successfully.&quot;);
     throw errorMessage; // Stop further processing by throwing an exception
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>step_validate_profile_urls_env_variables</name>
           <sequenceNumber>3</sequenceNumber>
           <enabled>true</enabled>
@@ -2217,7 +2217,7 @@ function getConsentResourceStatus(sourceXml) {
      }
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>Validate Mandatory Fields</name>
           <sequenceNumber>4</sequenceNumber>
           <enabled>true</enabled>
@@ -2392,7 +2392,7 @@ function validateMandatoryFields() {
     return null; // validation passed
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>API endpoint processing</name>
           <sequenceNumber>5</sequenceNumber>
           <enabled>true</enabled>
@@ -2715,11 +2715,11 @@ else {
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>XML</inboundDataType>
       <outboundDataType>RAW</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.0">
-        <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.0">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.1">
+        <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.1">
           <stripNamespaces>false</stripNamespaces>
         </serializationProperties>
-        <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.1">
           <splitType>Element_Name</splitType>
           <elementName></elementName>
           <level>1</level>
@@ -2727,16 +2727,16 @@ else {
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </outboundProperties>
     </transformer>
-    <filter version="26.3.0">
+    <filter version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.0">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
           <name>Http url and method validation</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -2860,12 +2860,12 @@ function notFound() {
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>1</metaDataId>
       <name>dest_bundle_validate</name>
-      <properties class="com.mirth.connect.connectors.vm.VmDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.vm.VmDispatcherProperties" version="26.3.1">
         <pluginProperties/>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -2889,45 +2889,45 @@ function notFound() {
         <channelTemplate>${message.encodedData}</channelTemplate>
         <mapVariables/>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements>
-          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.0">
+          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.1">
             <name>Accept message if &quot;$(&apos;endpoint&apos;)&quot; equals &apos;validate&apos;</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -2944,12 +2944,12 @@ function notFound() {
       <enabled>true</enabled>
       <waitForPrevious>true</waitForPrevious>
     </connector>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>2</metaDataId>
       <name>dest_bundle</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.1">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
             <mutualTlsEnabled>false</mutualTlsEnabled>
             <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -2978,7 +2978,7 @@ function notFound() {
             <subjectSanFilterPatterns/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -3136,45 +3136,45 @@ function notFound() {
         <charset>UTF-8</charset>
         <socketTimeout>300000</socketTimeout>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements>
-          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.0">
+          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.1">
             <name>Accept message if &quot;$(&apos;endpoint&apos;)&quot; equals &apos;bundle&apos;</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -3184,7 +3184,7 @@ function notFound() {
               <string>&apos;bundle&apos;</string>
             </values>
           </com.mirth.connect.plugins.rulebuilder.RuleBuilderRule>
-          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.0">
+          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.1">
             <name>Accept message if &quot;sourceMap.get(&apos;contextPath&apos;)&quot; equals &apos;/ccda/Bundle/&apos; or &apos;/ccda/Bundle&apos;</name>
             <sequenceNumber>1</sequenceNumber>
             <enabled>true</enabled>
@@ -3240,7 +3240,7 @@ return;
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="26.3.0">
+  <properties version="26.3.1">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>METADATA</messageStorageMode>
     <encryptData>false</encryptData>
@@ -3263,7 +3263,7 @@ return;</undeployScript>
         <mappingName>message_type</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="26.3.0">
+    <attachmentProperties version="26.3.1">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -3278,7 +3278,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1778845905252</time>
+        <time>1779209302080</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -3289,15 +3289,15 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>64e88e55-81d0-48c1-a9af-3ee59ba47a5a</id>
-        <name>0_5_31</name>
+        <id>e960d53a-be9f-4a30-844a-8ac7623e202c</id>
+        <name>0_5_32</name>
         <channelIds>
           <string>c09ea42f-cb4b-4f67-92cd-830a1ab4c51c</string>
         </channelIds>
         <backgroundColor>
-          <red>0</red>
-          <green>255</green>
-          <blue>255</blue>
+          <red>128</red>
+          <green>0</green>
+          <blue>0</blue>
           <alpha>255</alpha>
         </backgroundColor>
       </channelTag>

--- a/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundlleSubmission.xml
+++ b/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundlleSubmission.xml
@@ -1,19 +1,19 @@
-<channel version="26.3.0">
-  <id>1908260b-7361-46dc-a9c9-e7114b06e698</id>
+<channel version="26.3.1">
+  <id>9cbcd82b-a20e-4120-9d81-7c6698dfc1dd</id>
   <nextMetaDataId>4</nextMetaDataId>
   <name>FhirBundlleSubmission</name>
-  <description>Version: 0.8.29
-Resolved race condition issue by replacing globalMap usage for FHIR Bundle Submission URL with channelMap-based request isolation.</description>
+  <description>Version: 0.8.30
+Resolved race condition issue by replacing globalMap with channelMap for DataLake URL request isolation.</description>
   <revision>8</revision>
-  <sourceConnector version="26.3.0">
+  <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.0">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.0">
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
   <authType>NONE</authType>
         </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>true</mutualTlsEnabled>
           <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -44,11 +44,11 @@ Resolved race condition issue by replacing globalMap usage for FHIR Bundle Submi
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="26.3.0">
+      <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
         <port>9003</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="26.3.0">
+      <sourceConnectorProperties version="26.3.1">
         <responseVariable>finalResponse</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -100,7 +100,7 @@ Resolved race condition issue by replacing globalMap usage for FHIR Bundle Submi
       <useResponseHeadersVariable>false</useResponseHeadersVariable>
       <charset>DEFAULT_ENCODING</charset>
       <contextPath>/</contextPath>
-      <timeout>30000</timeout>
+      <timeout>300000</timeout>
       <requestHeaderSize>8192</requestHeaderSize>
       <staticResources>
         <com.mirth.connect.connectors.http.HttpStaticResource>
@@ -111,9 +111,9 @@ Resolved race condition issue by replacing globalMap usage for FHIR Bundle Submi
         </com.mirth.connect.connectors.http.HttpStaticResource>
       </staticResources>
     </properties>
-    <transformer version="26.3.0">
+    <transformer version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>lookup_manager</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -238,7 +238,6 @@ try {
     }
 
     channelMap.put(&quot;DATALAKE_API_URL&quot;, datalakeApiUrl);
-    globalMap.put(&quot;datalakeApiUrl&quot;, datalakeApiUrl);
 
 } catch (e) {
     logger.error(&quot;Error fetching Datalake API URL: &quot; + e);
@@ -416,7 +415,7 @@ function setErrorResponse(statusCode, errorMessage) {
     responseMap.put(&apos;finalResponse&apos;, createJsonResponse(statusCode, errorMessage));
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>FHIR Validation</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -473,22 +472,22 @@ responseMap.put(&apos;status&apos;, &apos;200&apos;); // Set HTTP status 200
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>RAW</inboundDataType>
       <outboundDataType>RAW</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </outboundProperties>
     </transformer>
-    <filter version="26.3.0">
+    <filter version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.0">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
           <name>Http url and method validation</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -610,12 +609,12 @@ function notFound() {
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>1</metaDataId>
       <name>dest_bundle</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.1">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
             <mutualTlsEnabled>true</mutualTlsEnabled>
             <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -646,7 +645,7 @@ function notFound() {
             <subjectSanFilterPatterns/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -820,45 +819,45 @@ function notFound() {
         <contentType>application/fhir+json</contentType>
         <dataTypeBinary>false</dataTypeBinary>
         <charset>UTF-8</charset>
-        <socketTimeout>30000</socketTimeout>
+        <socketTimeout>300000</socketTimeout>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements/>
       </filter>
       <transportName>HTTP Sender</transportName>
@@ -866,12 +865,12 @@ function notFound() {
       <enabled>true</enabled>
       <waitForPrevious>true</waitForPrevious>
     </connector>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>3</metaDataId>
       <name>dest_datalake</name>
-      <properties class="com.mirth.connect.connectors.js.JavaScriptDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.js.JavaScriptDispatcherProperties" version="26.3.1">
         <pluginProperties/>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -1059,9 +1058,9 @@ channelMap.put(&quot;datalake_response_message&quot;, dataLakeErrorMessage);
 
 return;</script>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
             <name>destination_datalake</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -1580,37 +1579,37 @@ function iterableToArrayStr(col) {&#xd;
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements/>
       </filter>
       <transportName>JavaScript Writer</transportName>
@@ -2430,7 +2429,7 @@ return;</deployScript>
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="26.3.0">
+  <properties version="26.3.1">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>METADATA</messageStorageMode>
     <encryptData>false</encryptData>
@@ -2453,7 +2452,7 @@ return;</undeployScript>
         <mappingName>message_type</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="26.3.0">
+    <attachmentProperties version="26.3.1">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -2468,7 +2467,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1778847182047</time>
+        <time>1779209154498</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -2479,13 +2478,13 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>1fed99a4-dc0e-4fc1-abb4-9ca4ddbd18b4</id>
-        <name>0_8_29</name>
+        <id>2355f83c-bab6-4b13-b45d-722b9ec6476f</id>
+        <name>0_8_30</name>
         <channelIds>
-          <string>1908260b-7361-46dc-a9c9-e7114b06e698</string>
+          <string>9cbcd82b-a20e-4120-9d81-7c6698dfc1dd</string>
         </channelIds>
         <backgroundColor>
-          <red>128</red>
+          <red>255</red>
           <green>0</green>
           <blue>0</blue>
           <alpha>255</alpha>

--- a/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundlleValidation.xml
+++ b/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundlleValidation.xml
@@ -1,19 +1,19 @@
-<channel version="26.3.0">
-  <id>fa2e04e2-8435-4a9c-bad2-ac65c1bb3a33</id>
+<channel version="26.3.1">
+  <id>96bd9c4c-3490-4ed9-9efe-4179e3d7d33d</id>
   <nextMetaDataId>5</nextMetaDataId>
   <name>FhirBundlleValidation</name>
-  <description>Version: 0.8.14
-Resolved Health Check handling issues to ensure proper data display in the UI and correct data persistence in the database.</description>
-  <revision>2</revision>
-  <sourceConnector version="26.3.0">
+  <description>Version: 0.8.15
+Increased timeout configuration to 300000 ms for long-running request handling.</description>
+  <revision>4</revision>
+  <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.0">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.0">
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
   <authType>NONE</authType>
         </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>true</mutualTlsEnabled>
           <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -44,11 +44,11 @@ Resolved Health Check handling issues to ensure proper data display in the UI an
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="26.3.0">
+      <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
         <port>9001</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="26.3.0">
+      <sourceConnectorProperties version="26.3.1">
         <responseVariable>finalResponse</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -100,7 +100,7 @@ Resolved Health Check handling issues to ensure proper data display in the UI an
       <useResponseHeadersVariable>false</useResponseHeadersVariable>
       <charset>DEFAULT_ENCODING</charset>
       <contextPath>/</contextPath>
-      <timeout>30000</timeout>
+      <timeout>300000</timeout>
       <requestHeaderSize>8192</requestHeaderSize>
       <staticResources>
         <com.mirth.connect.connectors.http.HttpStaticResource>
@@ -111,9 +111,9 @@ Resolved Health Check handling issues to ensure proper data display in the UI an
         </com.mirth.connect.connectors.http.HttpStaticResource>
       </staticResources>
     </properties>
-    <transformer version="26.3.0">
+    <transformer version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>lookup_manager</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -346,7 +346,7 @@ function setErrorResponse(statusCode, errorMessage) {
     responseMap.put(&apos;finalResponse&apos;, createJsonResponse(statusCode, errorMessage));
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>FHIR Validation</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -404,22 +404,22 @@ responseMap.put(&apos;status&apos;, &apos;200&apos;); // Set HTTP status 200
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>RAW</inboundDataType>
       <outboundDataType>RAW</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </outboundProperties>
     </transformer>
-    <filter version="26.3.0">
+    <filter version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.0">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
           <name>Htpp url and method validation</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -541,12 +541,12 @@ function notFound() {
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>1</metaDataId>
       <name>dest_bundle</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.1">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
             <mutualTlsEnabled>true</mutualTlsEnabled>
             <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -577,7 +577,7 @@ function notFound() {
             <subjectSanFilterPatterns/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -727,45 +727,45 @@ function notFound() {
         <contentType>application/fhir+json</contentType>
         <dataTypeBinary>false</dataTypeBinary>
         <charset>UTF-8</charset>
-        <socketTimeout>30000</socketTimeout>
+        <socketTimeout>300000</socketTimeout>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements/>
       </filter>
       <transportName>HTTP Sender</transportName>
@@ -1001,7 +1001,7 @@ return;</deployScript>
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="26.3.0">
+  <properties version="26.3.1">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>METADATA</messageStorageMode>
     <encryptData>false</encryptData>
@@ -1024,7 +1024,7 @@ return;</undeployScript>
         <mappingName>message_type</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="26.3.0">
+    <attachmentProperties version="26.3.1">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -1039,7 +1039,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1777351903771</time>
+        <time>1779209642449</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -1050,13 +1050,13 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>33ddab6d-7eec-4552-9e93-ef1638856ee4</id>
-        <name>0_8_14</name>
+        <id>e71737a3-3ae5-48ad-9868-a5ed18bee490</id>
+        <name>0_8_15</name>
         <channelIds>
-          <string>fa2e04e2-8435-4a9c-bad2-ac65c1bb3a33</string>
+          <string>96bd9c4c-3490-4ed9-9efe-4179e3d7d33d</string>
         </channelIds>
         <backgroundColor>
-          <red>128</red>
+          <red>255</red>
           <green>0</green>
           <blue>0</blue>
           <alpha>255</alpha>

--- a/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundle.xml
+++ b/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundle.xml
@@ -1,17 +1,20 @@
-<channel version="26.3.0">
+<channel version="26.3.1">
   <id>89def8c9-d8d2-46e2-a254-6345b05cfcb4</id>
   <nextMetaDataId>2</nextMetaDataId>
   <name>FlatFileCsvBundle</name>
-  <description>Version: 0.9.22
-Implemented validation and default fallback handling for the immediate query parameter.
+  <description>Version: 0.9.23
+Increased timeout configuration to 300000 ms for long-running request handling.
 </description>
-  <revision>13</revision>
-  <sourceConnector version="26.3.0">
+  <revision>4</revision>
+  <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.0">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
           <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -39,15 +42,12 @@ Implemented validation and default fallback handling for the immediate query par
           <pinnedLeafPins/>
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.0">
-  <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="26.3.0">
+      <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
         <port>9004</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="26.3.0">
+      <sourceConnectorProperties version="26.3.1">
         <responseVariable>fhirResponse</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -99,7 +99,7 @@ Implemented validation and default fallback handling for the immediate query par
       <useResponseHeadersVariable>false</useResponseHeadersVariable>
       <charset>DEFAULT_ENCODING</charset>
       <contextPath>/</contextPath>
-      <timeout>30000</timeout>
+      <timeout>300000</timeout>
       <requestHeaderSize>8192</requestHeaderSize>
       <staticResources>
         <com.mirth.connect.connectors.http.HttpStaticResource>
@@ -110,9 +110,9 @@ Implemented validation and default fallback handling for the immediate query par
         </com.mirth.connect.connectors.http.HttpStaticResource>
       </staticResources>
     </properties>
-    <transformer version="26.3.0">
+    <transformer version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>common js function</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -133,7 +133,7 @@ function setErrorResponse(statusCode, errorMessage) {
     responseMap.put(&apos;fhirResponse&apos;, createJsonResponse(statusCode, errorMessage));
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>lookup_manager</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -255,7 +255,7 @@ try {
 
 logger.info(&apos;[CHANNEL: &apos;+ channelName +&apos;  Lookup Manager Loader end &apos;);</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>Validate HTTP Request and collect headers</name>
           <sequenceNumber>2</sequenceNumber>
           <enabled>true</enabled>
@@ -469,7 +469,7 @@ if (!hasCsvFile) {
 }
 ///////////////////////////////////////////////////////////////////////////</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>FHIR validation and submission</name>
           <sequenceNumber>3</sequenceNumber>
           <enabled>true</enabled>
@@ -567,22 +567,22 @@ logger.info(&quot;[CHANNEL: &quot;+ channelName +&quot;] Prepared multipart/form
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>RAW</inboundDataType>
       <outboundDataType>RAW</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </outboundProperties>
     </transformer>
-    <filter version="26.3.0">
+    <filter version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.0">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
           <name>Http method and url checking</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -706,12 +706,12 @@ function notFound() {
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>1</metaDataId>
       <name>dest_bundle</name>
-      <properties class="com.mirth.connect.connectors.js.JavaScriptDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.js.JavaScriptDispatcherProperties" version="26.3.1">
         <pluginProperties/>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -860,43 +860,43 @@ channelMap.put(&quot;fhirResponseCode&quot;, responseCode);
 responseMap.put(&apos;fhirResponse&apos;, responseStr);
 </script>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements/>
       </filter>
       <transportName>JavaScript Writer</transportName>
@@ -913,7 +913,7 @@ return;</postprocessingScript>
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="26.3.0">
+  <properties version="26.3.1">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>METADATA</messageStorageMode>
     <encryptData>false</encryptData>
@@ -936,7 +936,7 @@ return;</undeployScript>
         <mappingName>message_type</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="26.3.0">
+    <attachmentProperties version="26.3.1">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -951,7 +951,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1778225130520</time>
+        <time>1779247517256</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -962,8 +962,8 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>619854e0-df17-4c7f-a28c-07769470fcb9</id>
-        <name>0_9_22</name>
+        <id>576da1f5-558f-4fea-ae7a-d76368d48ebc</id>
+        <name>0_9_23</name>
         <channelIds>
           <string>89def8c9-d8d2-46e2-a254-6345b05cfcb4</string>
         </channelIds>

--- a/integration-artifacts/hl7v2/hl7-techbd-channel-files/nexus-sandbox/TechBD HL7 Workflow.xml
+++ b/integration-artifacts/hl7v2/hl7-techbd-channel-files/nexus-sandbox/TechBD HL7 Workflow.xml
@@ -1,27 +1,25 @@
-<channel version="26.3.0">
-  <id>7bfc4fca-cf0a-4caf-b297-b4579d23684c</id>
+<channel version="26.3.1">
+  <id>548ec946-51d0-4c8b-a402-78345d8f0242</id>
   <nextMetaDataId>3</nextMetaDataId>
   <name>TechBD HL7 Workflow</name>
-  <description>Version: 0.1.38
-Added requested uri.
-Added uuid version 7.
-Removed organization inside violation.</description>
-  <revision>5</revision>
-  <sourceConnector version="26.3.0">
+  <description>Version: 0.1.39
+Increased timeout configuration to 300000 ms for long-running request handling.</description>
+  <revision>7</revision>
+  <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.0">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.0">
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
   <authType>NONE</authType>
         </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
-          <mutualTlsMigrated>false</mutualTlsMigrated>
+          <mutualTlsMigrated>true</mutualTlsMigrated>
           <clientCertValidationEnabled>false</clientCertValidationEnabled>
           <clientCertOptionalEnabled>false</clientCertOptionalEnabled>
-          <serverCertValidationEnabled>false</serverCertValidationEnabled>
+          <serverCertValidationEnabled>true</serverCertValidationEnabled>
           <verifyHostname>false</verifyHostname>
           <keystorePath/>
           <keystorePassword/>
@@ -40,13 +38,15 @@ Removed organization inside violation.</description>
           <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
           <truststoreUid/>
           <softFailIfResponderUnavailable>false</softFailIfResponderUnavailable>
+          <pinnedLeafPins/>
+          <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="26.3.0">
+      <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
         <port>9006</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="26.3.0">
+      <sourceConnectorProperties version="26.3.1">
         <responseVariable>finalResponse</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -98,7 +98,7 @@ Removed organization inside violation.</description>
       <useResponseHeadersVariable>false</useResponseHeadersVariable>
       <charset>DEFAULT_ENCODING</charset>
       <contextPath>/</contextPath>
-      <timeout>30000</timeout>
+      <timeout>300000</timeout>
       <requestHeaderSize>8192</requestHeaderSize>
       <staticResources>
         <com.mirth.connect.connectors.http.HttpStaticResource>
@@ -109,9 +109,9 @@ Removed organization inside violation.</description>
         </com.mirth.connect.connectors.http.HttpStaticResource>
       </staticResources>
     </properties>
-    <transformer version="26.3.0">
+    <transformer version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>Validate HTTP Request and collect headers</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -264,7 +264,7 @@ if (missingEnvVars.length &gt; 0) {
 
 logger.info(&quot;HTTP request validation ended.&quot;);</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
           <name>FileName validation</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -457,11 +457,11 @@ for (var i = 0; i &lt; lines.length; i++) {
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>XML</inboundDataType>
       <outboundDataType>HL7V2</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.0">
-        <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.0">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.1">
+        <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.1">
           <stripNamespaces>false</stripNamespaces>
         </serializationProperties>
-        <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.1">
           <splitType>Element_Name</splitType>
           <elementName></elementName>
           <level>1</level>
@@ -469,8 +469,8 @@ for (var i = 0; i &lt; lines.length; i++) {
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="26.3.0">
-        <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="26.3.0">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="26.3.1">
+        <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="26.3.1">
           <handleRepetitions>true</handleRepetitions>
           <handleSubcomponents>true</handleSubcomponents>
           <useStrictParser>false</useStrictParser>
@@ -479,16 +479,16 @@ for (var i = 0; i &lt; lines.length; i++) {
           <segmentDelimiter>\r</segmentDelimiter>
           <convertLineBreaks>true</convertLineBreaks>
         </serializationProperties>
-        <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="26.3.0">
+        <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="26.3.1">
           <useStrictParser>false</useStrictParser>
           <useStrictValidation>false</useStrictValidation>
           <segmentDelimiter>\r</segmentDelimiter>
         </deserializationProperties>
-        <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="26.3.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="26.3.1">
           <splitType>MSH_Segment</splitType>
           <batchScript></batchScript>
         </batchProperties>
-        <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="26.3.0">
+        <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="26.3.1">
           <segmentDelimiter>\r</segmentDelimiter>
           <successfulACKCode>AA</successfulACKCode>
           <successfulACKMessage></successfulACKMessage>
@@ -499,7 +499,7 @@ for (var i = 0; i &lt; lines.length; i++) {
           <msh15ACKAccept>false</msh15ACKAccept>
           <dateFormat>yyyyMMddHHmmss.SSS</dateFormat>
         </responseGenerationProperties>
-        <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="26.3.0">
+        <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="26.3.1">
           <successfulACKCode>AA,CA</successfulACKCode>
           <errorACKCode>AE,CE</errorACKCode>
           <rejectedACKCode>AR,CR</rejectedACKCode>
@@ -509,9 +509,9 @@ for (var i = 0; i &lt; lines.length; i++) {
         </responseValidationProperties>
       </outboundProperties>
     </transformer>
-    <filter version="26.3.0">
+    <filter version="26.3.1">
       <elements>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.0">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
           <name>http method and url validation</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -635,12 +635,12 @@ function notFound() {
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>1</metaDataId>
       <name>Destination 1</name>
-      <properties class="com.mirth.connect.connectors.vm.VmDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.vm.VmDispatcherProperties" version="26.3.1">
         <pluginProperties/>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -664,9 +664,9 @@ function notFound() {
         <channelTemplate>${message.encodedData}</channelTemplate>
         <mapVariables/>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
             <name>HL7 Validation</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -1018,7 +1018,7 @@ function validateOrganizationName(hl7Text) {
     return violations;
 }</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
             <name>Common Js func.</name>
             <sequenceNumber>1</sequenceNumber>
             <enabled>true</enabled>
@@ -1129,7 +1129,7 @@ function sendDataLedgerSync(payload) {
     }
 }</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
             <name>step_validate_profile_urls_env_variables</name>
             <sequenceNumber>2</sequenceNumber>
             <enabled>true</enabled>
@@ -1584,7 +1584,7 @@ function getMultipleAnswersForComponent(transformer, observations) {
     return transformer;
 }</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.0">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
             <name>API endpoint processing</name>
             <sequenceNumber>3</sequenceNumber>
             <enabled>true</enabled>
@@ -2112,8 +2112,8 @@ return value;
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>HL7V2</inboundDataType>
         <outboundDataType>XML</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="26.3.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="26.3.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="26.3.1">
             <handleRepetitions>true</handleRepetitions>
             <handleSubcomponents>true</handleSubcomponents>
             <useStrictParser>false</useStrictParser>
@@ -2122,16 +2122,16 @@ return value;
             <segmentDelimiter>\r</segmentDelimiter>
             <convertLineBreaks>true</convertLineBreaks>
           </serializationProperties>
-          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="26.3.0">
+          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="26.3.1">
             <useStrictParser>false</useStrictParser>
             <useStrictValidation>false</useStrictValidation>
             <segmentDelimiter>\r</segmentDelimiter>
           </deserializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="26.3.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="26.3.1">
             <splitType>MSH_Segment</splitType>
             <batchScript></batchScript>
           </batchProperties>
-          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="26.3.0">
+          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="26.3.1">
             <segmentDelimiter>\r</segmentDelimiter>
             <successfulACKCode>AA</successfulACKCode>
             <successfulACKMessage></successfulACKMessage>
@@ -2142,7 +2142,7 @@ return value;
             <msh15ACKAccept>false</msh15ACKAccept>
             <dateFormat>yyyyMMddHHmmss.SSS</dateFormat>
           </responseGenerationProperties>
-          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="26.3.0">
+          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="26.3.1">
             <successfulACKCode>AA,CA</successfulACKCode>
             <errorACKCode>AE,CE</errorACKCode>
             <rejectedACKCode>AR,CR</rejectedACKCode>
@@ -2151,11 +2151,11 @@ return value;
             <originalIdMapVariable></originalIdMapVariable>
           </responseValidationProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.1">
             <stripNamespaces>false</stripNamespaces>
           </serializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.1">
             <splitType>Element_Name</splitType>
             <elementName></elementName>
             <level>1</level>
@@ -2164,17 +2164,17 @@ return value;
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>XML</inboundDataType>
         <outboundDataType>XML</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.1">
             <stripNamespaces>false</stripNamespaces>
           </serializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.1">
             <splitType>Element_Name</splitType>
             <elementName></elementName>
             <level>1</level>
@@ -2182,11 +2182,11 @@ return value;
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.xml.XMLDataTypeProperties" version="26.3.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.xml.XMLSerializationProperties" version="26.3.1">
             <stripNamespaces>false</stripNamespaces>
           </serializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.xml.XMLBatchProperties" version="26.3.1">
             <splitType>Element_Name</splitType>
             <elementName></elementName>
             <level>1</level>
@@ -2195,7 +2195,7 @@ return value;
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements/>
       </filter>
       <transportName>Channel Writer</transportName>
@@ -2203,18 +2203,18 @@ return value;
       <enabled>true</enabled>
       <waitForPrevious>true</waitForPrevious>
     </connector>
-    <connector version="26.3.0">
+    <connector version="26.3.1">
       <metaDataId>2</metaDataId>
       <name>dest_bundle</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.0">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.1">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.0">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
             <mutualTlsEnabled>false</mutualTlsEnabled>
-            <mutualTlsMigrated>false</mutualTlsMigrated>
+            <mutualTlsMigrated>true</mutualTlsMigrated>
             <clientCertValidationEnabled>false</clientCertValidationEnabled>
             <clientCertOptionalEnabled>false</clientCertOptionalEnabled>
-            <serverCertValidationEnabled>false</serverCertValidationEnabled>
+            <serverCertValidationEnabled>true</serverCertValidationEnabled>
             <verifyHostname>false</verifyHostname>
             <keystorePath/>
             <keystorePassword/>
@@ -2233,9 +2233,11 @@ return value;
             <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
             <truststoreUid/>
             <softFailIfResponderUnavailable>false</softFailIfResponderUnavailable>
+            <pinnedLeafPins/>
+            <subjectSanFilterPatterns/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="26.3.0">
+        <destinationConnectorProperties version="26.3.1">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -2379,16 +2381,16 @@ return value;
         <contentType>application/fhir+json</contentType>
         <dataTypeBinary>false</dataTypeBinary>
         <charset>UTF-8</charset>
-        <socketTimeout>30000</socketTimeout>
+        <socketTimeout>300000</socketTimeout>
       </properties>
-      <transformer version="26.3.0">
+      <transformer version="26.3.1">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>HL7V2</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="26.3.0">
-          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DataTypeProperties" version="26.3.1">
+          <serializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2SerializationProperties" version="26.3.1">
             <handleRepetitions>true</handleRepetitions>
             <handleSubcomponents>true</handleSubcomponents>
             <useStrictParser>false</useStrictParser>
@@ -2397,16 +2399,16 @@ return value;
             <segmentDelimiter>\r</segmentDelimiter>
             <convertLineBreaks>true</convertLineBreaks>
           </serializationProperties>
-          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="26.3.0">
+          <deserializationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2DeserializationProperties" version="26.3.1">
             <useStrictParser>false</useStrictParser>
             <useStrictValidation>false</useStrictValidation>
             <segmentDelimiter>\r</segmentDelimiter>
           </deserializationProperties>
-          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="26.3.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2BatchProperties" version="26.3.1">
             <splitType>MSH_Segment</splitType>
             <batchScript></batchScript>
           </batchProperties>
-          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="26.3.0">
+          <responseGenerationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseGenerationProperties" version="26.3.1">
             <segmentDelimiter>\r</segmentDelimiter>
             <successfulACKCode>AA</successfulACKCode>
             <successfulACKMessage></successfulACKMessage>
@@ -2417,7 +2419,7 @@ return value;
             <msh15ACKAccept>false</msh15ACKAccept>
             <dateFormat>yyyyMMddHHmmss.SSS</dateFormat>
           </responseGenerationProperties>
-          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="26.3.0">
+          <responseValidationProperties class="com.mirth.connect.plugins.datatypes.hl7v2.HL7v2ResponseValidationProperties" version="26.3.1">
             <successfulACKCode>AA,CA</successfulACKCode>
             <errorACKCode>AE,CE</errorACKCode>
             <rejectedACKCode>AR,CR</rejectedACKCode>
@@ -2426,33 +2428,33 @@ return value;
             <originalIdMapVariable></originalIdMapVariable>
           </responseValidationProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.0">
+      <responseTransformer version="26.3.1">
         <elements/>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.0">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.0">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.0">
+      <filter version="26.3.1">
         <elements>
-          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.0">
+          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.1">
             <name>Accept message if &quot;$(&apos;endpoint&apos;)&quot; equals &apos;bundle&apos;</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -2462,7 +2464,7 @@ return value;
               <string>&apos;bundle&apos;</string>
             </values>
           </com.mirth.connect.plugins.rulebuilder.RuleBuilderRule>
-          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.0">
+          <com.mirth.connect.plugins.rulebuilder.RuleBuilderRule version="26.3.1">
             <name>Accept message if &quot;sourceMap.get(&apos;contextPath&apos;)&quot; equals &apos;/hl7v2/Bundle&apos; or &apos;/hl7v2/Bundle/&apos;</name>
             <sequenceNumber>1</sequenceNumber>
             <enabled>true</enabled>
@@ -3059,7 +3061,7 @@ globalMap.put(&apos;saveHL7Payload&apos;, saveHL7Payload);</deployScript>
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="26.3.0">
+  <properties version="26.3.1">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>DEVELOPMENT</messageStorageMode>
     <encryptData>false</encryptData>
@@ -3082,7 +3084,7 @@ return;</undeployScript>
         <mappingName>message_type</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="26.3.0">
+    <attachmentProperties version="26.3.1">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -3097,138 +3099,24 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1776926289589</time>
+        <time>1779247781971</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
         <archiveEnabled>true</archiveEnabled>
         <pruneErroredMessages>false</pruneErroredMessages>
       </pruningSettings>
-      <userId>6</userId>
+      <userId>10</userId>
     </metadata>
-    <codeTemplateLibraries>
-      <codeTemplateLibrary version="26.3.0">
-        <id>d56d125c-b75a-4803-9038-3a65e9bfbbb5</id>
-        <name>UuidUtil</name>
-        <revision>9</revision>
-        <lastModified>
-          <time>1776860769883</time>
-          <timezone>America/New_York</timezone>
-        </lastModified>
-        <description></description>
-        <includeNewChannels>false</includeNewChannels>
-        <enabledChannelIds class="sorted-set">
-          <string>0f97d63c-b506-4b71-aa83-bfe95b9c08a5</string>
-          <string>1ec01527-8a44-4184-a05a-2a91c04f37df</string>
-          <string>32a3cbc1-921f-441c-8e68-3bda27e63ee6</string>
-          <string>35ee3e0b-ad66-44c5-bf30-6ebe8ff7c7ec</string>
-          <string>461db608-904d-41c3-a9f5-d1c23a450ce9</string>
-          <string>48098091-34dc-4d63-b9a9-c6201f0c0fa4</string>
-          <string>66bd741d-7d06-4fce-84ee-aff81a32606f</string>
-          <string>6df6b37f-e6df-4648-a7e1-67715a4e3157</string>
-          <string>7bfc4fca-cf0a-4caf-b297-b4579d23684c</string>
-          <string>95deaa8d-3907-4b7e-bd01-bbf5d507a474</string>
-          <string>c00e53b6-6165-4bb3-bd47-7f1e5d9708d4</string>
-          <string>d341dceb-069e-49ab-8efa-c45398145216</string>
-          <string>e0db16bd-35c7-4cc9-9874-79b6fb154472</string>
-        </enabledChannelIds>
-        <disabledChannelIds class="sorted-set">
-          <string>00389d41-c2ce-45c7-a702-353b449b1026</string>
-          <string>01fbb835-f605-4376-84eb-9c4affcf159e</string>
-          <string>04ef5b0d-3120-4dd4-ba3f-fd7ec1ab1fdb</string>
-          <string>158a1edb-a782-4fb4-bc18-f05f40ce3e18</string>
-          <string>1c406954-d304-4882-b05d-b513d699785b</string>
-          <string>2240d25e-de1d-4c6f-904c-832e7f68a574</string>
-          <string>2d6fac85-49e1-4aa8-b39f-b4e39f12597e</string>
-          <string>3322c442-7c6e-46b4-b6d1-f0cff8c4741d</string>
-          <string>38c30482-47ef-41e0-b6f3-fa56e8bc76ae</string>
-          <string>3f3f6dcd-2923-4f09-89c3-1e248c1556b3</string>
-          <string>4c2ba30f-c175-44b4-a740-0297048c7969</string>
-          <string>50e1c70e-7b48-4ed0-be9e-309710a85195</string>
-          <string>657d9972-aa59-406d-b248-22f39bbceed2</string>
-          <string>784f3cf4-180a-4ea3-b519-f12626b33dcc</string>
-          <string>78fd5c66-613e-46dd-bd45-c3dd0021a5fb</string>
-          <string>87d008ec-f78d-4f2f-b986-cb1a4d926540</string>
-          <string>89118684-3b07-4336-ab6e-c06a1d9c0440</string>
-          <string>8ca393c1-16ac-4b77-b78f-a8fca05ae3d6</string>
-          <string>95b30942-c7ab-4267-8dc8-7e9436e0f470</string>
-          <string>9608b1d8-a780-4093-a7b2-14412f61e0ea</string>
-          <string>a2eede47-0ee3-4345-b6c2-92c07c553950</string>
-          <string>ab20f626-8de4-4845-8080-0f2c6b80669a</string>
-          <string>ac705673-f0a4-4cc1-aa75-8a92badefe1a</string>
-          <string>b1be1080-160c-42e5-a1fb-b82439b1757e</string>
-          <string>bafa98dd-04f2-48ef-babb-4a3bedbcb0ed</string>
-          <string>bfe53f29-12c4-4575-856b-64c5700f2564</string>
-          <string>c56c8654-6ece-4975-bdad-29ef940c7081</string>
-          <string>c79799dd-a972-4d99-beba-1331ed5e49a2</string>
-          <string>cd224bbd-4d5c-46b7-99c5-ed3ec89e6d06</string>
-          <string>d3a8414c-8bcd-40c8-b806-5d163a5dbab1</string>
-          <string>d85d0014-300a-46f9-81b7-ad6c6ef1516b</string>
-          <string>e634b038-8196-4ac4-80fc-819a0a9c9bb1</string>
-          <string>f26f4d16-f640-4f02-b654-3d5ef8f9dc54</string>
-          <string>f2d185dd-96c3-4065-bbb9-5044afb7ba80</string>
-        </disabledChannelIds>
-        <codeTemplates>
-          <codeTemplate version="26.3.0">
-            <id>5094a1a4-a8c6-4818-b26f-2a773e673ef3</id>
-            <name>Uuid Generator Instance</name>
-            <revision>1</revision>
-            <lastModified>
-              <time>1776844786916</time>
-              <timezone>America/New_York</timezone>
-            </lastModified>
-            <contextSet>
-              <delegate class="sorted-set">
-                <contextType>GLOBAL_DEPLOY</contextType>
-                <contextType>GLOBAL_UNDEPLOY</contextType>
-                <contextType>GLOBAL_PREPROCESSOR</contextType>
-                <contextType>GLOBAL_POSTPROCESSOR</contextType>
-                <contextType>CHANNEL_DEPLOY</contextType>
-                <contextType>CHANNEL_UNDEPLOY</contextType>
-                <contextType>CHANNEL_PREPROCESSOR</contextType>
-                <contextType>CHANNEL_POSTPROCESSOR</contextType>
-                <contextType>CHANNEL_ATTACHMENT</contextType>
-                <contextType>CHANNEL_BATCH</contextType>
-                <contextType>SOURCE_RECEIVER</contextType>
-                <contextType>SOURCE_FILTER_TRANSFORMER</contextType>
-                <contextType>DESTINATION_FILTER_TRANSFORMER</contextType>
-                <contextType>DESTINATION_DISPATCHER</contextType>
-                <contextType>DESTINATION_RESPONSE_TRANSFORMER</contextType>
-              </delegate>
-            </contextSet>
-            <properties class="com.mirth.connect.model.codetemplates.BasicCodeTemplateProperties">
-              <type>FUNCTION</type>
-              <code>function getUuidGenerator() {
-    var generator = globalMap.get(&apos;UUID_GENERATOR&apos;);
-
-    if (generator == null) {
-        var Generators = Packages.com.fasterxml.uuid.Generators;
-        generator = Generators.timeBasedEpochGenerator();
-
-        globalMap.put(&apos;UUID_GENERATOR&apos;, generator);
-        logger.info(&apos;UUID Generator initialized ONCE&apos;);
-    }
-
-    return generator;
-}
-
-function generateUuid() {
-    return getUuidGenerator().generate().toString();
-}</code>
-            </properties>
-          </codeTemplate>
-        </codeTemplates>
-      </codeTemplateLibrary>
-    </codeTemplateLibraries>
     <channelTags>
       <channelTag>
-        <id>3fcfccb5-c571-4a2c-ab55-cda48f4f3e98</id>
-        <name>0_1_38</name>
+        <id>0b30d130-ff02-4150-80cd-5427c26688df</id>
+        <name>0_1_39</name>
         <channelIds>
-          <string>7bfc4fca-cf0a-4caf-b297-b4579d23684c</string>
+          <string>548ec946-51d0-4c8b-a402-78345d8f0242</string>
         </channelIds>
         <backgroundColor>
-          <red>255</red>
+          <red>128</red>
           <green>0</green>
           <blue>0</blue>
           <alpha>255</alpha>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -3,16 +3,16 @@
     {
       "type": "FHIR",
       "channel": "FhirBundlleSubmission.xml",
-      "version": "0.8.29",
+      "version": "0.8.30",
       "editedby": "jewelbonnie",
-      "date": "2026-05-15"
+      "date": "2026-05-19"
     },
     {
       "type": "FHIR",
       "channel": "FhirBundleValidate.xml",
-      "version": "0.8.14",
+      "version": "0.8.15",
       "editedby": "jewelbonnie",
-      "date": "2026-04-28"
+      "date": "2026-05-19"
     },
     {
       "type": "CCDA",
@@ -31,9 +31,9 @@
     {
       "type": "FLAT FILE",
       "channel": "FlatFileCsvBundle.xml",
-      "version": "0.9.22",
+      "version": "0.9.24",
       "editedby": "jewelbonnie",
-      "date": "2026-05-08"
+      "date": "2026-05-19"
     },
     {
       "type": "FLAT FILE",
@@ -45,9 +45,9 @@
     {
       "type": "HL7v2",
       "channel": "TechBD HL7 Workflow.xml",
-      "version": "0.1.38",
-      "editedby": "abhiramisanthosh90",
-      "date": "2026-04-23"
+      "version": "0.1.39",
+      "editedby": "jewelbonnie",
+      "date": "2026-05-19"
     },
     {
       "type": "HL7v2",
@@ -94,16 +94,16 @@
     {
       "type": "CCDA",
       "channel": "TechBD CCD Workflow.xml",
-      "version": "0.5.31",
+      "version": "0.5.32",
       "editedby": "jewelbonnie",
-      "date": "2026-05-15"
+      "date": "2026-05-19"
     },
     {
       "type": "Router",
       "channel": "RouterChannel.xml",
-      "version": "0.2.13",
-      "editedby": "anoopvarma-2000-p",
-      "date": "2026-05-05"
+      "version": "0.2.14",
+      "editedby": "jewelbonnie",
+      "date": "2026-05-19"
     },
   {
       "type": "code-templates",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1157.0</revision>
+        <revision>0.1158.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Replaced globalMap usage with channelMap for DataLake URI request isolation during   parallel execution
- Increased request timeout from 30000ms to 300000ms for long-running requests
- Bumped version to 0.1158.0