### PR TITLE
fix: align resource ID generation logic in HL7 workflow and bump version to 0.1166.0 #1515

### DIFF
--- a/integration-artifacts/hl7v2/hl7-techbd-channel-files/nexus-sandbox/TechBD HL7 Workflow.xml
+++ b/integration-artifacts/hl7v2/hl7-techbd-channel-files/nexus-sandbox/TechBD HL7 Workflow.xml
@@ -2,17 +2,14 @@
   <id>6432709e-b815-40a3-91a8-f77570d3273e</id>
   <nextMetaDataId>3</nextMetaDataId>
   <name>TechBD HL7 Workflow</name>
-  <description>Version: 0.1.42
-Refactored Observation resource ID generation logic in the Bridge Link channel to use a compact identifier format, reducing overall character length and improving payload efficiency.</description>
-  <revision>2</revision>
+  <description>Version: 0.1.43
+Completed investigation and validation of resource ID generation logic; verified expected behavior and consistency across processing workflows.</description>
+  <revision>5</revision>
   <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
-  <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
@@ -41,6 +38,9 @@ Refactored Observation resource ID generation logic in the Bridge Link channel t
           <pinnedLeafPins/>
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
@@ -2010,6 +2010,7 @@ try {
 
 try {
     var rawTransformedData = connectorMessage.getTransformedData();
+	getPatientMRN(rawTransformedData);
 	logger.info(logPrefix + &quot;Raw HL7 Message (pre-clean): &quot; + rawTransformedData);
 
 
@@ -3297,7 +3298,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1780051935847</time>
+        <time>1780397474992</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
@@ -3308,8 +3309,8 @@ return;</undeployScript>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>b4762047-5c0f-4ff0-9f92-f8c4490a3dc7</id>
-        <name>0_1_42</name>
+        <id>3bfdf251-2f4a-441e-99a0-62e81de23049</id>
+        <name>0_1_43</name>
         <channelIds>
           <string>6432709e-b815-40a3-91a8-f77570d3273e</string>
         </channelIds>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -52,9 +52,9 @@
     {
       "type": "HL7v2",
       "channel": "TechBD HL7 Workflow.xml",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "editedby": "jewelbonnie",
-      "date": "2026-05-29"
+      "date": "2026-06-02"
     },
     {
       "type": "HL7v2",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1165.0</revision>
+        <revision>0.1166.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Added patient MRN extraction prior to resource ID generation
- Aligned resource ID generation behavior across workflow processing steps
- Verified encounter resource ID consistency during validation
- Bumped version to 0.1166.0