### PR TITLE
fix: update the XSLT file to remove multiple Grouper Observation entry generated in FHIR Bundles from Medent CCDA files #3155

### DIFF
--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -50,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -182,8 +181,8 @@
   </xsl:variable>
   <!-- End of Guthrie logic -->
 
-  <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
+  <!-- Get Organization name Author -->
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/> -->
 
 
   <xsl:template match="/">
@@ -914,14 +913,9 @@
               </xsl:if>
           ],
         </xsl:if>
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
                   
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -50,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -159,7 +158,7 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -1026,14 +1025,9 @@
               </xsl:if>
           ],
         </xsl:if>
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -49,6 +49,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -147,7 +148,7 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -849,14 +850,8 @@
           ],
         </xsl:if>
 
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
@@ -1060,23 +1055,31 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
-            <xsl:variable name="encounterEffectiveTime">
-                  <xsl:choose>
-                      <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
-                          <xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
-                          </xsl:call-template>
-                      </xsl:when>
-                      <xsl:when test="$encounterEffectiveTimeValue">
-                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
-                      </xsl:when>
-                      <xsl:otherwise>
-                          <xsl:value-of select="$currentTimestamp"/>
-                      </xsl:otherwise>
-                  </xsl:choose>
-              </xsl:variable>
+            <xsl:variable name="observationEffectiveTimeBase">
+                    <xsl:choose>
+                        <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                    </xsl:choose>
+                </xsl:variable>
 
-              <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                <xsl:variable name="observationEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="string-length(normalize-space($observationEffectiveTimeBase)) > 0">
+                            <xsl:value-of select="$observationEffectiveTimeBase"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+
+              <xsl:variable name="observationEffectiveTimeDigits" select="translate($observationEffectiveTimeBase, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
 
               <xsl:variable name="observationIdSource">
                 <xsl:choose>
@@ -1085,10 +1088,10 @@
                     <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
                   </xsl:when>
 
-                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                  <!-- Fallback: questionCode + observation EffectiveTime -->
                   <xsl:otherwise>
                     <xsl:value-of
-                      select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                      select="concat($questionCode, '-', $observationEffectiveTimeDigits)"/>
                   </xsl:otherwise>
                 </xsl:choose>
               </xsl:variable>
