### PR TITLE
feat: remove unnecessary info level log entries from CCDA and HL7 Mirth Connect Channel scripts #3156

### DIFF
--- a/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
+++ b/support/specifications/channel-files/mirth-connect/TechBD CCD Workflow.xml
@@ -2,8 +2,8 @@
   <id>0cefb37a-ca0a-48cc-85a1-aa0b727d26a2</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version: 0.4.47</description>
-  <revision>9</revision>
+  <description>Version: 0.4.48</description>
+  <revision>20</revision>
   <sourceConnector version="4.5.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -94,7 +94,6 @@ if(jdbcUrl != null) {
 var jdbcUsername = java.lang.System.getenv(&quot;MC_JDBC_USERNAME&quot;);
 if(jdbcUsername != null) {
     channelMap.put(&apos;jdbcUsername&apos;, jdbcUsername);
-    //logger.info(&quot;jdbcUsername: &quot; + jdbcUsername);
 } else {
     var errorMessage = &apos;MC_JDBC_USERNAME variable is not set&apos;;
     logger.error(errorMessage);
@@ -105,7 +104,6 @@ if(jdbcUsername != null) {
 var jdbcPassword = java.lang.System.getenv(&quot;MC_JDBC_PASSWORD&quot;);
 if(jdbcPassword != null) {
     channelMap.put(&apos;jdbcPassword&apos;, jdbcPassword);
-    //logger.info(&quot;jdbcPassword: &quot; + jdbcPassword);
 } else {
     var errorMessage = &apos;MC_JDBC_PASSWORD variable is not set&apos;;
     logger.error(errorMessage);
@@ -126,13 +124,6 @@ function toJsonb(value) {
 }
 
 function saveCcdaPayload(interactionId, tenantId, requestUri, payloadJson, operation) {
-	
-	logger.info(&quot;interactionId: &quot; + interactionId);
-	logger.info(&quot;tenantId: &quot; + tenantId);
-	logger.info(&quot;requestUri: &quot; + requestUri);
-	logger.info(&quot;payloadJson: &quot; + payloadJson);
-	logger.info(&quot;operation: &quot; + operation);
-
 	var ccdaAuthoringDevice = channelMap.get(&apos;ehrVendor&apos;);
 	//If any error happens in between, find the ccda source type from the input file
 	if (operation === &quot;saveOgCCDAPayload&quot; &amp;&amp; typeof ccdaAuthoringDevice === &apos;undefined&apos; || ccdaAuthoringDevice === &quot;&quot; || ccdaAuthoringDevice === null){
@@ -148,8 +139,6 @@ function saveCcdaPayload(interactionId, tenantId, requestUri, payloadJson, opera
 	var stmt = null;
 	
 	try {
-	    logger.info(&quot;Inside DB Try&quot;);
-
 	    // Database connection details
 		var dbUrl = channelMap.get(&apos;jdbcUrl&apos;);
 		var dbUser = channelMap.get(&apos;jdbcUsername&apos;);
@@ -157,7 +146,6 @@ function saveCcdaPayload(interactionId, tenantId, requestUri, payloadJson, opera
 
 		//Devl
 	    conn = DriverManager.getConnection(dbUrl, dbUser, dbPassword);
-	    logger.info(&quot;Database connection established successfully.&quot;);
 		
 		var sql = &quot;select techbd_udi_ingress.register_interaction_ccda_request(?::text,?::text,?::jsonb,?::text,?::text,?::jsonb,?::text,?::text,?::jsonb,?::text,?::text,?::text,?::text,?::text,?::text,?::text,?,?::text,?,?::text,?::text,?::text,?::text,?::text,?::text,?::text,?::text,?::text,?::text)&quot;;
 	    stmt = conn.prepareCall(sql);
@@ -229,14 +217,12 @@ function saveCcdaPayload(interactionId, tenantId, requestUri, payloadJson, opera
 		stmt.setString(29, ccdaAuthoringDevice);
 
 	    var result = stmt.execute();
-	    logger.info(&quot;Stored procedure executed, result: &quot; + result);
 	
 	} catch (e) {
 	    logger.error(&quot;Error executing stored procedure: &quot; + e);
 	} finally {
 	    if (stmt != null) stmt.close();
 	    if (conn != null) conn.close();
-	    logger.info(&quot;DB connection closed.&quot;);
 	}
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
@@ -308,12 +294,9 @@ function getJsonInvalidOperationOutcome(errorMsg, code, severity) {
 }
 
 function sendDataLedgerSync(payload) {
-    logger.info(&quot;sendDataLedgerSync: &quot; + payload);
     
     var apiUrl = java.lang.System.getenv(&quot;DATA_LEDGER_API_URL&quot;);
     var dataLedgerApiKey = java.lang.System.getenv(&quot;TECHBD_NYEC_DATALEDGER_API_KEY&quot;);
-
-    logger.info(&quot;API URL: &quot; + apiUrl);
 
     if (apiUrl == null) {
         throw new Error(&quot;Environment variable DATA_LEDGER_API_URL is not set.&quot;);
@@ -348,7 +331,7 @@ function sendDataLedgerSync(payload) {
             var responseBody = EntityUtils.toString(response.getEntity());
 
             if (statusCode &gt;= 200 &amp;&amp; statusCode &lt; 300) {
-                logger.info(&quot;Data Ledger API Response: &quot; + responseBody);
+                //logger.info(&quot;Data Ledger API Response: &quot; + responseBody);
                 return {
                     statusCode: statusCode,
                     body: responseBody
@@ -385,13 +368,11 @@ function saveDataLedgerSync(interactionId) {
 	// Check if tracking is enabled
 	var trackingEnabled = java.lang.System.getenv(&quot;DATA_LEDGER_TRACKING&quot;);
 	if (trackingEnabled != null &amp;&amp; trackingEnabled.toLowerCase() == &quot;true&quot;) {
-	   logger.info(&quot;data ledger api call -BEGIN sent&quot;);
 	   try {
         	sendDataLedgerSync(payload);
 	   } catch (e) {
 	        logger.error(&quot;Error occurred while sending data to Data Ledger: &quot; + e.message);
 	   }
-	   logger.info(&quot;data ledger api call -END sent&quot;);
 	} else {
 	   logger.info(&quot;DATA_LEDGER_TRACKING is not true; skipping Data Ledger sync for sent.&quot;);
 	}
@@ -567,7 +548,6 @@ function extractClinicalDocument(rawXml) {
 		} else {
 			rawCcdaXml = extractedXml;
 		}
-	    logger.info(&quot;Original file content: &quot; + rawCcdaXml);
 
 		// Save Original Payload
 	     saveCcdaPayload(
@@ -668,7 +648,6 @@ function convertCcdaToFhirBundle(phiFilteredXml) {
 	        // We resolve it against the same dynamic folder
 	        var resolvedPath = ccdaSchemaFolder + &quot;/&quot; + href;
 	        var file = new java.io.File(resolvedPath);
-	        logger.info(&quot;URIResolver resolving: &quot; + resolvedPath);
 	        return new javax.xml.transform.stream.StreamSource(file);
 	    }
     }));
@@ -727,7 +706,7 @@ function convertCcdaToFhirBundle(phiFilteredXml) {
     var jsonObject = JSON.parse(rawJson);
     var cleanedJsonString = JSON.stringify(jsonObject, removeEmptyValues, 2);
 
-    logger.info(&quot;Cleaned FHIR Bundle JSON : &quot; + cleanedJsonString);	
+    //logger.info(&quot;Cleaned FHIR Bundle JSON : &quot; + cleanedJsonString);	
     channelMap.put(&apos;ccd_fhir_bundle&apos;, cleanedJsonString);
     return cleanedJsonString;
 }</script>
@@ -736,9 +715,7 @@ function convertCcdaToFhirBundle(phiFilteredXml) {
           <name>Validate HTTP Request and Collect Headers</name>
           <sequenceNumber>2</sequenceNumber>
           <enabled>true</enabled>
-          <script>logger.info(&quot;HTTP request validation started.&quot;);
-
-var requestedPath = sourceMap.get(&apos;contextPath&apos;);
+          <script>var requestedPath = sourceMap.get(&apos;contextPath&apos;);
 logger.info(&quot;Request URL: &quot; + requestedPath);
 
 if (requestedPath == &quot;/&quot;) {
@@ -751,7 +728,7 @@ var missingHeaders = [];
 // Helper to check and store missing header
 function checkRequiredHeader(headerName, displayName, storeInMap, mapKey) {
     var value = $(&apos;headers&apos;).getHeader(headerName);
-    logger.info(headerName + &quot;: &quot; + value);
+    //logger.info(headerName + &quot;: &quot; + value);
 
     if (value == null || String(value).trim() === &quot;&quot;) {
         missingHeaders.push(&quot;Missing required header &quot; + displayName);
@@ -777,11 +754,9 @@ if (!contentType || !contentType.startsWith(&apos;multipart/form-data&apos;) /*|
 // Get User-Agent header to set at HTTP Writer not to show &apos;Mirth connect&apos; as Agent at the application side.
 var userAgent = $(&apos;headers&apos;).getHeader(&apos;User-Agent&apos;);
 channelMap.put(&apos;userAgent&apos;, userAgent);
-logger.info(&quot;User-Agent: &quot; + userAgent);
 
 var severityLevel = String($(&apos;headers&apos;).getHeader(&apos;X-TechBD-Validation-Severity-Level&apos;) || &quot;&quot;).trim();
 channelMap.put(&apos;SeverityLevel&apos;, severityLevel || &quot;error&quot;);
-logger.info(&quot;SeverityLevel: &quot; + (severityLevel || &quot;error&quot;));
 
 channelMap.put(&apos;uri&apos;, sourceMap.get(&apos;uri&apos;));
 channelMap.put(&apos;contextPath&apos;, sourceMap.get(&apos;contextPath&apos;));
@@ -793,11 +768,9 @@ if (requestedPath == &quot;/ccda/Bundle/&quot; || requestedPath == &quot;/ccda/B
 	
 	//2.NPI
 	var organizationNPI = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OrgNPI&apos;);
-	logger.info(&quot;X-TechBD-OrgNPI: &quot; + organizationNPI);
 	
 	//3.TIN
 	var organizationTIN = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OrgTIN&apos;);
-	logger.info(&quot;X-TechBD-OrgTIN: &quot; + organizationTIN);
 	
 	// Check if both are missing — only then it&apos;s an error
 	if ((organizationNPI == null || String(organizationNPI).trim() === &quot;&quot;) &amp;&amp;
@@ -819,29 +792,25 @@ if (requestedPath == &quot;/ccda/Bundle/&quot; || requestedPath == &quot;/ccda/B
 	checkRequiredHeader(&apos;X-TechBD-Encounter-Type&apos;, &apos;X-TechBD-Encounter-Type&apos;, true, &apos;encounterType&apos;);
 
 	//6. Screening code (used for Grouper resource) for Epic CCD files
-	var screeningCode = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Screening-Code&apos;);	
-	logger.info(&quot;X-TechBD-Screening-Code: &quot; + screeningCode);
+	var screeningCode = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Screening-Code&apos;);
 	if (screeningCode &amp;&amp; String(screeningCode).trim() !== &quot;&quot;) {
 	    channelMap.put(&apos;X-TechBD-Screening-Code&apos;, screeningCode);
 	}
 
 	//7. Part 2 Data Flagging 
-	var part2DataFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Part2&apos;);	
-	logger.info(&quot;X-TechBD-Part2: &quot; + part2DataFlag);
+	var part2DataFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Part2&apos;);
 	if (part2DataFlag &amp;&amp; String(part2DataFlag).trim() !== &quot;&quot;) {
 	    channelMap.put(&apos;X-TechBD-Part2&apos;, part2DataFlag);
 	}
 
 	// 8. OMH Flagging
 	var OMHFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OMH&apos;);
-	logger.info(&quot;X-TechBD-OMH: &quot; + OMHFlag);
 	if (OMHFlag &amp;&amp; String(OMHFlag).trim() !== &quot;&quot;) {
 	    channelMap.put(&apos;X-TechBD-OMH&apos;, OMHFlag);
 	}
 	
 	// 9. OPWDD Flagging
 	var OPWDDFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OPWDD&apos;);
-	logger.info(&quot;X-TechBD-OPWDD: &quot; + OPWDDFlag);
 	if (OPWDDFlag &amp;&amp; String(OPWDDFlag).trim() !== &quot;&quot;) {
 	    channelMap.put(&apos;X-TechBD-OPWDD&apos;, OPWDDFlag);
 	}
@@ -923,7 +892,6 @@ if(fhirBundleSubmissionApiUrl != null) {
 var ccdaSchemaFolder = java.lang.System.getenv(&quot;MC_CCDA_SCHEMA_FOLDER&quot;);
 if (ccdaSchemaFolder != null) {
     channelMap.put(&apos;ccdaSchemaFolder&apos;, ccdaSchemaFolder);
-    logger.info(&quot;ccdaSchemaFolder: &quot; + ccdaSchemaFolder);
     channelMap.put(&apos;xsdFilePath&apos;, ccdaSchemaFolder + &apos;/CDA.xsd&apos;);
     //logger.info(&quot;using xsdFilePath: &quot; + channelMap.get(&apos;xsdFilePath&apos;));
 } else {
@@ -1054,18 +1022,60 @@ function bytesToHex(byteArray) {
     return hexString.toString();
 }
 
+function generateSHA256Id(resource, resourceName, resourceIdName, transformer, additionalString) {
+    if (resource != undefined) { 
+        // Get MRN and CIN from channelMap
+        var mrn = channelMap.get(&apos;Patient-MRN&apos;) || &quot;&quot;;
+        var cin = channelMap.get(&apos;patientCIN&apos;) || &quot;&quot;;
+        var combinedText = mrn + cin;
+
+        if (typeof additionalString !== &apos;undefined&apos; &amp;&amp; additionalString != null &amp;&amp; additionalString !== &apos;&apos;) {
+            combinedText += additionalString;
+        }
+
+        var resourceText = resourceName + resource.toString().trim();
+        combinedText += resourceText;
+
+        // Generate SHA-256 hash
+        var sha256Hash = generateSHA256(new java.lang.String(combinedText));
+        transformer.setParameter(resourceIdName, sha256Hash);
+    } else {
+        logger.error(resourceName + &quot; not found in the XML.&quot;);
+    }
+
+    return transformer;
+}
+
+function generateCompactSha256(sourceXml, resourceName, resourceIdName, transformer) {
+    if (sourceXml != undefined) { 
+	    var MessageDigest = Packages.java.security.MessageDigest;
+	    var digest = MessageDigest.getInstance(&quot;SHA-256&quot;);
+	
+	    // Raw SHA-256 bytes
+	    var hashBytes = digest.digest(new java.lang.String(sourceXml).getBytes(&quot;UTF-8&quot;));
+	
+	    // Base64 URL-safe encoding
+	    var sha256Hash = Packages.java.util.Base64
+	        .getUrlEncoder()
+	        .withoutPadding()
+	        .encodeToString(hashBytes);
+	    // Convert Java String to JavaScript String
+    	    sha256Hash = String(sha256Hash).replace(/_/g, &apos;-&apos;);
+	
+	    transformer.setParameter(resourceIdName, sha256Hash);
+	    channelMap.put(resourceName + &quot;_Resource_ID&quot;, sha256Hash);
+	    logger.info(resourceName + &quot; Resource_ID : &quot; + sha256Hash);
+    } else {
+	        logger.error(resourceName + &quot; not found.&quot;);
+	    }
+
+    return transformer;
+}
+
 function getPatientMRN(patientRoles) {
     var extensionAttr = &apos;&apos;;
     var ehrVendor = channelMap.get(&apos;ehrVendor&apos;);
 
-    /*function isSSNFormat(ext) {
-    	    return (
-	        ext &amp;&amp; 
-	        String.fromCharCode(ext.charCodeAt(3)) == &apos;-&apos; &amp;&amp;
-	        String.fromCharCode(ext.charCodeAt(6)) == &apos;-&apos; &amp;&amp;
-	        /^\d{3}-\d{2}-\d{4}$/.test(ext)
-	    );
-    }*/
     function isSSNFormat(ext) {
         return (
             ext &amp;&amp;
@@ -1092,7 +1102,7 @@ function getPatientMRN(patientRoles) {
                     !isSSNFormat(ext)
                 ) {
                     extensionAttr = ext;
-                    logger.info(&quot;Patient MRN (Medent): &quot; + extensionAttr);
+                    //logger.info(&quot;Patient MRN (Medent): &quot; + extensionAttr);
                     break;
                 }
             }
@@ -1108,7 +1118,7 @@ function getPatientMRN(patientRoles) {
                     // Check if the extracted part is not SSN
                     if (mrnPart &amp;&amp; mrnPart.trim() !== &quot;&quot; &amp;&amp; !isSSNFormat(mrnPart)) {
                         extensionAttr = mrnPart.trim();
-                        logger.info(&quot;Patient MRN (Athenahealth): &quot; + extensionAttr);
+                        //logger.info(&quot;Patient MRN (Athenahealth): &quot; + extensionAttr);
                         break; // Only first valid occurrence
                     }
                 }
@@ -1129,7 +1139,7 @@ function getPatientMRN(patientRoles) {
                     !isSSNFormat(ext)
                 ) {
                     extensionAttr = ext;
-                    logger.info(&quot;Patient MRN (Epic): &quot; + extensionAttr);
+                    //logger.info(&quot;Patient MRN (Epic): &quot; + extensionAttr);
                     break;
                 }
             }
@@ -1141,7 +1151,7 @@ function getPatientMRN(patientRoles) {
                 
                 if (ext !== &quot;&quot; &amp;&amp; !isSSNFormat(ext)) {
                     extensionAttr = ext;
-                    logger.info(&quot;Patient MRN (Epic): &quot; + extensionAttr);
+                    //logger.info(&quot;Patient MRN (Epic): &quot; + extensionAttr);
                     break;
                 }
             }
@@ -1185,30 +1195,6 @@ function getEncounterEffectiveTime(encounterNodeList, returnFallBackTime) {
     }
 
     return fallbackTime;
-}
-
-function generateSHA256Id(resource, resourceName, resourceIdName, transformer, additionalString) {
-    if (resource != undefined) { 
-        // Get MRN and CIN from channelMap
-        var mrn = channelMap.get(&apos;Patient-MRN&apos;) || &quot;&quot;;
-        var cin = channelMap.get(&apos;patientCIN&apos;) || &quot;&quot;;
-        var combinedText = mrn + cin;
-
-        if (typeof additionalString !== &apos;undefined&apos; &amp;&amp; additionalString != null &amp;&amp; additionalString !== &apos;&apos;) {
-            combinedText += additionalString;
-        }
-
-        var resourceText = resourceName + resource.toString().trim();
-        combinedText += resourceText;
-
-        // Generate SHA-256 hash
-        var sha256Hash = generateSHA256(new java.lang.String(combinedText));
-        transformer.setParameter(resourceIdName, sha256Hash);
-    } else {
-        logger.error(resourceName + &quot; not found in the XML.&quot;);
-    }
-
-    return transformer;
 }
 
 function getCategoryDisplay(code) {
@@ -1492,7 +1478,8 @@ function setResourceIdParameters(transformer) {
                               .*::section.(@ID == &apos;sexualOrientation&apos;)
                               .*::entry
                               .*::observation;
-	transformer = generateSHA256Id(sexualOrientation, &quot;sexualOrientation&quot;, &quot;sexualOrientationResourceId&quot;, transformer);
+	//transformer = generateSHA256Id(sexualOrientation, &quot;sexualOrientation&quot;, &quot;sexualOrientationResourceId&quot;, transformer);
+	transformer = generateCompactSha256(sexualOrientation, &quot;sexualOrientation&quot;, &quot;sexualOrientationResourceId&quot;, transformer);	
 
 	// Extract `encompassingEncounter`
 	try {
@@ -1550,8 +1537,6 @@ function setResourceIdParameters(transformer) {
 	        }
 	    }
 	
-	    logger.info(&quot;Grouper Screening Effective Time: &quot; + grouperScreeningEffectiveTime);
-	
 	} catch (e) {
 	    logger.error(&quot;Error extracting grouperScreeningEffectiveTime: &quot; + e);
 	}
@@ -1560,7 +1545,6 @@ function setResourceIdParameters(transformer) {
 	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
 	
 	    grouperScreeningCode = &apos;100698-0&apos;;
-	    logger.info(&quot;Defaulting grouperScreeningCode to 100698-0 for Epic&quot;);
 	
 	} else if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Medent&apos;)
 	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
@@ -1578,7 +1562,6 @@ function setResourceIdParameters(transformer) {
 	            for each (var obs in observations) {
 	                if (obs.*::code &amp;&amp; obs.*::code.@code.toString().trim() != &apos;&apos;) {
 	                    grouperScreeningCode = obs.*::code.@code.toString().trim();
-	                    logger.info(&quot;Using screening code from CCDA observation (Medent): &quot; + grouperScreeningCode);
 	                    break;
 	                }
 	            }
@@ -1591,7 +1574,6 @@ function setResourceIdParameters(transformer) {
 	    // Final fallback if still empty (matches XSLT)
 	    if (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;) {
 	        grouperScreeningCode = &apos;96777-8&apos;;
-	        logger.info(&quot;Defaulting grouperScreeningCode to 96777-8 for Medent&quot;);
 	    }
 	} else { // For general CCDA files
 		//grouperScreeningEffectiveTime = &apos;&apos;;
@@ -1600,7 +1582,6 @@ function setResourceIdParameters(transformer) {
 	grouperScreeningCode = (grouperScreeningCode || &apos;&apos;).trim();
 	
 	transformer.setParameter(&apos;grouperScreeningCode&apos;, String(grouperScreeningCode));
-	logger.info(&apos;grouperScreeningCode&apos; + &quot; : &quot; + grouperScreeningCode);
 
 	// Get encounter effective time
 	var encounterEffectiveTime = &apos;&apos;;
@@ -1633,18 +1614,13 @@ function setResourceIdParameters(transformer) {
 	
 	if (!finalEffectiveTime || finalEffectiveTime.trim() === &apos;&apos;) {
 	    finalEffectiveTime = encounterEffectiveTime || &apos;&apos;;
-	    logger.info(&quot;Using encounterEffectiveTime as fallback for generating Grouper Resource ID : &quot; + finalEffectiveTime);
 	}
-
-     logger.info(&quot;Hash Inputs → MRN: &quot; + mrn + &quot;, CIN: &quot; + cin +
-            &quot;, Code: &quot; + grouperScreeningCode +
-            &quot;, EffectiveTime: &quot; + finalEffectiveTime);
-            
+           
      var combinedText = mrn + cin + grouperScreeningCode + finalEffectiveTime;
-     var sha256Hash = generateSHA256(new java.lang.String(combinedText)); 
+     transformer = generateCompactSha256(combinedText, &quot;grouperObservation&quot;, &quot;grouperObservationResourceSha256Id&quot;, transformer);   
     
-     transformer.setParameter(&apos;grouperObservationResourceSha256Id&apos;, sha256Hash);
-     logger.info(&apos;grouperObservationResourceSha256Id&apos; + &quot; : &quot; + sha256Hash);
+     //transformer.setParameter(&apos;grouperObservationResourceSha256Id&apos;, encodedSha256Hash);
+     //logger.info(&apos;grouperObservationResourceSha256Id&apos; + &quot; : &quot; + encodedSha256Hash);
      
      // Set category xml
      transformer = getObservationCategoryCodes(transformer, sourceXml); //observations
@@ -1833,7 +1809,6 @@ function getConsentResourceStatus(sourceXml) {
 		}		
 		// Convert to JSON string (optional, for sending/logging)
 		var consentJsonString = JSON.stringify(consentInfo);
-		logger.info(&quot;Consent Info JSON: &quot; + consentJsonString);
 		channelMap.put(&apos;elaboration&apos;, consentJsonString);
 	} catch (e) {
         var errorMsg;
@@ -1979,8 +1954,6 @@ function validateMandatoryFields() {
 	    errors.push(&quot;Organization name -&gt; &quot; + organizationNameXPath);
 	}
 	
-	logger.info(&quot;Organization Name resolved as: &quot; + organizationName);
-
     // -----------------------------
     // Return OperationOutcome if errors exist
     // -----------------------------
@@ -1997,7 +1970,6 @@ function validateMandatoryFields() {
           <sequenceNumber>5</sequenceNumber>
           <enabled>true</enabled>
           <script>var requestedPath = sourceMap.get(&apos;contextPath&apos;);
-logger.info(&quot;Request URL: &quot; + requestedPath);
 
 if (requestedPath == &quot;/&quot;) {
 	return;
@@ -2005,7 +1977,6 @@ if (requestedPath == &quot;/&quot;) {
 
 //Extract the name and extension of the file received before processing.
 msg = channelMap.get(&apos;fileContent&apos;);
-logger.info(&quot;msg: &quot; + msg);
 
 // Route based on the API call
 if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
@@ -2062,7 +2033,6 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
     	try {
         phiFilteredXml = applyPhiFilter(sourceXml);
         channelMap.put(&apos;phi_filtered_ccd&apos;, phiFilteredXml);
-        logger.info(&quot;PHI Filtered CCD: &quot; + phiFilteredXml);
     	} catch (e) {
         failAndExit(
             &quot;CCD XML PHI filtering failed. &quot; + e.message,
@@ -2143,13 +2113,11 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
 		// Check if tracking is enabled
 		var trackingEnabled = java.lang.System.getenv(&quot;DATA_LEDGER_TRACKING&quot;);
 		if (trackingEnabled != null &amp;&amp; trackingEnabled.toLowerCase() == &quot;true&quot;) {
-		    logger.info(&quot;data ledger api call -BEGIN received&quot;);
 		    try {
 		        sendDataLedgerSync(payload);
 		    } catch (e) {
 		        logger.error(&quot;Error occurred while sending data to Data Ledger: &quot; + e.message);
 		    }
-		    logger.info(&quot;data ledger api call -END received&quot;);
 		} else {
 		    logger.info(&quot;DATA_LEDGER_TRACKING is not true; skipping Data Ledger sync.&quot;);
 		}
@@ -2199,7 +2167,6 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
     try {
         phiFilteredXml = applyPhiFilter(sourceXml);
         channelMap.put(&apos;phi_filtered_ccd&apos;, phiFilteredXml);
-        logger.info(&quot;PHI Filtered CCD: &quot; + phiFilteredXml);
     } catch (e) {
         failAndExit(
             &quot;CCD XML PHI filtering failed. &quot; + e.message,
@@ -2223,31 +2190,6 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
 
         		//*********** DATA LEDGER ***************
         		saveDataLedgerSync(interactionId);
-	          /*var  currentTimestamEnd = new Date().toISOString().replace(/\.(\d{3})Z$/, function(match, millis) {
-				// Add 3 more random digits to simulate microseconds
-				var micros = millis + (Math.floor(Math.random() * 1000)).toString().padStart(3, &apos;0&apos;);
-				return &apos;.&apos; + micros + &apos;Z&apos;;
-			});
-			var payload = JSON.stringify({
-		        executedAt: currentTimestamEnd,
-		        actor: &quot;TechBD&quot;,
-		        action: &quot;sent&quot;, 
-		        destination: &quot;Invalid - CCD Conversion Failed&quot;,
-		        dataId: interactionId,
-		        payloadType: &quot;hrsnBundle&quot;
-		  	});		
-				
-			if (trackingEnabled != null &amp;&amp; trackingEnabled.toLowerCase() == &quot;true&quot;) {
-			    logger.info(&quot;data ledger api call -BEGIN sent&quot;);
-			   try {
-		        sendDataLedgerSync(payload);
-			    } catch (e) {
-			        logger.error(&quot;Error occurred while sending data to Data Ledger: &quot; + e.message);
-			    }
-			    logger.info(&quot;data ledger api call -END sent&quot;);
-			} else {
-			    logger.info(&quot;DATA_LEDGER_TRACKING is not true; skipping Data Ledger sync for sent.&quot;);
-			}*/
 			//*********** DATA LEDGER ***************
     }
 
@@ -2677,7 +2619,7 @@ if(endpoint == &apos;bundle&apos;) {
 	    // Log the response details
 	    logger.info(&quot;Response from &quot; + destinationName + &quot;:&quot;);
 	    logger.info(&quot;Status Code: &quot; + responseStatus);
-	    logger.info(&quot;Response Data: &quot; + responseData);
+	    //logger.info(&quot;Response Data: &quot; + responseData);
 	} else {
 	    logger.info(&quot;No response found for destination: &quot; + destinationName);
 	}
@@ -2728,7 +2670,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1777976124987</time>
+        <time>1779786001708</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>

--- a/support/specifications/channel-files/mirth-connect/TechBD HL7 Workflow.xml
+++ b/support/specifications/channel-files/mirth-connect/TechBD HL7 Workflow.xml
@@ -2,8 +2,8 @@
   <id>6b056724-d5c4-48ac-84e4-92b9c3768212</id>
   <nextMetaDataId>3</nextMetaDataId>
   <name>TechBD HL7 Workflow</name>
-  <description>Version: 0.1.14</description>
-  <revision>13</revision>
+  <description>Version: 0.1.15</description>
+  <revision>21</revision>
   <sourceConnector version="4.5.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -89,7 +89,6 @@ function toJsonb(value) {
     }
     
     jsonbObj.setValue(value);
-    logger.info(&quot;jsonbObj: &quot; + jsonbObj);
     return jsonbObj;
 }
 
@@ -124,27 +123,17 @@ if(jdbcPassword != null) {
 }
 
 function saveHL7Payload(interactionId, tenantId, requestUri, payloadJson, operation) {
-	
-	logger.info(&quot;interactionId: &quot; + interactionId);
-	logger.info(&quot;tenantId: &quot; + tenantId);
-	logger.info(&quot;requestUri: &quot; + requestUri);
-	logger.info(&quot;payloadJson: &quot; + payloadJson);
-	logger.info(&quot;operation: &quot; + operation);
-	
 	var DriverManager = java.sql.DriverManager;
 	var conn = null;
 	var stmt = null;
 	
 	try {
-	     logger.info(&quot;Inside DB Try&quot;);	    
-
 	     // Database connection details
 		var dbUrl = channelMap.get(&apos;jdbcUrl&apos;);
 		var dbUser = channelMap.get(&apos;jdbcUsername&apos;);
 		var dbPassword = channelMap.get(&apos;jdbcPassword&apos;);
 
 		conn = DriverManager.getConnection(dbUrl, dbUser, dbPassword);
-	     logger.info(&quot;Database connection established successfully.&quot;);
 	
 		var sql = &quot;select techbd_udi_ingress.register_interaction_hl7_request(?::text,?::text,?::jsonb,?::text,?::text,?::jsonb,?::text,?::text,?::jsonb,?::text,?::text,?::text,?::text,?::text,?::text,?::text,?,?::text,?,?::text,?::text,?::text,?::text,?::text,?::text,?::text,?::text,?::text)&quot;;
 	     stmt = conn.prepareCall(sql);
@@ -216,14 +205,13 @@ function saveHL7Payload(interactionId, tenantId, requestUri, payloadJson, operat
 		stmt.setString(28, channelMap.get(&apos;filename&apos;));
 
 	    var result = stmt.execute();
-	    logger.info(&quot;Stored procedure executed, result: &quot; + result);
+	    //logger.info(&quot;Stored procedure executed, result: &quot; + result);
 	
 	} catch (e) {
 	    logger.error(&quot;Error executing stored procedure: &quot; + e);
 	} finally {
 	    if (stmt != null) stmt.close();
 	    if (conn != null) conn.close();
-	    logger.info(&quot;DB connection closed.&quot;);
 	}
 }
 
@@ -233,10 +221,7 @@ channelMap.put(&apos;saveHL7Payload&apos;, saveHL7Payload);</script>
           <name>Validate Request and Headers</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
-          <script>logger.info(&quot;HTTP request validation started.&quot;);
-
-var requestedPath = sourceMap.get(&apos;contextPath&apos;);
-logger.info(&quot;Request URL: &quot; + requestedPath);
+          <script>var requestedPath = sourceMap.get(&apos;contextPath&apos;);
 
 if (requestedPath == &quot;/&quot;) {
 	return;
@@ -248,7 +233,7 @@ var missingHeaders = [];
 // Helper to check and store missing header
 function checkRequiredHeader(headerName, displayName, storeInMap, mapKey) {
     var value = $(&apos;headers&apos;).getHeader(headerName);
-    logger.info(headerName + &quot;: &quot; + value);
+    //logger.info(headerName + &quot;: &quot; + value);
 
     if (value == null || String(value).trim() === &quot;&quot;) {
         missingHeaders.push(&quot;Missing required header &quot; + displayName);
@@ -274,15 +259,12 @@ if (!contentType || !contentType.startsWith(&apos;multipart/form-data&apos;) /*|
 // Get User-Agent header to set at HTTP Writer not to show &apos;Mirth connect&apos; as Agent at the application side.
 var userAgent = $(&apos;headers&apos;).getHeader(&apos;User-Agent&apos;);
 channelMap.put(&apos;userAgent&apos;, userAgent);
-logger.info(&quot;User-Agent: &quot; + userAgent);
 
 var OrganizationName = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Organization-Name&apos;);
 channelMap.put(&apos;OrganizationName&apos;, OrganizationName);
-logger.info(&quot;OrganizationName: &quot; + OrganizationName);
 
 var severityLevel = String($(&apos;headers&apos;).getHeader(&apos;X-TechBD-Validation-Severity-Level&apos;) || &quot;&quot;).trim();
 channelMap.put(&apos;SeverityLevel&apos;, severityLevel || &quot;error&quot;);
-logger.info(&quot;SeverityLevel: &quot; + (severityLevel || &quot;error&quot;));
 
 channelMap.put(&apos;uri&apos;, sourceMap.get(&apos;uri&apos;));
 channelMap.put(&apos;contextPath&apos;, sourceMap.get(&apos;contextPath&apos;));
@@ -294,11 +276,9 @@ if (requestedPath == &quot;/hl7v2/Bundle/&quot; || requestedPath == &quot;/hl7v2
 	
 	//2.NPI
 	var organizationNPI = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OrgNPI&apos;);
-	logger.info(&quot;X-TechBD-OrgNPI: &quot; + organizationNPI);
 	
 	//3.TIN
 	var organizationTIN = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OrgTIN&apos;);
-	logger.info(&quot;X-TechBD-OrgTIN: &quot; + organizationTIN);
 	
 	// Check if both are missing — only then it&apos;s an error
 	if ((organizationNPI == null || String(organizationNPI).trim() === &quot;&quot;) &amp;&amp;
@@ -320,22 +300,19 @@ if (requestedPath == &quot;/hl7v2/Bundle/&quot; || requestedPath == &quot;/hl7v2
 	checkRequiredHeader(&apos;X-TechBD-Encounter-Type&apos;, &apos;X-TechBD-Encounter-Type&apos;, true, &apos;encounterType&apos;);
 
 	//6. Part 2 Data Flagging 
-	var part2DataFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Part2&apos;);	
-	logger.info(&quot;X-TechBD-Part2: &quot; + part2DataFlag);
+	var part2DataFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Part2&apos;);
 	if (part2DataFlag &amp;&amp; String(part2DataFlag).trim() !== &quot;&quot;) {
 	    channelMap.put(&apos;X-TechBD-Part2&apos;, part2DataFlag);
 	}
 
 	// 7. OMH Flagging
 	var OMHFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OMH&apos;);
-	logger.info(&quot;X-TechBD-OMH: &quot; + OMHFlag);
 	if (OMHFlag &amp;&amp; String(OMHFlag).trim() !== &quot;&quot;) {
 	    channelMap.put(&apos;X-TechBD-OMH&apos;, OMHFlag);
 	}
 	
 	// 8. OPWDD Flagging
 	var OPWDDFlag = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-OPWDD&apos;);
-	logger.info(&quot;X-TechBD-OPWDD: &quot; + OPWDDFlag);
 	if (OPWDDFlag &amp;&amp; String(OPWDDFlag).trim() !== &quot;&quot;) {
 	    channelMap.put(&apos;X-TechBD-OPWDD&apos;, OPWDDFlag);
 	}
@@ -373,9 +350,7 @@ if (missingEnvVars.length &gt; 0) {
     logger.error(errorMessage);
     setErrorResponse(500, errorMessage); // Internal Server Error
     throw errorMessage;
-}
-
-logger.info(&quot;HTTP request validation ended.&quot;);</script>
+}</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
         <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.5.0">
           <name>FileName Validation</name>
@@ -424,7 +399,6 @@ var saveHL7Payload = channelMap.get(&apos;saveHL7Payload&apos;);
 
 var xml = new XML(rawData);
 var hl7Message = xml.Content.Part.Content.toString();
-logger.info(&quot;hl7Message : &quot; + hl7Message);
 
 var filename = null;
 var filenameMatch = rawData.match(/filename=&quot;([^&quot;]+)&quot;/);
@@ -436,7 +410,6 @@ if (filenameMatch &amp;&amp; filenameMatch.length &gt; 1) {
 
     var extensionMatch = filename.match(/\.([0-9a-z]+)$/i);
     var extension = extensionMatch ? extensionMatch[1].toLowerCase().trim() : null;
-    logger.info(&quot;File extension: &quot; + extension);
 
     if (extension !== &quot;hl7&quot; &amp;&amp; extension !== &quot;txt&quot;) {
        var errorMessage = &quot;Unsupported file extension: &quot; + extension + &quot;. Only .hl7 and .txt are allowed.&quot;;
@@ -467,9 +440,7 @@ if (hl7Data == null || hl7Data.trim() === &quot;&quot;) {
 
 		try{
 			//DB Save Original Payload
-		     logger.info(&quot;DB Save inside Source transformer&quot;);
 		     var tenantId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Tenant-ID&apos;);
-		     logger.info(&quot;tenant Id: &quot; + tenantId);
 		     channelMap.put(&apos;tenantId&apos;, tenantId);
 		     var interactionId = channelMap.get(&apos;interactionId&apos;);
 		     logger.info(&quot;interactionId: &quot; + interactionId);
@@ -829,7 +800,7 @@ function getRequiredSegmentsAndFieldsFromXml(xmlPath) {
 		        description: description
 		    });
 		
-		    logger.info(&quot;✅ Extracted required field: &quot; + seg + &quot;-&quot; + fieldIndex + (componentIndex ? &quot;.&quot; + componentIndex : &quot;&quot;));
+		    //logger.info(&quot;✅ Extracted required field: &quot; + seg + &quot;-&quot; + fieldIndex + (componentIndex ? &quot;.&quot; + componentIndex : &quot;&quot;));
 		}
 
 		// Handle &lt;OneOfGroup&gt;
@@ -931,7 +902,6 @@ function validateOBXSpecialRule(hl7Text) {
 
             var obx3_1 = components.length &gt;= 1 ? components[0].trim() : &quot;&quot;;
             var obx3_2 = components.length &gt;= 2 ? components[1].trim().toLowerCase() : &quot;&quot;;
-            logger.info(&quot;obx3_2: &quot; + obx3_2);
 
             // Skip rule ONLY if OBX-3.2 matches special phrase
             if (obx3_2 === &quot;ahc-hrsn patient consent&quot;) {
@@ -1050,12 +1020,9 @@ function getJsonInvalidOperationOutcome(errorMsg, code) {
 }
 
 function sendDataLedgerSync(payload) {
-    logger.info(&quot;sendDataLedgerSync: &quot; + payload);
     
     var apiUrl = java.lang.System.getenv(&quot;DATA_LEDGER_API_URL&quot;);
     var dataLedgerApiKey = java.lang.System.getenv(&quot;TECHBD_NYEC_DATALEDGER_API_KEY&quot;);
-
-    logger.info(&quot;API URL: &quot; + apiUrl);
 
     if (apiUrl == null) {
         throw new Error(&quot;Environment variable DATA_LEDGER_API_URL is not set.&quot;);
@@ -1090,7 +1057,6 @@ function sendDataLedgerSync(payload) {
             var responseBody = EntityUtils.toString(response.getEntity());
 
             if (statusCode &gt;= 200 &amp;&amp; statusCode &lt; 300) {
-                logger.info(&quot;Data Ledger API Response: &quot; + responseBody);
                 return {
                     statusCode: statusCode,
                     body: responseBody
@@ -1152,7 +1118,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(bundleMetaProfileUrl != null) {
 		transformer.setParameter(&quot;bundleMetaProfileUrl&quot;, bundleMetaProfileUrl);
 		channelMap.put(&apos;bundleMetaProfileUrl&apos;, bundleMetaProfileUrl);
-		logger.info(&quot;bundleMetaProfileUrl: &quot; + bundleMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_BUNDLE variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1163,7 +1128,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(patientMetaProfileUrl != null) {
 		transformer.setParameter(&quot;patientMetaProfileUrl&quot;, patientMetaProfileUrl);
 		channelMap.put(&apos;patientMetaProfileUrl&apos;, patientMetaProfileUrl);
-		logger.info(&quot;patientMetaProfileUrl: &quot; + patientMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_PATIENT variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1174,7 +1138,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(encounterMetaProfileUrl != null) {
 		transformer.setParameter(&quot;encounterMetaProfileUrl&quot;, encounterMetaProfileUrl);
 		channelMap.put(&apos;encounterMetaProfileUrl&apos;, encounterMetaProfileUrl);
-		logger.info(&quot;encounterMetaProfileUrl: &quot; + encounterMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_ENCOUNTER variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1185,7 +1148,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(consentMetaProfileUrl != null) {
 		transformer.setParameter(&quot;consentMetaProfileUrl&quot;, consentMetaProfileUrl);
 		channelMap.put(&apos;consentMetaProfileUrl&apos;, consentMetaProfileUrl);
-		logger.info(&quot;consentMetaProfileUrl: &quot; + consentMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_CONSENT variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1196,7 +1158,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(organizationMetaProfileUrl != null) {
 		transformer.setParameter(&quot;organizationMetaProfileUrl&quot;, organizationMetaProfileUrl);
 		channelMap.put(&apos;organizationMetaProfileUrl&apos;, organizationMetaProfileUrl);
-		logger.info(&quot;organizationMetaProfileUrl: &quot; + organizationMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_ORGANIZATION variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1207,7 +1168,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(observationMetaProfileUrl != null) {
 		transformer.setParameter(&quot;observationMetaProfileUrl&quot;, observationMetaProfileUrl);
 		channelMap.put(&apos;observationMetaProfileUrl&apos;, observationMetaProfileUrl);
-		logger.info(&quot;observationMetaProfileUrl: &quot; + observationMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_OBSERVATION variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1218,7 +1178,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(observationSexualOrientationMetaProfileUrl != null) {
 		transformer.setParameter(&quot;observationSexualOrientationMetaProfileUrl&quot;, observationSexualOrientationMetaProfileUrl);
 		channelMap.put(&apos;observationSexualOrientationMetaProfileUrl&apos;, observationSexualOrientationMetaProfileUrl);
-		logger.info(&quot;observationSexualOrientationMetaProfileUrl: &quot; + observationSexualOrientationMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_SEXUAL_ORIENTATION variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1229,7 +1188,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(questionnaireMetaProfileUrl != null) {
 		transformer.setParameter(&quot;questionnaireMetaProfileUrl&quot;, questionnaireMetaProfileUrl);
 		channelMap.put(&apos;questionnaireMetaProfileUrl&apos;, questionnaireMetaProfileUrl);
-		logger.info(&quot;questionnaireMetaProfileUrl: &quot; + questionnaireMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_QUESTIONNAIRE variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1240,7 +1198,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(questionnaireResponseMetaProfileUrl != null) {
 		transformer.setParameter(&quot;questionnaireResponseMetaProfileUrl&quot;, questionnaireResponseMetaProfileUrl);
 		channelMap.put(&apos;questionnaireResponseMetaProfileUrl&apos;, questionnaireResponseMetaProfileUrl);
-		logger.info(&quot;questionnaireResponseMetaProfileUrl: &quot; + questionnaireResponseMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_QUESTIONNAIRE_RESPONSE variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1251,7 +1208,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(practitionerMetaProfileUrl != null) {
 		transformer.setParameter(&quot;practitionerMetaProfileUrl&quot;, practitionerMetaProfileUrl);
 		channelMap.put(&apos;practitionerMetaProfileUrl&apos;, practitionerMetaProfileUrl);
-		logger.info(&quot;practitionerMetaProfileUrl: &quot; + practitionerMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_PRACTITIONER variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1262,7 +1218,6 @@ function set_fhir_resource_profile_urls(transformer) {
 	if(procedureMetaProfileUrl != null) {
 		transformer.setParameter(&quot;procedureMetaProfileUrl&quot;, procedureMetaProfileUrl);
 		channelMap.put(&apos;procedureMetaProfileUrl&apos;, procedureMetaProfileUrl);
-		logger.info(&quot;procedureMetaProfileUrl: &quot; + procedureMetaProfileUrl);
 	} else {
 		var errorMessage = &apos;PROFILE_URL_PROCEDURE variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1321,12 +1276,10 @@ function getConsentResourceStatus(sourceXml) {
 		    }
 		}
 		if (consentCode != undefined &amp;&amp; consentCode.length &gt; 0) {
-		    logger.info(&quot;Consent Code: &quot; + consentCode);
 		        consentInfo.status = &quot;provided&quot;;
 		}		
 		// Convert to JSON string (optional, for sending/logging)
 		var consentJsonString = JSON.stringify(consentInfo);
-		logger.info(&quot;Consent Info JSON: &quot; + consentJsonString);
 		channelMap.put(&apos;elaboration&apos;, consentJsonString);
 	} catch (e) {
         var errorMsg;
@@ -1454,7 +1407,6 @@ function getObservationCategoryCodes(transformer, observations) {
      var categoryXml = JSON.stringify(categoryJsonArray);
 	
 	transformer.setParameter(&apos;categoryXml&apos;, categoryXml);
-	logger.info(&quot;categoryXml : &quot; + categoryXml);
 	return transformer;
 }
 
@@ -1476,14 +1428,6 @@ function bytesToHex(byteArray) {
     return hexString.toString();
 }
 
-function getPatientMRN(sourceXml){
-	var xmlDoc = new XML(sourceXml);
-	var patientMRN = xmlDoc..PID[&quot;PID.3&quot;][&quot;PID.3.1&quot;].toString().trim();
-	channelMap.put(&apos;patientMRN&apos;, patientMRN);
-	logger.info(&quot;patientMRN: &quot; + patientMRN);
-	
-}
-
 function generateSHA256Id(sourceXml, resourceName, resourceIdName, transformer, additionalString) {
     if (sourceXml != undefined) { 
     	var xmlDoc = new XML(sourceXml);
@@ -1494,7 +1438,6 @@ function generateSHA256Id(sourceXml, resourceName, resourceIdName, transformer, 
 
         if (typeof additionalString !== &apos;undefined&apos; &amp;&amp; additionalString != null &amp;&amp; additionalString !== &apos;&apos;) {
             combinedText += additionalString;
-            logger.info(&quot;Including additionalString in SHA-256: &quot; + additionalString);
         }
 
         var resourceText = resourceName + xmlDoc.toString().trim();
@@ -1510,6 +1453,39 @@ function generateSHA256Id(sourceXml, resourceName, resourceIdName, transformer, 
     }
 
     return transformer;
+}
+
+function generateCompactSha256(sourceXml, resourceName, resourceIdName, transformer) {
+    if (sourceXml != undefined) { 
+	    var MessageDigest = Packages.java.security.MessageDigest;
+	    var digest = MessageDigest.getInstance(&quot;SHA-256&quot;);
+	
+	    // Raw SHA-256 bytes
+	    var hashBytes = digest.digest(new java.lang.String(sourceXml).getBytes(&quot;UTF-8&quot;));
+	
+	    // Base64 URL-safe encoding
+	    var sha256Hash = Packages.java.util.Base64
+	        .getUrlEncoder()
+	        .withoutPadding()
+	        .encodeToString(hashBytes);
+
+	    // Convert Java String to JavaScript String
+	    sha256Hash = String(sha256Hash).replace(/_/g, &apos;-&apos;);
+	
+	    transformer.setParameter(resourceIdName, sha256Hash);
+	    channelMap.put(resourceName + &quot;_Resource_ID&quot;, sha256Hash);
+	    logger.info(resourceName + &quot; Resource_ID : &quot; + sha256Hash);
+    } else {
+	        logger.error(resourceName + &quot; not found.&quot;);
+	    }
+
+    return transformer;
+}
+
+function getPatientMRN(sourceXml){
+	var xmlDoc = new XML(sourceXml);
+	var patientMRN = xmlDoc..PID[&quot;PID.3&quot;][&quot;PID.3.1&quot;].toString().trim();
+	channelMap.put(&apos;patientMRN&apos;, patientMRN);	
 }
 
 function getMultipleAnswersForComponent(transformer, observations) {
@@ -1542,7 +1518,6 @@ function getMultipleAnswersForComponent(transformer, observations) {
     }
 
     transformer.setParameter(&apos;componentAnswersXml&apos;, JSON.stringify(codingArray));
-    logger.info(&quot;componentAnswersXml : &quot; + JSON.stringify(codingArray));
     return transformer;
 }</script>
           </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
@@ -1573,7 +1548,6 @@ try {
 
 
     var hl7Body = extractHL7Body(raw);
-    logger.info(&quot;Extracted HL7:\n&quot; + hl7Body);
     if (!hl7Body) {
 	    var msg = &quot;No MSH segment found — invalid HL7 message.&quot;;
 	    responseMap.put(&quot;finalResponse&quot;, getOutcome(msg, &quot;error&quot;, &quot;missing-segment&quot;, interactionId));
@@ -1585,11 +1559,9 @@ try {
     // Step 2: Extract input segments
     var inputSegments = extractSegments(hl7Body);
     var normalizedInput = inputSegments.map(String);
-    logger.info(&quot;Extracted input segments: &quot; + normalizedInput.join(&apos;,&apos;));
 
     // Step 3: Load required segments from XML template
     var xmlPath = java.lang.System.getenv(&quot;HL7_XSLT_PATH&quot;) + &quot;/hl7v2-validation-schema.xml&quot;;
-    logger.info(&quot;Extracted template:\n&quot; + xmlPath);
 
 	var profile = getRequiredSegmentsAndFieldsFromXml(xmlPath);
 	var requiredSegments = profile.requiredSegments;
@@ -1666,10 +1638,7 @@ try {
     logger.info(success);
 
     			// SAVE VALIDATION RESULT
-			logger.info(&quot;DB Validation Save inside Validate&quot;);
 		     var tenantId = channelMap.get(&apos;tenantId&apos;);
-		     logger.info(&quot;tenant Id: &quot; + tenantId);
-		     logger.info(&quot;successResponse: &quot; + getOutcome(success, &quot;information&quot;, &quot;valid&quot;, interactionId));
 		     var operation = &quot;saveValidationSuccess&quot;;
 		     var result = saveHL7Payload(
 			    interactionId,
@@ -1727,13 +1696,11 @@ else if (requestedPath == &quot;/hl7v2/Bundle/&quot; || requestedPath == &quot;/
 	// Check if tracking is enabled
 	var trackingEnabled = java.lang.System.getenv(&quot;DATA_LEDGER_TRACKING&quot;);
 	if (trackingEnabled != null &amp;&amp; trackingEnabled.toLowerCase() == &quot;true&quot;) {
-	    logger.info(&quot;data ledger api call -BEGIN received&quot;);
 	    try {
 	        sendDataLedgerSync(payload);
 	    } catch (e) {
 	        logger.error(&quot;Error occurred while sending data to Data Ledger: &quot; + e.message);
 	    }
-	    logger.info(&quot;data ledger api call -END received&quot;);
 	} else {
 	    logger.info(&quot;DATA_LEDGER_TRACKING is not true; skipping Data Ledger sync.&quot;);
 	}
@@ -1767,7 +1734,6 @@ try {
     }
 
     var hl7Body = extractHL7Body(raw);
-    logger.info(&quot;Extracted HL7:\n&quot; + hl7Body);
     if (!hl7Body) {
 	    var msg = &quot;No MSH segment found — invalid HL7 message.&quot;;
 	    responseMap.put(&quot;finalResponse&quot;, getOutcome(msg, &quot;error&quot;, &quot;missing-segment&quot;, interactionId));
@@ -1779,11 +1745,9 @@ try {
     // Step 2: Extract input segments
     var inputSegments = extractSegments(hl7Body);
     var normalizedInput = inputSegments.map(String);
-    logger.info(&quot;Extracted input segments: &quot; + normalizedInput.join(&apos;,&apos;));
 
     // Step 3: Load required segments from XML template
     var xmlPath = java.lang.System.getenv(&quot;HL7_XSLT_PATH&quot;) + &quot;/hl7v2-validation-schema.xml&quot;;
-    logger.info(&quot;Extracted template:\n&quot; + xmlPath);
 
 	var profile = getRequiredSegmentsAndFieldsFromXml(xmlPath);
 	var requiredSegments = profile.requiredSegments;
@@ -1860,10 +1824,7 @@ try {
     logger.info(success);
 
     // SAVE VALIDATION RESULT
-			logger.info(&quot;DB Validation Save inside Validate&quot;);
 		     var tenantId = channelMap.get(&apos;tenantId&apos;);
-		     logger.info(&quot;tenant Id: &quot; + tenantId);
-		     logger.info(&quot;successResponse: &quot; + getOutcome(success, &quot;information&quot;, &quot;valid&quot;, interactionId));
 		     var operation = &quot;saveValidationSuccess&quot;;
 		     var result = saveHL7Payload(
 			    interactionId,
@@ -1893,13 +1854,11 @@ try {
 
 try {
     var rawTransformedData = connectorMessage.getTransformedData();
-    logger.info(&quot;Raw HL7 Message (pre-clean): &quot; + rawTransformedData);
     getPatientMRN(rawTransformedData);
 	
 
     // Load XSLT from file system
     var xsltPathFromEnv = java.lang.System.getenv(&quot;HL7_XSLT_PATH&quot;) + &quot;/hl7v2-fhir-bundle.xslt&quot;;
-    logger.info(&quot;HL7_XSLT_PATH: &quot; + xsltPathFromEnv);
     var xsltPath = xsltPathFromEnv;
     var xsltFile = new java.io.File(xsltPath);
     var xsltStream = new java.io.FileInputStream(xsltFile);
@@ -1992,7 +1951,8 @@ try {
 	        logger.info(&quot;No OBX segments present in HL7 message.&quot;);
 	    }
     }
-    transformer = generateSHA256Id(soXml, &quot;sexualOrientation&quot;, &quot;sexualOrientationResourceId&quot;, transformer);
+    //transformer = generateSHA256Id(soXml, &quot;sexualOrientation&quot;, &quot;sexualOrientationResourceId&quot;, transformer);
+    transformer = generateCompactSha256(&quot;sexualOrientation&quot; + soXml, &quot;sexualOrientation&quot;, &quot;sexualOrientationResourceId&quot;, transformer);
 
     // Observations
     var observationsXml = &quot;&quot;;
@@ -2001,7 +1961,8 @@ try {
     } else {
     		logger.info(&quot;No OBX segments present in HL7 message.&quot;);
     }
-    transformer = generateSHA256Id(observationsXml, &quot;observations&quot;, &quot;observationResourceSha256Id&quot;, transformer);
+    //transformer = generateSHA256Id(observationsXml, &quot;observations&quot;, &quot;observationResourceSha256Id&quot;, transformer);
+    transformer = generateCompactSha256(&quot;observations&quot; + observationsXml, &quot;observations&quot;, &quot;observationResourceSha256Id&quot;, transformer);
 
     // Grouper Observation
     /*var selectedObr = null;
@@ -2101,17 +2062,17 @@ try {
 	        }
 	    }
 	}
-    transformer = generateSHA256Id(grouperObsXml, &quot;groupObservations&quot;, &quot;grouperObservationResourceSha256Id&quot;, transformer, channelMap.get(&apos;observations_Resource_ID&apos;));
+    //transformer = generateSHA256Id(grouperObsXml, &quot;groupObservations&quot;, &quot;grouperObservationResourceSha256Id&quot;, transformer, channelMap.get(&apos;observations_Resource_ID&apos;));
+    transformer = generateCompactSha256((channelMap.get(&apos;observations_Resource_ID&apos;) || &apos;&apos;) + grouperObsXml, &quot;groupObservations&quot;, &quot;grouperObservationResourceSha256Id&quot;, transformer);
+
 
 
     // Retrieve the X-TechBD-Base-FHIR-URL header
 		var customBaseFhirUrl = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Base-FHIR-URL&apos;);
-		logger.info(&quot;X-TechBD-Base-FHIR-URL: &quot; + customBaseFhirUrl);
 
 
     // Retrieve the VALID_URLS environment variable (comma-separated list)
 		var validUrlsEnv = java.lang.System.getenv(&quot;MC_VALID_FHIR_URLS&quot;);
-		logger.info(&quot;MC_VALID_FHIR_URLS from environment: &quot; + validUrlsEnv);
 		
 		// Convert VALID_URLS to an array for validation
 		var validUrls = validUrlsEnv ? validUrlsEnv.split(&quot;,&quot;).map(function(url) { return url.trim(); }) : [];
@@ -2146,16 +2107,13 @@ try {
 			// Store the transformed XML in the channel map
 			var hl7FhirBundle = xmlOutputStream.toString();
 			channelMap.put(&apos;hl7_fhir_bundle&apos;, hl7FhirBundle);
-			logger.info(&quot;HL7 FHIR Bundle: &quot; + hl7FhirBundle);
 
 			var jsonObject = JSON.parse(hl7FhirBundle); // Parse the string into an object
 			var cleanedJsonString = JSON.stringify(jsonObject, removeEmptyValues, 2);
-			logger.info(&quot;Cleaned JSON : &quot; + cleanedJsonString);
+			//logger.info(&quot;Cleaned JSON : &quot; + cleanedJsonString);
 
 			//Save Converted FHIR
-				logger.info(&quot;FHIR Conversion Save inside Bundle&quot;);
 			     var tenantId = channelMap.get(&apos;tenantId&apos;);
-			     logger.info(&quot;tenant Id: &quot; + tenantId);
 			     var operation = &quot;saveConversionSuccess&quot;;
 			     var result = saveHL7Payload(
 				    interactionId,
@@ -2563,7 +2521,7 @@ if(endpoint == &apos;bundle&apos;) {
 	    // Log the response details
 	    logger.info(&quot;Response from &quot; + destinationName + &quot;:&quot;);
 	    logger.info(&quot;Status Code: &quot; + responseStatus);
-	    logger.info(&quot;Response Data: &quot; + responseData);
+	    //logger.info(&quot;Response Data: &quot; + responseData);
 	} else {
 	    logger.info(&quot;No response found for destination: &quot; + destinationName);
 	}
@@ -2614,7 +2572,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1778843716000</time>
+        <time>1779785074710</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>


### PR DESCRIPTION
- Removed unnecessary info level log entries from CCDA and HL7 Mirth Connect Channel scripts
- Updated resource id generation logic for grouper observation, sexual orientation and observations (HL7 only) to reduce the length of generated hashed ID to 44 characters, so that after adding facility_id and code, it should not exeed 64 characters.