### PR TITLE
fix: update the XSLT file to resolve CCDA XSD validation failures by selecting only the first Grouper Observation entry when multiple Grouper and related Observation entries are present in Medent CCDA files #3155

### DIFF
--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="procedureResourceSha256Id"/>
@@ -1024,7 +1022,7 @@
   </xsl:template>
 
   <!-- Observation Template -->
-  <xsl:template name="Observation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship">
+  <xsl:template name="Observation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry[1]/ccda:observation/ccda:entryRelationship">
     <!--The observation resource will be generated only for the question codes present in the list specified in 'mapObservationCategoryCodes'-->
     <xsl:variable name="allowedCodes" select="' 71802-3 96778-6 96779-4 88122-7 88123-5 93030-5 96780-2 96782-8 95618-5 95617-7 95616-9 95615-1 95614-4 '" />
     <!-- Set questionCode -->
@@ -1559,44 +1557,4 @@
       </xsl:for-each>
     </xsl:if>
   </xsl:template>
-
-  <!-- Template to format an address -->
-  <!-- <xsl:template name="format-address">
-      <xsl:param name="addr"/>
-
-      <xsl:variable name="street">
-          <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-              <xsl:value-of select="normalize-space(.)"/>
-              <xsl:if test="position() != last()">, </xsl:if>
-          </xsl:for-each>
-      </xsl:variable>
-
-      <xsl:variable name="city"  select="normalize-space($addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''])"/>
-      <xsl:variable name="state" select="normalize-space($addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''])"/>
-      <xsl:variable name="zip"   select="normalize-space($addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != ''])"/>
-
-      <xsl:variable name="fullAddress">
-          <xsl:if test="string-length(normalize-space($street)) &gt; 0">
-              <xsl:value-of select="$street"/>
-          </xsl:if>
-
-          <xsl:if test="$city != ''">
-              <xsl:if test="normalize-space($street) != ''">, </xsl:if>
-              <xsl:value-of select="$city"/>
-          </xsl:if>
-
-          <xsl:if test="$state != ''">
-              <xsl:if test="$city != '' or normalize-space($street) != ''">, </xsl:if>
-              <xsl:value-of select="$state"/>
-          </xsl:if>
-
-          <xsl:if test="$zip != ''">
-              <xsl:text> </xsl:text>
-              <xsl:value-of select="$zip"/>
-          </xsl:if>
-      </xsl:variable>
-
-      <xsl:value-of select="normalize-space($fullAddress)"/>
-  </xsl:template> -->
-
 </xsl:stylesheet>

--- a/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
@@ -139,7 +139,7 @@
                                 ]
                             ]"/>
                                         
-                    <xsl:if test="$observations">
+                    <!-- <xsl:if test="$observations">
                         <component>
                             <section ID="observations">
                                 <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:templateId"/>
@@ -156,6 +156,73 @@
                                         <xsl:copy-of select="$observations" />
                                     </observation>
                                 </entry>
+                            </section>
+                        </component>
+                    </xsl:if> -->
+                    <xsl:if test="$observations">
+                        <component>
+                            <section ID="observations">
+
+                                <!-- Copy section-level metadata only once -->
+                                <xsl:copy-of select="
+                                    hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:templateId
+                                    | hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:code
+                                    | hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:title
+                                "/>
+
+                                <!-- Loop through each parent observation -->
+                                <xsl:for-each select="
+                                    hl7:component
+                                    /hl7:structuredBody
+                                    /hl7:component
+                                    /hl7:section[hl7:code[@code='47519-4']]
+                                    /hl7:entry
+                                    /hl7:observation[hl7:code[not(@code='76690-7')]]
+                                ">
+                                    <entry>
+                                        <observation classCode="OBS" moodCode="EVN">
+
+                                            <!-- Copy only current observation data -->
+                                            <xsl:copy-of select="hl7:templateId 
+                                                                | hl7:id 
+                                                                | hl7:code 
+                                                                | hl7:statusCode 
+                                                                | hl7:effectiveTime 
+                                                                | hl7:value"/>
+
+                                            <!-- Copy only valid entryRelationships -->
+                                            <xsl:copy-of select="
+                                                hl7:entryRelationship[
+                                                    hl7:observation[
+                                                        (
+                                                            hl7:code[
+                                                                (@codeSystemName = 'LOINC' or @codeSystemName = 'SNOMED' or @codeSystemName = 'SNOMED CT')
+                                                                and not(@code='UNK') and string-length(@code) > 0
+                                                            ]
+                                                            and (
+                                                                hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer'
+                                                                or hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-declined'
+                                                                or hl7:value[
+                                                                        not(@code='UNK') 
+                                                                        and string-length(@code) > 0 
+                                                                        and string-length(@nullFlavor)=0
+                                                                    ]
+                                                            )
+                                                        )
+                                                        or
+                                                        (
+                                                            hl7:code[@code='95614-4'] 
+                                                            and string-length(hl7:value/@value) > 0
+                                                        )
+                                                    ]
+                                                ]
+                                            "/>
+
+                                        </observation>
+                                    </entry>
+
+                                </xsl:for-each>
+
                             </section>
                         </component>
                     </xsl:if>


### PR DESCRIPTION
Updated the XSLT file to resolve CCDA XSD validation failures by selecting only the first Grouper Observation entry when multiple Grouper and related Observation entries are present in Medent CCDA files.