### PR TITLE
feat: implement session management and FusionAuth webhook handling #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/component/SessionCleanupListener.java
+++ b/hub-prime/src/main/java/org/techbd/component/SessionCleanupListener.java
@@ -1,0 +1,26 @@
+package org.techbd.component;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SessionCleanupListener implements HttpSessionListener {
+
+    @Autowired
+    private SessionRegistry sessionRegistry;
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se) {
+        HttpSession session = se.getSession();
+
+        String userId = (String) session.getAttribute("USER_ID");
+
+        if (userId != null) {
+            sessionRegistry.removeSession(userId, session);
+        }
+    }
+}

--- a/hub-prime/src/main/java/org/techbd/component/SessionRegistry.java
+++ b/hub-prime/src/main/java/org/techbd/component/SessionRegistry.java
@@ -1,0 +1,35 @@
+package org.techbd.component;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SessionRegistry {
+
+    private final Map<String, Set<HttpSession>> userSessions = new ConcurrentHashMap<>();
+
+    public void addSession(String userId, HttpSession session) {
+        userSessions
+                .computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet())
+                .add(session);
+    }
+
+    public Set<HttpSession> getSessions(String userId) {
+        return userSessions.getOrDefault(userId, Set.of());
+    }
+
+    public void removeSession(String userId, HttpSession session) {
+        Set<HttpSession> sessions = userSessions.get(userId);
+        if (sessions != null) {
+            sessions.remove(session);
+            if (sessions.isEmpty()) {
+                userSessions.remove(userId);
+            }
+        }
+    }
+}