@@ -1248,7 +1251,7 @@
                           <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                             "derivedFrom": [
                               <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                                <xsl:variable name="encounterEffectiveTimeDF">
+                                <xsl:variable name="observationEffectiveTimeDF">
                                     <xsl:choose>
                                         <xsl:when test="ccda:effectiveTime/@value">
                                             <xsl:call-template name="formatDateTime">
@@ -1258,13 +1261,10 @@
                                         <xsl:when test="$encounterEffectiveTimeValue">
                                             <xsl:value-of select="$encounterEffectiveTimeValue"/>
                                         </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:value-of select="$currentTimestamp"/>
-                                        </xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:variable>
 
-                                <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                                <xsl:variable name="observationEffectiveTimeDigitsDF" select="translate($observationEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
                                 <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
 
                                 <xsl:variable name="observationIdSourceDF">
@@ -1274,10 +1274,10 @@
                                       <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
                                     </xsl:when>
 
-                                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                                    <!-- Fallback: questionCode + observation EffectiveTime -->
                                     <xsl:otherwise>
                                       <xsl:value-of
-                                        select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                                        select="concat($questionCodeDF, '-', $observationEffectiveTimeDigitsDF)"/>
                                     </xsl:otherwise>
                                   </xsl:choose>
                                 </xsl:variable>
@@ -1320,7 +1320,7 @@
                     "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                   }
                 </xsl:if>
-                , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
+                , "effectiveDateTime": "<xsl:value-of select='$observationEffectiveTime'/>"
                 <xsl:if test="string($organizationResourceId)">
                 , "performer": [{
                               "reference": "Organization/<xsl:value-of select='$organizationResourceId'/>"
@@ -1385,7 +1385,6 @@
     </xsl:variable>
 
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
-      <xsl:for-each select="$grouperObs[ccda:code/@code = $screeningCode]"> <!--'96777-8'-->       
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
             <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
@@ -1475,7 +1474,7 @@
 
               <!-- Gather filtered observations first -->
               <xsl:variable name="filteredObservations">
-                <xsl:for-each select="ccda:entryRelationship/ccda:observation">
+                <xsl:for-each select="$grouperObs/ccda:entryRelationship/ccda:observation">
                   <xsl:variable name="questionCode" select="ccda:code/@code"/>
                   <xsl:if test="string($questionCode) 
                                 and contains($allowedCodes, concat('|', $questionCode, '|'))
@@ -1505,7 +1504,7 @@
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
                 <xsl:variable name="questionCode" select="ccda:code/@code"/>
-                <xsl:variable name="encounterEffectiveTime">
+                <xsl:variable name="observationEffectiveTimeGprouper">
                     <xsl:choose>
                         <xsl:when test="ccda:effectiveTime/@value">
                             <xsl:call-template name="formatDateTime">
@@ -1515,25 +1514,22 @@
                         <xsl:when test="$encounterEffectiveTimeValue">
                             <xsl:value-of select="$encounterEffectiveTimeValue"/>
                         </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="$currentTimestamp"/>
-                        </xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
 
-                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                <xsl:variable name="observationEffectiveTimeGrouperDigits" select="translate($observationEffectiveTimeGprouper, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
 
-                <xsl:variable name="observationIdSource">
+                <xsl:variable name="HMobservationIdSource">
                   <xsl:choose>
                     <!-- Use extension if present and not empty -->
                     <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
                       <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
                     </xsl:when>
 
-                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <!-- Fallback: questionCode + observation EffectiveTime -->
                     <xsl:otherwise>
                       <xsl:value-of
-                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                        select="concat($questionCode, '-', $observationEffectiveTimeGrouperDigits)"/>
                     </xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -1541,7 +1537,7 @@
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
+                    <xsl:with-param name="sha256ResourceId" select="$HMobservationIdSource"/>
                   </xsl:call-template>
                 </xsl:variable>
 
@@ -1554,7 +1550,6 @@
             "url": "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$grouperObservationResourceId'/>"
           }
         }
-      </xsl:for-each>
     </xsl:if>
   </xsl:template>
 </xsl:stylesheet>

--- a/support/specifications/develop/ccda/cda-fhir-bundle.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,7 +38,6 @@
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
   <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -49,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -111,6 +111,8 @@
   </xsl:variable>
   <!-- Remove unwanted space,if any -->
   <xsl:variable name="encounterEffectiveTimeValue" select="normalize-space($encounterEffTimeValue)"/>
+
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -1005,7 +1007,7 @@
           ],
         </xsl:if>
         "name" : "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.2 -->
+<!-- Version : 0.1.3 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -56,7 +56,7 @@
                                         hl7:code/@code = '105511-0'
                                         and
                                         hl7:value[
-                                            @displayName='Permit' or @displayName='permit'
+                                            translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT'
                                             or
                                             @code='LA33-6'
                                         ]
@@ -71,7 +71,7 @@
                                         hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.86']
                                         and
                                         hl7:value[
-                                            ( @displayName='Permit' or @displayName='permit' )
+                                            ( translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT' )
                                             and
                                             @xsi:type='CD'
                                         ]
@@ -83,7 +83,9 @@
                                         hl7:code[
                                             @code='59284-0'
                                             and
-                                            (@displayName='yes' or @displayName='Permit' or @displayName='permit')
+                                            (translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'YES' 
+                                            or 
+                                            translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT')
                                         ]
                                     ]
                                 "/>

--- a/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.0 -->
+<!-- Version : 0.1.1 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -139,26 +139,6 @@
                                 ]
                             ]"/>
                                         
-                    <!-- <xsl:if test="$observations">
-                        <component>
-                            <section ID="observations">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:templateId"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:code"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:title"/>
-                                <entry>
-                                    <observation classCode="OBS" moodCode="EVN">
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:templateId"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:id"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:code"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:statusCode"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:effectiveTime"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:value"/>
-                                        <xsl:copy-of select="$observations" />
-                                    </observation>
-                                </entry>
-                            </section>
-                        </component>
-                    </xsl:if> -->
                     <xsl:if test="$observations">
                         <component>
                             <section ID="observations">


### PR DESCRIPTION
- Updated the XSLT file to remove multiple Grouper Observation entry generated in FHIR Bundles from Medent CCDA files
- Updated XSLT and channel files to add Organization name while generating the Organization resource ID in Epic, AthenaHealth Medent and Generic CCDA files.
- Removed the fallback to currentTimeStamp from Encounter Effective Date while generating the Observation Resource in Medent CCDA files.