### PR TITLE
Added Host header validation for BridgeLink channel requests (#1115)

### DIFF
--- a/integration-artifacts/Router/RouterChannel.xml
+++ b/integration-artifacts/Router/RouterChannel.xml
@@ -2,17 +2,14 @@
   <id>6db40d54-c29f-47e3-aaf8-fc99cb2e53b6</id>
   <nextMetaDataId>3</nextMetaDataId>
   <name>RouterChannel</name>
-  <description>Version: 0.2.16
-Corrected redirection for replay api.</description>
-  <revision>2</revision>
+  <description>Version: 0.2.17
+Added host validation in router channel.</description>
+  <revision>3</revision>
   <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
-  <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>true</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
@@ -41,6 +38,9 @@ Corrected redirection for replay api.</description>
           <pinnedLeafPins/>
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
@@ -203,6 +203,63 @@ logger.info(fhirJson);</script>
           <enabled>true</enabled>
           <script>var httpMethod = String(sourceMap.get(&apos;method&apos;)).toUpperCase();
 var contextPath = String(connectorMessage.getSourceMap().get(&apos;contextPath&apos;)).replace(/\/$/, &apos;&apos;);
+
+
+var hostHeader = $(&apos;headers&apos;).getHeader(&apos;Host&apos;);
+
+if (hostHeader != null) {
+
+    var hostname =
+        String(hostHeader)
+            .split(&apos;:&apos;)[0]
+            .toLowerCase()
+            .trim();
+
+    // Read allowed hosts from Lookup Manager
+    var allowedHostConfig =
+        String(
+            LookupHelper.get(&quot;Config&quot;, &quot;ALLOWED_HOSTS&quot;) || &apos;&apos;
+        ).toLowerCase();
+
+    // Convert comma separated string to array
+    var allowedHosts =
+        allowedHostConfig
+            .split(&apos;,&apos;);
+
+    // Trim spaces
+    for (var i = 0; i &lt; allowedHosts.length; i++) {
+        allowedHosts[i] =
+            allowedHosts[i].trim();
+    }
+
+    // Validate host
+    if (allowedHosts.indexOf(hostname) === -1) {
+
+        logger.error(
+            &apos;Invalid Host header: &apos; + hostname
+        );
+
+        var errorBody = JSON.stringify({
+            status: 400,
+            error: &apos;Invalid Host header&apos;
+        });
+
+        var errorResponse =
+            new com.mirth.connect.userutil.Response(
+                com.mirth.connect.userutil.Status.ERROR,
+                new java.lang.String(errorBody)
+            );
+
+        responseMap.put(&apos;d1&apos;, errorResponse);
+
+        responseMap.put(&apos;status&apos;, &apos;400&apos;);
+        responseMap.put(&apos;responseStatusCode&apos;, 400);
+        responseMap.put(&apos;responseContentType&apos;, &apos;application/json&apos;);
+        responseMap.put(&apos;responseBody&apos;, errorBody);
+
+        return false;
+    }
+}
 
 // HEALTHCHECK&#xd;
 if (contextPath === &apos;/healthcheck&apos;) {&#xd;
@@ -892,7 +949,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1779338103434</time>
+        <time>1780380053461</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -901,10 +958,147 @@ return;</undeployScript>
       </pruningSettings>
       <userId>6</userId>
     </metadata>
+    <codeTemplateLibraries>
+      <codeTemplateLibrary version="26.3.1">
+        <id>66cf0efd-4f83-4c42-8b8e-71a5c57d9b11</id>
+        <name>TechBD Functions</name>
+        <revision>129</revision>
+        <lastModified>
+          <time>1780375703728</time>
+          <timezone>America/New_York</timezone>
+        </lastModified>
+        <description></description>
+        <includeNewChannels>true</includeNewChannels>
+        <enabledChannelIds class="sorted-set">
+          <string>04ef5b0d-3120-4dd4-ba3f-fd7ec1ab1fdb</string>
+          <string>158a1edb-a782-4fb4-bc18-f05f40ce3e18</string>
+          <string>1886486f-4cbd-4e25-9057-ebd6cc6f6478</string>
+          <string>1908260b-7361-46dc-a9c9-e7114b06e698</string>
+          <string>1c406954-d304-4882-b05d-b513d699785b</string>
+          <string>207ba60a-9430-4126-9553-8c8eb588f419</string>
+          <string>2240d25e-de1d-4c6f-904c-832e7f68a574</string>
+          <string>29316ddf-46cc-4d33-813d-2b71a8b41902</string>
+          <string>2d6fac85-49e1-4aa8-b39f-b4e39f12597e</string>
+          <string>35ee3e0b-ad66-44c5-bf30-6ebe8ff7c7ec</string>
+          <string>38c30482-47ef-41e0-b6f3-fa56e8bc76ae</string>
+          <string>3acb72be-f9c1-4721-b990-ff0486b038fc</string>
+          <string>3bfca654-f2c7-4c5e-bb88-1ab68cd32f44</string>
+          <string>3cbc2ace-4a86-4ef9-839a-2aa4feac2ee3</string>
+          <string>3f3f6dcd-2923-4f09-89c3-1e248c1556b3</string>
+          <string>45c0836b-0e92-4861-9e58-16898e1e0835</string>
+          <string>4cd30607-97b1-44ad-9d8f-4cfc7dfa4028</string>
+          <string>4d4a6df4-774e-4cbd-b7aa-4ce0314d8faa</string>
+          <string>520ded48-a0be-4492-8cba-4fad5a227afd</string>
+          <string>548ec946-51d0-4c8b-a402-78345d8f0242</string>
+          <string>61730c66-eedd-4c67-bb98-71c867be56a4</string>
+          <string>6432709e-b815-40a3-91a8-f77570d3273e</string>
+          <string>657d9972-aa59-406d-b248-22f39bbceed2</string>
+          <string>66b6457a-d8a4-40fb-bf4a-7fd09c941285</string>
+          <string>6ba3d163-f959-4b4f-9aca-f9bcdc5e7887</string>
+          <string>71d75aee-a90e-4800-86cd-ec4d4ff8ba0c</string>
+          <string>78fd5c66-613e-46dd-bd45-c3dd0021a5fb</string>
+          <string>7bfc4fca-cf0a-4caf-b297-b4579d23684c</string>
+          <string>7ffeeda4-e8e9-4534-8cf0-28eb8ce65510</string>
+          <string>8255fb74-da31-4573-ba36-1da03f1bfc27</string>
+          <string>87d008ec-f78d-4f2f-b986-cb1a4d926540</string>
+          <string>89def8c9-d8d2-46e2-a254-6345b05cfcb4</string>
+          <string>8af30ec7-ad08-4ac8-9604-3ddd35f6d8b2</string>
+          <string>8ca393c1-16ac-4b77-b78f-a8fca05ae3d6</string>
+          <string>92bad760-5de9-4b86-91f4-33011e68ca43</string>
+          <string>95b30942-c7ab-4267-8dc8-7e9436e0f470</string>
+          <string>96bd9c4c-3490-4ed9-9efe-4179e3d7d33d</string>
+          <string>9a7e7b61-5745-4e29-a7e1-43a7d61b60ba</string>
+          <string>9c85680a-7b06-43fb-9d12-01db1d9c0448</string>
+          <string>9cbcd82b-a20e-4120-9d81-7c6698dfc1dd</string>
+          <string>9f99a5c7-84d9-4dc2-aa7f-451096b5bb8b</string>
+          <string>a1bf0b83-9809-4841-b748-41ee68cb1765</string>
+          <string>a5b2ab2c-b422-4614-ac3c-c7b0876c8579</string>
+          <string>ab20f626-8de4-4845-8080-0f2c6b80669a</string>
+          <string>abe04006-4dc5-462a-88f6-93fdefb35933</string>
+          <string>af622c7c-a713-4fe6-a12c-3d8b199efc75</string>
+          <string>b84ee0f0-dfed-40bd-8a9e-af052b60860e</string>
+          <string>bafa98dd-04f2-48ef-babb-4a3bedbcb0ed</string>
+          <string>c00e53b6-6165-4bb3-bd47-7f1e5d9708d4</string>
+          <string>c09ea42f-cb4b-4f67-92cd-830a1ab4c51c</string>
+          <string>c50e41d7-9fb2-4899-84f8-38909d092722</string>
+          <string>c79799dd-a972-4d99-beba-1331ed5e49a2</string>
+          <string>cc1fe1c8-04cd-4b08-9797-0cb34491208b</string>
+          <string>d320f5d3-7af1-4de1-b618-6ed11e84390d</string>
+          <string>d341dceb-069e-49ab-8efa-c45398145216</string>
+          <string>d8205661-526c-4762-bef0-0cb8414424cb</string>
+          <string>d85d0014-300a-46f9-81b7-ad6c6ef1516b</string>
+          <string>dc1d3367-14d7-4e36-a87e-d208d839fc78</string>
+          <string>dfa0f0a0-c211-4aa2-bb6c-444d5c23da7e</string>
+          <string>e634b038-8196-4ac4-80fc-819a0a9c9bb1</string>
+          <string>eb2f5490-8909-4216-b65a-5947fb0f359e</string>
+          <string>f23e19b0-a0e0-422a-884c-caae6c52ecac</string>
+          <string>f2d185dd-96c3-4065-bbb9-5044afb7ba80</string>
+          <string>fa2e04e2-8435-4a9c-bad2-ac65c1bb3a33</string>
+          <string>ffc6ec26-9bda-4da6-b9e5-20912920ab83</string>
+        </enabledChannelIds>
+        <disabledChannelIds class="sorted-set"/>
+        <codeTemplates>
+          <codeTemplate version="26.3.1">
+            <id>030add36-72d6-4bb4-8db4-aa0cc8b906c9</id>
+            <name>setErrorResponse</name>
+            <revision>15</revision>
+            <lastModified>
+              <time>1779700772800</time>
+              <timezone>America/New_York</timezone>
+            </lastModified>
+            <contextSet>
+              <delegate class="sorted-set">
+                <contextType>GLOBAL_DEPLOY</contextType>
+                <contextType>GLOBAL_UNDEPLOY</contextType>
+                <contextType>GLOBAL_PREPROCESSOR</contextType>
+                <contextType>GLOBAL_POSTPROCESSOR</contextType>
+                <contextType>CHANNEL_DEPLOY</contextType>
+                <contextType>CHANNEL_UNDEPLOY</contextType>
+                <contextType>CHANNEL_PREPROCESSOR</contextType>
+                <contextType>CHANNEL_POSTPROCESSOR</contextType>
+                <contextType>CHANNEL_ATTACHMENT</contextType>
+                <contextType>CHANNEL_BATCH</contextType>
+                <contextType>SOURCE_RECEIVER</contextType>
+                <contextType>SOURCE_FILTER_TRANSFORMER</contextType>
+                <contextType>DESTINATION_FILTER_TRANSFORMER</contextType>
+                <contextType>DESTINATION_DISPATCHER</contextType>
+                <contextType>DESTINATION_RESPONSE_TRANSFORMER</contextType>
+              </delegate>
+            </contextSet>
+            <properties class="com.mirth.connect.model.codetemplates.BasicCodeTemplateProperties">
+              <type>FUNCTION</type>
+              <code>/**
+	Util function to set error response.
+
+	@param {Any} statusCode - 
+	@param {Any} errorMessage - 
+	@param {Any} map - 
+	@return {Any} 
+*/
+function setErrorResponse(statusCode, errorMessage, map) {
+    var targetMap = map || responseMap;
+
+    var json = createJsonResponse(statusCode, errorMessage);
+    targetMap.put(&apos;status&apos;, String(statusCode));
+    targetMap.put(&apos;responseStatusCode&apos;, statusCode);
+    targetMap.put(&apos;fhirResponse&apos;, json);
+    targetMap.put(&apos;finalResponse&apos;, json);
+}
+/**
+ Util function to generate json string wit hstatus and message
+*/
+function createJsonResponse(status, message) {
+    return JSON.stringify({ status: status, message: message });
+}</code>
+            </properties>
+          </codeTemplate>
+        </codeTemplates>
+      </codeTemplateLibrary>
+    </codeTemplateLibraries>
     <channelTags>
       <channelTag>
-        <id>dad98b8a-599f-458e-8232-3740e527258a</id>
-        <name>0_2_16</name>
+        <id>c8ba2360-5df9-42b0-8c25-ef165040ae4e</id>
+        <name>0_2_17</name>
         <channelIds>
           <string>6db40d54-c29f-47e3-aaf8-fc99cb2e53b6</string>
         </channelIds>

--- a/integration-artifacts/lookup-manager/nexus/lookup_group_config_export.json
+++ b/integration-artifacts/lookup-manager/nexus/lookup_group_config_export.json
@@ -40,7 +40,8 @@
     "PROFILE_URL_SEXUAL_ORIENTATION" : "/StructureDefinition/shinny-observation-sexual-orientation",
     "SM_KEY_RDS_SECRETS" : "techbd-rds-secrets",
     "TECHBD_CSV_SERVICE_API_URL" : "https://nexus.csv.sandbox.techbd.org",
-    "TECHBD_DEFAULT_DATALAKE_API_URL" : "https://uzrlhp39e0.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle"
+    "TECHBD_DEFAULT_DATALAKE_API_URL" : "https://uzrlhp39e0.execute-api.us-east-1.amazonaws.com/dev/HRSNBundle",
+    "ALLOWED_HOSTS" : "1.nexus-txd-sbx.techbd.org"
   },
   "exportDate" : "2026-03-18T14:14:12.699+00:00"
 }

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -82,7 +82,7 @@
       "channel": "lookup_group_config_export.json",
       "version": "",
       "editedby": "abhiramisanthosh90",
-      "date": "2026-04-14"
+      "date": "2026-06-02"
     },
     {
       "type": "Lookup Manager",
@@ -108,9 +108,9 @@
     {
       "type": "Router",
       "channel": "RouterChannel.xml",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "editedby": "abhiramisanthosh90",
-      "date": "2026-05-21"
+      "date": "2026-06-02"
     },
   {
       "type": "code-templates",


### PR DESCRIPTION
Implemented Host header validation in BridgeLink source filter to prevent processing requests with invalid or spoofed Host headers.

Changes:
- Added validation for incoming HTTP Host header
- Allowed only valid allowed  domain pattern from lookup manager
- Rejected invalid host values with HTTP 400 response
- Added logging for invalid Host header attempts
- Applied validation before request processing and mTLS validation flow