--- a/hub-prime/src/main/java/org/techbd/controller/FusionAuthWebhookController.java
+++ b/hub-prime/src/main/java/org/techbd/controller/FusionAuthWebhookController.java
@@ -1,0 +1,67 @@
+package org.techbd.controller;
+
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.techbd.component.SessionRegistry;
+import org.techbd.service.http.FusionAuthUserAuthorizationFilter;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RestController
+@RequestMapping("/fusionauth")
+public class FusionAuthWebhookController {
+
+    @Autowired
+    private SessionRegistry sessionRegistry;
+    private static final Logger LOG = LoggerFactory.getLogger(FusionAuthUserAuthorizationFilter.class);
+
+    @SuppressWarnings("unchecked")
+    @PostMapping("/webhook")
+    public ResponseEntity<?> handleWebhook(@RequestBody Map<String, Object> payload) {
+
+        LOG.info("Webhook received: {}", payload);
+
+        Map<String, Object> event = (Map<String, Object>) payload.get("event");
+
+        if (event == null) {
+            return ResponseEntity.ok().build();
+        }
+
+        String type = (String) event.get("type");
+
+        // Only handle lock/deactivate event
+        if ("user.deactivate".equals(type) || "user.delete".equals(type)) {
+
+            Map<String, Object> user = (Map<String, Object>) event.get("user");
+
+            if (user != null) {
+                Boolean active = (Boolean) user.get("active");
+                String userId = (String) user.get("id");
+
+                if (Boolean.FALSE.equals(active)) {
+
+                    LOG.info("User locked, invalidating sessions for userId: {}", userId);
+
+                    Set<HttpSession> sessions = sessionRegistry.getSessions(userId);
+
+                    for (HttpSession session : sessions) {
+                        session.invalidate();
+                        sessionRegistry.removeSession(userId, session);
+                    }
+                }
+            }
+        }
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUserAuthorizationFilter.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUserAuthorizationFilter.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -13,6 +14,7 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.techbd.component.SessionRegistry;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -20,6 +22,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 @Component
 @ConditionalOnProperty(name = "AUTH_PROVIDER", havingValue = "fusionauth", matchIfMissing = true)
@@ -32,6 +35,9 @@ public class FusionAuthUserAuthorizationFilter extends OncePerRequestFilter {
     private static final String SUPPORT_EMAIL_DISPLAY = "Tech by Design Support <" + SUPPORT_EMAIL + ">";
 
     private final FusionAuthUsersService fusionAuthUsersService;
+
+    @Autowired
+    private SessionRegistry sessionRegistry;
 
     public FusionAuthUserAuthorizationFilter(final FusionAuthUsersService fusionAuthUsersService) {
         this.fusionAuthUsersService = fusionAuthUsersService;
@@ -85,17 +91,41 @@ public class FusionAuthUserAuthorizationFilter extends OncePerRequestFilter {
                     //      LOG.info("Role permissions cached in session for role {}: {}", role, permissions);
                     //    }
                         // fusionAuthUsersService.convertToJson(enrichedOAuth2User);
+                                           
+                    String userId = (faUser != null) ? faUser.fusionAuthId() : null;
 
-                        LOG.info("FusionAuth user enriched and set in SecurityContext: {}", faUser.email());
-                    } catch (Exception e) {
-                        LOG.error("Error processing FusionAuth user login", e);
-                        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal auth error");
-                        return;
+                    if (userId == null || userId.isBlank()) {
+                        LOG.warn("Skipping session registration: userId is null or empty");
+                    } else {
+                        HttpSession session = request.getSession(false);
+
+                        if (session == null) {
+                            session = request.getSession(true); // create only if needed
+                            LOG.debug("New session created for userId: {}", userId);
+                        }
+
+                        session.setAttribute("USER_ID", userId);
+
+                        // Avoid duplicate registration
+                        Object existingUser = session.getAttribute("USER_ID_REGISTERED");
+                        if (existingUser == null) {
+                            sessionRegistry.addSession(userId, session);
+                            session.setAttribute("USER_ID_REGISTERED", true);
+                            LOG.debug("Session registered for userId: {}", userId);
+                        }
                     }
-                } else {
-                    LOG.debug("User already enriched, skipping enrichment");
+                    LOG.info("FusionAuth user enriched. userId={}, email={}",
+                            faUser != null ? faUser.fusionAuthId() : "NULL",
+                            faUser != null ? faUser.email() : "NULL");
+                } catch (Exception e) {
+                    LOG.error("Error processing FusionAuth user login", e);
+                    response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal auth error");
+                    return;
                 }
+            } else {
+                LOG.debug("User already enriched, skipping enrichment");
             }
+        }
 
         // Actuator access check
         if (request.getRequestURI().startsWith("/actuator")) {

--- a/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig {
                         authorize -> authorize
                                 .requestMatchers(Constant.UNAUTHENTICATED_URLS)
                                 .permitAll()
+                                .requestMatchers("/fusionauth/webhook").permitAll()
                                 .anyRequest().authenticated())
                 .oauth2Login(
                         oauth2Login -> oauth2Login

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1158.0</revision>
+        <revision>0.1159.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Summary
Implemented real-time auto logout functionality for FusionAuth users using webhook-based session invalidation. #1687

## Changes
- Added `/fusionauth/webhook` endpoint to receive FusionAuth events
- Handled `user.deactivate` (user lock) event to invalidate active sessions
- Introduced `SessionRegistry` to track user sessions across the application
- Registered sessions during login via `FusionAuthUserAuthorizationFilter`
- Added `SessionCleanupListener` to prevent memory leaks on session destroy
- Updated Spring Security configuration to allow webhook endpoint
- Improved logging and null safety in authentication flow

## Behavior
- When a user is locked/deactivated in FusionAuth:
  - Webhook is triggered
  - Backend receives event
  - All active sessions for that user are invalidated
  - User is automatically logged out on next request/refresh

## Notes
- Currently designed for single-server setup
- For multi-instance deployments, distributed session handling (e.g., Redis) may be required
- Webhook endpoint should be secured (API key/signature validation can be added as enhancement)

## Testing
- Verified login and session creation
- Locked user from FusionAuth UI → webhook triggered successfully
- Confirmed session invalidation and forced logout behavior