### PR TITLE
feat: move updated XSLT and Channel files to integration artifacts #3155

### DIFF
--- a/integration-artifacts/ccda/ccda-techbd-channel-files/mirth-connect/TechBD CCD Workflow.xml
+++ b/integration-artifacts/ccda/ccda-techbd-channel-files/mirth-connect/TechBD CCD Workflow.xml
@@ -2,8 +2,8 @@
   <id>0cefb37a-ca0a-48cc-85a1-aa0b727d26a2</id>
   <nextMetaDataId>12</nextMetaDataId>
   <name>TechBD CCD Workflow</name>
-  <description>Version: 0.4.48</description>
-  <revision>20</revision>
+  <description>Version: 0.4.49</description>
+  <revision>32</revision>
   <sourceConnector version="4.5.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -1430,6 +1430,7 @@ function setResourceIdParameters(transformer) {
 	var sourceXml = channelMap.get(&apos;phi_filtered_ccd&apos;);
 	var xmlDoc = new XML(sourceXml);
 	default xml namespace = &quot;urn:hl7-org:v3&quot;;
+	var ehrVendor = channelMap.get(&apos;ehrVendor&apos;);
 	
 	// Generate Bundle resource Id
 	var ccda_fhir_bundle_id = channelMap.get(&apos;interactionId&apos;);
@@ -1451,20 +1452,65 @@ function setResourceIdParameters(transformer) {
 	transformer = generateSHA256Id(consent, &quot;consent&quot;, &quot;consentResourceId&quot;, transformer, currentTimestamp);
 	
 	// Extract `author (organization)`
-	var author = xmlDoc.*::author[0];
-	transformer = generateSHA256Id(author, &quot;Author&quot;, &quot;organizationResourceId&quot;, transformer);
+	var author = xmlDoc.*::author[0];	
+	var organizationName = &quot;&quot;;
 
-	// Extract `Questionnaire`
-	var Questionnaire = xmlDoc.*::component
-                              .*::structuredBody
-                              .*::component
-                              .*::section.(@ID != &apos;sexualOrientation&apos;)
-                              .*::entry;
-	transformer = generateSHA256Id(Questionnaire, &quot;Questionnaire&quot;, &quot;questionnaireResourceId&quot;, transformer);
+	if (ehrVendor == &apos;Epic&apos; || ehrVendor == &apos;Medent&apos;) {	
+	    var encounterOrgName =
+	        xmlDoc.*::component
+	              .*::structuredBody
+	              .*::component
+	              .*::section.(@ID == &apos;encounters&apos;)
+	              .*::entry[0]
+	              .*::encounter
+	              .*::participant.(@typeCode == &apos;LOC&apos;)[0]
+	              .*::participantRole.(@classCode == &apos;SDLOC&apos;)
+	              .*::playingEntity
+	              .*::name[0];	
+	    if (encounterOrgName != undefined &amp;&amp; encounterOrgName.toString().trim() != &quot;&quot;) {	
+	        organizationName = encounterOrgName.toString().trim();
+	
+	    } else {	
+	        var authorOrgName =
+	            xmlDoc.*::author[0]
+	                  .*::assignedAuthor
+	                  .*::representedOrganization
+	                  .*::name[0];	
+	        if (authorOrgName != undefined &amp;&amp; authorOrgName.toString().trim() != &quot;&quot;) {
+	            organizationName = authorOrgName.toString().trim();
+	        }
+	    }
+	
+	} else {	
+	    var authorOrgName =
+	        xmlDoc.*::author[0]
+	              .*::assignedAuthor
+	              .*::representedOrganization
+	              .*::name[0];
+	
+	    if (authorOrgName != undefined &amp;&amp; authorOrgName.toString().trim() != &quot;&quot;) {
+            organizationName = authorOrgName.toString().trim();
+         }
+	}
+	
+	transformer.setParameter(&apos;organizationName&apos;, organizationName);
+	//logger.info(&apos;organizationName : &apos; + organizationName);
+	transformer = generateSHA256Id(author, &quot;Author&quot;, &quot;organizationResourceId&quot;, transformer, organizationName);
+
+	// Extract `Questionnaire` - used only for Generic CCDA files
+	if (ehrVendor != &apos;Medent&apos; &amp;&amp; ehrVendor != &apos;Athenahealth&apos; &amp;&amp; ehrVendor != &apos;Epic&apos;) {
+		var Questionnaire = xmlDoc.*::component
+	                              .*::structuredBody
+	                              .*::component
+	                              .*::section.(@ID != &apos;sexualOrientation&apos;)
+	                              .*::entry;
+		transformer = generateSHA256Id(Questionnaire, &quot;Questionnaire&quot;, &quot;questionnaireResourceId&quot;, transformer);
+	}
+	
 	transformer.setParameter(&apos;patient-MRN&apos;, channelMap.get(&apos;Patient-MRN&apos;));
 	
 	// Extract `observations`
-	try {
+	/*try {
 		var observations = xmlDoc.*::component
 	                         .*::structuredBody
 	                         .*::component
@@ -1477,7 +1523,7 @@ function setResourceIdParameters(transformer) {
 		transformer = generateSHA256Id(observations, &quot;observations&quot;, &quot;observationResourceSha256Id&quot;, transformer);
 	} catch (e) {
 	    logger.error(&quot;Error accessing Observations: &quot; + e);
-	}
+	}*/
 	
 	// Extract `sexualOrientation`
 	var sexualOrientation = xmlDoc.*::component
@@ -1549,12 +1595,12 @@ function setResourceIdParameters(transformer) {
 	    logger.error(&quot;Error extracting grouperScreeningEffectiveTime: &quot; + e);
 	}
 
-	if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Epic&apos; || channelMap.get(&apos;ehrVendor&apos;) == &apos;Athenahealth&apos;)
+	if ((ehrVendor == &apos;Epic&apos; || ehrVendor == &apos;Athenahealth&apos;)
 	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
 	
 	    grouperScreeningCode = &apos;100698-0&apos;;
 	
-	} else if ((channelMap.get(&apos;ehrVendor&apos;) == &apos;Medent&apos;)
+	} else if ((ehrVendor == &apos;Medent&apos;)
 	    &amp;&amp; (!grouperScreeningCode || grouperScreeningCode.trim() === &apos;&apos;)) {
 	
 	    // Try to extract from CCDA observations
@@ -1666,7 +1712,7 @@ function setResourceIdParameters(transformer) {
 	        if (isValidLocation(location_name, location_address)) { locationSuccess = true; }
 	    }
 	    // Fallback path: structuredBody → encounters section → encounter → participant → participantRole → playingEntity → name
-		if (!locationSuccess || channelMap.get(&apos;ehrVendor&apos;) == &apos;Medent&apos;) {
+		if (!locationSuccess || ehrVendor == &apos;Medent&apos;) {
 	        var section = xmlDoc.component.structuredBody.component.section.(@ID == &apos;encounters&apos;);
 	        if (
 	            section &amp;&amp;
@@ -1705,7 +1751,7 @@ function set_profile_url(transformer, profileUrl, urlEnv, metaProfileUrlName) {
 	if(profileUrl != null) {
 		transformer.setParameter(metaProfileUrlName, profileUrl);
 		channelMap.put(metaProfileUrlName, profileUrl);
-		logger.info(metaProfileUrlName + &quot;: &quot; + profileUrl);
+		//logger.info(metaProfileUrlName + &quot;: &quot; + profileUrl);
 	} else {
 		var errorMessage = urlEnv + &apos; variable is not set&apos;;
 		logger.error(errorMessage);
@@ -1778,6 +1824,7 @@ function getConsentResourceStatus(sourceXml) {
 		
 		var xmlDoc = new XML(sourceXml); // Convert XML string to XML object			
 		default xml namespace = &quot;urn:hl7-org:v3&quot;; // Default namespace for HL7 documents
+		var xsi = new Namespace(&quot;xsi&quot;, &quot;http://www.w3.org/2001/XMLSchema-instance&quot;);
 	
 		// If consent section is there, the consentInfo.status should be &quot;provided&quot;.
 		var consentSection = xmlDoc.*::authorization.*::consent;
@@ -1785,6 +1832,8 @@ function getConsentResourceStatus(sourceXml) {
 			consentInfo.status = &quot;provided&quot;;
 		}
 		else {
+			/* For Medent, if both the two cases fail (first authorization section, secon observation with code &quot;105511-0&quot;), 
+			   check the observation that contains consent details without code.code but value.displayname as &quot;Permit&quot; or &quot;Deny&quot;*/
 			// Iterate through all &lt;section&gt; elements
 			for each (var section in xmlDoc..section) {
 			    var sectionCode = section.code.@code.toString();
@@ -1795,10 +1844,21 @@ function getConsentResourceStatus(sourceXml) {
 			            for each (var observation in entry.observation) {
 			                for each (var entryRel in observation.entryRelationship) {
 			                    for each (var nestedObs in entryRel.observation) {
-			                        var obsCode = nestedObs.code.@code.toString();
+			                        var obsCode = nestedObs.code.@code.toString();			                        
 			                        if (obsCode == &quot;105511-0&quot;) {
 			                            consentInfo.status = &quot;provided&quot;;
+			                            logger.info(&quot;consentInfo.status 2: &quot; + consentInfo.status);
 			                            break;
+			                        } else if (ehrVendor == &apos;athenahealth&apos;) {
+			                        	    var obsRoot = nestedObs.templateId.@root.toString().trim();
+			                        	    var obsValueDisplayName = nestedObs.value.@displayName.toString().trim().toLowerCase();
+			                        	    var xsiType = nestedObs.value.@xsi::type.toString();
+				                        if (obsRoot == &apos;2.16.840.1.113883.10.20.22.4.86&apos; 
+				                        		&amp;&amp; (obsValueDisplayName == &quot;permit&quot; || obsValueDisplayName == &quot;deny&quot;) 
+				                        		&amp;&amp; xsiType == &quot;CD&quot;) {
+				                        	   consentInfo.status = &quot;provided&quot;;
+				                            break;
+				                        }
 			                        }
 			                    }
 			                }
@@ -1806,7 +1866,8 @@ function getConsentResourceStatus(sourceXml) {
 			        }
 			    }
 			}
-		}		
+		}
+		
 		// Convert to JSON string (optional, for sending/logging)
 		var consentJsonString = JSON.stringify(consentInfo);
 		channelMap.put(&apos;elaboration&apos;, consentJsonString);
@@ -2042,7 +2103,7 @@ if (requestedPath == &quot;/ccda/Bundle/$validate/&quot; ||
     	// 4. XSD Validation
     	// -----------------------------------
     	try {
-		validateAgainstXsd(phiFilteredXml);
+        validateAgainstXsd(phiFilteredXml);
         logger.info(&quot;CCD XML is valid according to the XSD.&quot;);
     	} catch (e) {
     	   var errorMessage = buildValidationErrorMessage(&quot;CCD XML validation failed.&quot;, e);
@@ -2664,7 +2725,7 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1779786001708</time>
+        <time>1780486598436</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -50,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -182,8 +181,8 @@
   </xsl:variable>
   <!-- End of Guthrie logic -->
 
-  <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
+  <!-- Get Organization name Author -->
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/> -->
 
 
   <xsl:template match="/">
@@ -914,14 +913,9 @@
               </xsl:if>
           ],
         </xsl:if>
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
                   
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -50,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -159,7 +158,7 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -1026,14 +1025,9 @@
               </xsl:if>
           ],
         </xsl:if>
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="procedureResourceSha256Id"/>
@@ -51,6 +49,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -149,7 +148,7 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -851,14 +850,8 @@
           ],
         </xsl:if>
 
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
@@ -1024,7 +1017,7 @@
   </xsl:template>
 
   <!-- Observation Template -->
-  <xsl:template name="Observation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship">
+  <xsl:template name="Observation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry[1]/ccda:observation/ccda:entryRelationship">
     <!--The observation resource will be generated only for the question codes present in the list specified in 'mapObservationCategoryCodes'-->
     <xsl:variable name="allowedCodes" select="' 71802-3 96778-6 96779-4 88122-7 88123-5 93030-5 96780-2 96782-8 95618-5 95617-7 95616-9 95615-1 95614-4 '" />
     <!-- Set questionCode -->
@@ -1062,23 +1055,31 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
-            <xsl:variable name="encounterEffectiveTime">
-                  <xsl:choose>
-                      <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
-                          <xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
-                          </xsl:call-template>
-                      </xsl:when>
-                      <xsl:when test="$encounterEffectiveTimeValue">
-                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
-                      </xsl:when>
-                      <xsl:otherwise>
-                          <xsl:value-of select="$currentTimestamp"/>
-                      </xsl:otherwise>
-                  </xsl:choose>
-              </xsl:variable>
+                <xsl:variable name="observationEffectiveTimeBase">
+                    <xsl:choose>
+                        <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                    </xsl:choose>
+                </xsl:variable>
 
-              <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                <xsl:variable name="observationEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="string-length(normalize-space($observationEffectiveTimeBase)) > 0">
+                            <xsl:value-of select="$observationEffectiveTimeBase"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+
+              <xsl:variable name="observationEffectiveTimeDigits" select="translate($observationEffectiveTimeBase, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
 
               <xsl:variable name="observationIdSource">
                 <xsl:choose>
@@ -1087,10 +1088,10 @@
                     <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
                   </xsl:when>
 
-                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                  <!-- Fallback: questionCode + observation EffectiveTime -->
                   <xsl:otherwise>
                     <xsl:value-of
-                      select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                      select="concat($questionCode, '-', $observationEffectiveTimeDigits)"/>
                   </xsl:otherwise>
                 </xsl:choose>
               </xsl:variable>
@@ -1250,7 +1251,7 @@
                           <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                             "derivedFrom": [
                               <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                                <xsl:variable name="encounterEffectiveTimeDF">
+                                <xsl:variable name="observationEffectiveTimeDF">
                                     <xsl:choose>
                                         <xsl:when test="ccda:effectiveTime/@value">
                                             <xsl:call-template name="formatDateTime">
@@ -1260,13 +1261,10 @@
                                         <xsl:when test="$encounterEffectiveTimeValue">
                                             <xsl:value-of select="$encounterEffectiveTimeValue"/>
                                         </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:value-of select="$currentTimestamp"/>
-                                        </xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:variable>
 
-                                <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                                <xsl:variable name="observationEffectiveTimeDigitsDF" select="translate($observationEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
                                 <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
 
                                 <xsl:variable name="observationIdSourceDF">
@@ -1276,10 +1274,10 @@
                                       <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
                                     </xsl:when>
 
-                                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                                    <!-- Fallback: questionCode + observation EffectiveTime -->
                                     <xsl:otherwise>
                                       <xsl:value-of
-                                        select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                                        select="concat($questionCodeDF, '-', $observationEffectiveTimeDigitsDF)"/>
                                     </xsl:otherwise>
                                   </xsl:choose>
                                 </xsl:variable>
@@ -1322,7 +1320,7 @@
                     "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                   }
                 </xsl:if>
-                , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
+                , "effectiveDateTime": "<xsl:value-of select='$observationEffectiveTime'/>"
                 <xsl:if test="string($organizationResourceId)">
                 , "performer": [{
                               "reference": "Organization/<xsl:value-of select='$organizationResourceId'/>"
@@ -1387,7 +1385,6 @@
     </xsl:variable>
 
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
-      <xsl:for-each select="$grouperObs[ccda:code/@code = $screeningCode]"> <!--'96777-8'-->       
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
             <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
@@ -1405,7 +1402,7 @@
             },
             "language": "en",
             "status": "<xsl:call-template name='mapObservationStatus'>
-                          <xsl:with-param name='statusCode' select='ccda:statusCode/@code'/>
+                          <xsl:with-param name='statusCode' select='$grouperObs/ccda:statusCode/@code'/>
                         </xsl:call-template>",
             "code": {
               "coding": [
@@ -1437,9 +1434,9 @@
               },
             </xsl:if>
             "effectiveDateTime": "<xsl:choose>
-                                      <xsl:when test='ccda:effectiveTime/@value'>
+                                      <xsl:when test='$grouperObs/ccda:effectiveTime/@value'>
                                         <xsl:call-template name='formatDateTime'>
-                                          <xsl:with-param name='dateTime' select='ccda:effectiveTime/@value'/>
+                                          <xsl:with-param name='dateTime' select='$grouperObs/ccda:effectiveTime/@value'/>
                                         </xsl:call-template>
                                       </xsl:when>
                                       <xsl:when test='$encounterEffectiveTimeValue'>
@@ -1477,7 +1474,7 @@
 
               <!-- Gather filtered observations first -->
               <xsl:variable name="filteredObservations">
-                <xsl:for-each select="ccda:entryRelationship/ccda:observation">
+                <xsl:for-each select="$grouperObs/ccda:entryRelationship/ccda:observation">
                   <xsl:variable name="questionCode" select="ccda:code/@code"/>
                   <xsl:if test="string($questionCode) 
                                 and contains($allowedCodes, concat('|', $questionCode, '|'))
@@ -1507,7 +1504,7 @@
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
                 <xsl:variable name="questionCode" select="ccda:code/@code"/>
-                <xsl:variable name="encounterEffectiveTime">
+                <xsl:variable name="observationEffectiveTimeGprouper">
                     <xsl:choose>
                         <xsl:when test="ccda:effectiveTime/@value">
                             <xsl:call-template name="formatDateTime">
@@ -1517,25 +1514,22 @@
                         <xsl:when test="$encounterEffectiveTimeValue">
                             <xsl:value-of select="$encounterEffectiveTimeValue"/>
                         </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="$currentTimestamp"/>
-                        </xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
 
-                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                <xsl:variable name="observationEffectiveTimeGrouperDigits" select="translate($observationEffectiveTimeGprouper, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
 
-                <xsl:variable name="observationIdSource">
+                <xsl:variable name="HMobservationIdSource">
                   <xsl:choose>
                     <!-- Use extension if present and not empty -->
                     <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
                       <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
                     </xsl:when>
 
-                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <!-- Fallback: questionCode + observation EffectiveTime -->
                     <xsl:otherwise>
                       <xsl:value-of
-                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                        select="concat($questionCode, '-', $observationEffectiveTimeGrouperDigits)"/>
                     </xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -1543,7 +1537,7 @@
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
+                    <xsl:with-param name="sha256ResourceId" select="$HMobservationIdSource"/>
                   </xsl:call-template>
                 </xsl:variable>
 
@@ -1556,8 +1550,6 @@
             "url": "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$grouperObservationResourceId'/>"
           }
         }
-      </xsl:for-each>
     </xsl:if>
   </xsl:template>
-
 </xsl:stylesheet>

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-fhir-bundle.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,7 +38,6 @@
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
   <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -49,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -111,6 +111,8 @@
   </xsl:variable>
   <!-- Remove unwanted space,if any -->
   <xsl:variable name="encounterEffectiveTimeValue" select="normalize-space($encounterEffTimeValue)"/>
+
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -1005,7 +1007,7 @@
           ],
         </xsl:if>
         "name" : "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter-athenahealth.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.2 -->
+<!-- Version : 0.1.3 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -47,39 +47,92 @@
             <xsl:copy-of select="hl7:legalAuthenticator"/>
             <xsl:copy-of select="hl7:documentationOf"/>
 
-            <!-- Consent details are in Social History section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value (Yes/No)  -->
-            <xsl:variable name="consent" select="
-                hl7:component/hl7:structuredBody/hl7:component
-                /hl7:section[hl7:code[@code='29762-2']]
-                /hl7:entry/hl7:observation/hl7:entryRelationship
-                /hl7:observation[hl7:code/@code = '105511-0']
-            "/>   
+            <!-- Consent details are in Social History section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value (Yes/No)  -->            
+            <xsl:variable name="observationConsent" select="
+                                    hl7:component/hl7:structuredBody/hl7:component
+                                    /hl7:section[hl7:code[@code='29762-2']]
+                                    /hl7:entry/hl7:observation/hl7:entryRelationship
+                                    /hl7:observation[
+                                        hl7:code/@code = '105511-0'
+                                        and
+                                        hl7:value[
+                                            translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT'
+                                            or
+                                            @code='LA33-6'
+                                        ]
+                                    ]
+                                "/>
+
+            <xsl:variable name="consentPermitObservation" select="
+                                    hl7:component/hl7:structuredBody/hl7:component
+                                    /hl7:section[hl7:code[@code='29762-2']]
+                                    /hl7:entry/hl7:observation/hl7:entryRelationship
+                                    /hl7:observation[
+                                        hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.86']
+                                        and
+                                        hl7:value[
+                                            ( translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT' )
+                                            and
+                                            @xsi:type='CD'
+                                        ]
+                                    ]
+                                "/>
+
+            <xsl:variable name="authorizationConsent" select="
+                                    hl7:authorization/hl7:consent[
+                                        hl7:code[
+                                            @code='59284-0'
+                                            and
+                                            (translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'YES' 
+                                            or 
+                                            translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT')
+                                        ]
+                                    ]
+                                "/>
+
             <xsl:choose>
-                <xsl:when test="$consent">
-                    <xsl:variable name="consentDisplay">
-                        <xsl:choose>
-                            <xsl:when test="$consent/hl7:value/@code = 'LA33-6'">permit</xsl:when>
-                            <xsl:otherwise>deny</xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:variable>
+                <!-- Case 1 or Case 2 : Consent is in Social History section -->
+                <xsl:when test="$observationConsent or $consentPermitObservation">
                     <authorization>
                         <consent>
                             <id root="2.16.840.1.113883.3.227.2845.10.41.1.1"/>
-                            <code code="105511-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
-                                <xsl:attribute name="displayName"><xsl:value-of select="$consentDisplay"/></xsl:attribute>
-                            </code>
-                            <xsl:copy-of select="$consent/hl7:statusCode"/>
+                            <code
+                                code="105511-0"
+                                codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC"
+                                displayName="permit"/>
+
+                            <xsl:choose>
+                                <xsl:when test="$observationConsent">
+                                    <xsl:copy-of select="$observationConsent/hl7:statusCode"/>
+                                </xsl:when>
+
+                                <xsl:when test="$consentPermitObservation">
+                                    <xsl:copy-of select="$consentPermitObservation/hl7:statusCode"/>
+                                </xsl:when>
+
+                                <xsl:otherwise>
+                                    <statusCode code="completed"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
                         </consent>
-                    </authorization>
+                    </authorization>                    
                 </xsl:when>
-                <xsl:when test="hl7:authorization/hl7:consent[hl7:code[@code='59284-0']]">
+
+                <!-- Case 3 : Consent is in authorization section -->
+                <xsl:when test="$authorizationConsent">
                     <xsl:copy-of select="hl7:authorization"/>
                 </xsl:when>
+
+                <!-- Default -->
                 <xsl:otherwise>
                     <authorization>
                         <consent>
                             <id root="2.16.840.1.113883.3.933"/>
-                            <code code="59284-0" codeSystem="2.16.840.1.113883.6.1" displayName="deny"/>
+                            <code
+                                code="59284-0"
+                                codeSystem="2.16.840.1.113883.6.1"
+                                displayName="deny"/>
                             <statusCode code="completed"/>
                         </consent>
                     </authorization>

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter-medent.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.2 -->
+<!-- Version : 0.1.3 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -141,20 +141,67 @@
                     <xsl:if test="$observations">
                         <component>
                             <section ID="observations">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:templateId"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:code"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:title"/>
-                                <entry>
-                                    <observation classCode="OBS" moodCode="EVN">
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:templateId"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:id"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:code"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:statusCode"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:effectiveTime"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:value"/>
-                                        <xsl:copy-of select="$observations" />
-                                    </observation>
-                                </entry>
+
+                                <!-- Copy section-level metadata only once -->
+                                <xsl:copy-of select="
+                                    hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:templateId
+                                    | hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:code
+                                    | hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:title
+                                "/>
+
+                                <!-- Loop through each parent observation -->
+                                <xsl:for-each select="
+                                    hl7:component
+                                    /hl7:structuredBody
+                                    /hl7:component
+                                    /hl7:section[hl7:code[@code='47519-4']]
+                                    /hl7:entry
+                                    /hl7:observation[hl7:code[not(@code='76690-7')]]
+                                ">
+                                    <entry>
+                                        <observation classCode="OBS" moodCode="EVN">
+
+                                            <!-- Copy only current observation data -->
+                                            <xsl:copy-of select="hl7:templateId 
+                                                                | hl7:id 
+                                                                | hl7:code 
+                                                                | hl7:statusCode 
+                                                                | hl7:effectiveTime 
+                                                                | hl7:value"/>
+
+                                            <!-- Copy only valid entryRelationships -->
+                                            <xsl:copy-of select="
+                                                hl7:entryRelationship[
+                                                    hl7:observation[
+                                                        (
+                                                            hl7:code[
+                                                                (@codeSystemName = 'LOINC' or @codeSystemName = 'SNOMED' or @codeSystemName = 'SNOMED CT')
+                                                                and not(@code='UNK') and string-length(@code) > 0
+                                                            ]
+                                                            and (
+                                                                hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer'
+                                                                or hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-declined'
+                                                                or hl7:value[
+                                                                        not(@code='UNK') 
+                                                                        and string-length(@code) > 0 
+                                                                        and string-length(@nullFlavor)=0
+                                                                    ]
+                                                            )
+                                                        )
+                                                        or
+                                                        (
+                                                            hl7:code[@code='95614-4'] 
+                                                            and string-length(hl7:value/@value) > 0
+                                                        )
+                                                    ]
+                                                ]
+                                            "/>
+
+                                        </observation>
+                                    </entry>
+
+                                </xsl:for-each>
+
                             </section>
                         </component>
                     </xsl:if>

--- a/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter.xslt
+++ b/integration-artifacts/ccda/ccda-techbd-schema-files/cda-phi-filter.xslt
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Version : 0.1.0 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -160,58 +160,58 @@
       {
         "name": "cda-fhir-bundle.xslt",
         "type": "CCDA",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "editedby": "cibijacob",
-        "date": "2026-05-27"
+        "date": "2026-06-04"
       },
       {
         "name": "cda-fhir-bundle-epic.xslt",
         "type": "CCDA",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "editedby": "cibijacob",
-        "date": "2026-05-27"
+        "date": "2026-06-04"
       },
       {
         "name": "cda-fhir-bundle-medent.xslt",
         "type": "CCDA",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "editedby": "cibijacob",
-        "date": "2026-05-27"
+        "date": "2026-06-04"
       },
       {
         "name": "cda-fhir-bundle-athenahealth.xslt",
         "type": "CCDA",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "editedby": "cibijacob",
-        "date": "2026-05-27"
+        "date": "2026-06-04"
       },      
       {
         "name": "cda-phi-filter-athenahealth.xslt",
         "type": "CCDA",
-        "version": "0.1.1",
-        "editedby": "vinodaravind01",
-        "date": "2025-10-10"
+        "version": "0.1.3",
+        "editedby": "cibijacob",
+        "date": "2026-06-04"
       },    
       {
         "name": "cda-phi-filter.xslt",
         "type": "CCDA",
         "version": "0.1.0",
-        "editedby": "",
+        "editedby": "cibijacob",
         "date": "2025-08-01"
       },
       {
         "name": "cda-phi-filter-epic.xslt",
         "type": "CCDA",
-        "version": "0.1.0",
-        "editedby": "",
+        "version": "0.1.1",
+        "editedby": "cibijacob",
         "date": "2025-08-01"
       },
       {
         "name": "cda-phi-filter-medent.xslt",
         "type": "CCDA",
-        "version": "0.1.1",
-        "editedby": "",
-        "date": "2025-08-01"
+        "version": "0.1.3",
+        "editedby": "cibijacob",
+        "date": "2026-06-04"
       },
       {
         "name": "datatypes.xsd",
@@ -258,9 +258,9 @@
       {
       "type": "CCDA-MirthConnect",
       "channel": "TechBD CCD Workflow.xml",
-      "version": "0.4.48",
+      "version": "0.4.49",
       "editedby": "cibijacob",
-      "date": "2026-05-27"
+      "date": "2026-06-04"
     }
     ],
     "HL7v2": [

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -50,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -182,8 +181,8 @@
   </xsl:variable>
   <!-- End of Guthrie logic -->
 
-  <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
+  <!-- Get Organization name Author -->
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/> -->
 
 
   <xsl:template match="/">
@@ -914,14 +913,9 @@
               </xsl:if>
           ],
         </xsl:if>
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
                   
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -50,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -159,7 +158,7 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -1026,14 +1025,9 @@
               </xsl:if>
           ],
         </xsl:if>
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,8 +38,6 @@
   <xsl:param name="encounterResourceId"/>
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
-  <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="procedureResourceSha256Id"/>
@@ -51,6 +49,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -149,7 +148,7 @@
   <!-- End of Guthrie logic -->
 
   <!-- Get Organization name from the first encounter entry -->
-  <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/>
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='encounters']/ccda:entry[1]/ccda:encounter/ccda:participant[@typeCode='LOC' and position()=1]/ccda:participantRole[@classCode='SDLOC']/ccda:playingEntity/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -851,14 +850,8 @@
           ],
         </xsl:if>
 
-        <xsl:variable name="orgNameRaw">
-          <xsl:choose>
-            <xsl:when test="$organizationName"><xsl:value-of select="$organizationName"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/></xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
         "name": "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="$orgNameRaw"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">
@@ -1024,7 +1017,7 @@
   </xsl:template>
 
   <!-- Observation Template -->
-  <xsl:template name="Observation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship">
+  <xsl:template name="Observation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry[1]/ccda:observation/ccda:entryRelationship">
     <!--The observation resource will be generated only for the question codes present in the list specified in 'mapObservationCategoryCodes'-->
     <xsl:variable name="allowedCodes" select="' 71802-3 96778-6 96779-4 88122-7 88123-5 93030-5 96780-2 96782-8 95618-5 95617-7 95616-9 95615-1 95614-4 '" />
     <!-- Set questionCode -->
@@ -1062,23 +1055,31 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
-            <xsl:variable name="encounterEffectiveTime">
-                  <xsl:choose>
-                      <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
-                          <xsl:call-template name="formatDateTime">
-                              <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
-                          </xsl:call-template>
-                      </xsl:when>
-                      <xsl:when test="$encounterEffectiveTimeValue">
-                          <xsl:value-of select="$encounterEffectiveTimeValue"/>
-                      </xsl:when>
-                      <xsl:otherwise>
-                          <xsl:value-of select="$currentTimestamp"/>
-                      </xsl:otherwise>
-                  </xsl:choose>
-              </xsl:variable>
+                <xsl:variable name="observationEffectiveTimeBase">
+                    <xsl:choose>
+                        <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
+                            <xsl:call-template name="formatDateTime">
+                                <xsl:with-param name="dateTime" select="ccda:observation/ccda:effectiveTime/@value"/>
+                            </xsl:call-template>
+                        </xsl:when>
+                        <xsl:when test="$encounterEffectiveTimeValue">
+                            <xsl:value-of select="$encounterEffectiveTimeValue"/>
+                        </xsl:when>
+                    </xsl:choose>
+                </xsl:variable>
 
-              <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                <xsl:variable name="observationEffectiveTime">
+                    <xsl:choose>
+                        <xsl:when test="string-length(normalize-space($observationEffectiveTimeBase)) > 0">
+                            <xsl:value-of select="$observationEffectiveTimeBase"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="$currentTimestamp"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+
+              <xsl:variable name="observationEffectiveTimeDigits" select="translate($observationEffectiveTimeBase, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
 
               <xsl:variable name="observationIdSource">
                 <xsl:choose>
@@ -1087,10 +1088,10 @@
                     <xsl:value-of select="concat($questionCode, '-', ccda:observation/ccda:id/@extension)"/>
                   </xsl:when>
 
-                  <!-- Fallback: questionCode + encounterEffectiveTime -->
+                  <!-- Fallback: questionCode + observation EffectiveTime -->
                   <xsl:otherwise>
                     <xsl:value-of
-                      select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                      select="concat($questionCode, '-', $observationEffectiveTimeDigits)"/>
                   </xsl:otherwise>
                 </xsl:choose>
               </xsl:variable>
@@ -1250,7 +1251,7 @@
                           <xsl:if test="exsl:node-set($derivedObservations)/ccda:observation">
                             "derivedFrom": [
                               <xsl:for-each select="exsl:node-set($derivedObservations)/ccda:observation">
-                                <xsl:variable name="encounterEffectiveTimeDF">
+                                <xsl:variable name="observationEffectiveTimeDF">
                                     <xsl:choose>
                                         <xsl:when test="ccda:effectiveTime/@value">
                                             <xsl:call-template name="formatDateTime">
@@ -1260,13 +1261,10 @@
                                         <xsl:when test="$encounterEffectiveTimeValue">
                                             <xsl:value-of select="$encounterEffectiveTimeValue"/>
                                         </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:value-of select="$currentTimestamp"/>
-                                        </xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:variable>
 
-                                <xsl:variable name="encounterEffectiveTimeDigitsDF" select="translate($encounterEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                                <xsl:variable name="observationEffectiveTimeDigitsDF" select="translate($observationEffectiveTimeDF, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
                                 <xsl:variable name="questionCodeDF" select="ccda:code/@code"/>
 
                                 <xsl:variable name="observationIdSourceDF">
@@ -1276,10 +1274,10 @@
                                       <xsl:value-of select="concat($questionCodeDF, '-', ccda:id/@extension)"/>
                                     </xsl:when>
 
-                                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                                    <!-- Fallback: questionCode + observation EffectiveTime -->
                                     <xsl:otherwise>
                                       <xsl:value-of
-                                        select="concat($questionCodeDF, '-', $encounterEffectiveTimeDigitsDF)"/>
+                                        select="concat($questionCodeDF, '-', $observationEffectiveTimeDigitsDF)"/>
                                     </xsl:otherwise>
                                   </xsl:choose>
                                 </xsl:variable>
@@ -1322,7 +1320,7 @@
                     "reference": "Encounter/<xsl:value-of select='$encounterResourceId'/>"
                   }
                 </xsl:if>
-                , "effectiveDateTime": "<xsl:value-of select='$encounterEffectiveTime'/>"
+                , "effectiveDateTime": "<xsl:value-of select='$observationEffectiveTime'/>"
                 <xsl:if test="string($organizationResourceId)">
                 , "performer": [{
                               "reference": "Organization/<xsl:value-of select='$organizationResourceId'/>"
@@ -1387,7 +1385,6 @@
     </xsl:variable>
 
     <xsl:if test="($grouperObs != '') and (normalize-space($categoryXml) != '[]')">
-      <xsl:for-each select="$grouperObs[ccda:code/@code = $screeningCode]"> <!--'96777-8'-->       
         <xsl:variable name="grouperObservationResourceId">
           <xsl:call-template name="generateFixedLengthResourceId">
             <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
@@ -1405,7 +1402,7 @@
             },
             "language": "en",
             "status": "<xsl:call-template name='mapObservationStatus'>
-                          <xsl:with-param name='statusCode' select='ccda:statusCode/@code'/>
+                          <xsl:with-param name='statusCode' select='$grouperObs/ccda:statusCode/@code'/>
                         </xsl:call-template>",
             "code": {
               "coding": [
@@ -1437,9 +1434,9 @@
               },
             </xsl:if>
             "effectiveDateTime": "<xsl:choose>
-                                      <xsl:when test='ccda:effectiveTime/@value'>
+                                      <xsl:when test='$grouperObs/ccda:effectiveTime/@value'>
                                         <xsl:call-template name='formatDateTime'>
-                                          <xsl:with-param name='dateTime' select='ccda:effectiveTime/@value'/>
+                                          <xsl:with-param name='dateTime' select='$grouperObs/ccda:effectiveTime/@value'/>
                                         </xsl:call-template>
                                       </xsl:when>
                                       <xsl:when test='$encounterEffectiveTimeValue'>
@@ -1477,7 +1474,7 @@
 
               <!-- Gather filtered observations first -->
               <xsl:variable name="filteredObservations">
-                <xsl:for-each select="ccda:entryRelationship/ccda:observation">
+                <xsl:for-each select="$grouperObs/ccda:entryRelationship/ccda:observation">
                   <xsl:variable name="questionCode" select="ccda:code/@code"/>
                   <xsl:if test="string($questionCode) 
                                 and contains($allowedCodes, concat('|', $questionCode, '|'))
@@ -1507,7 +1504,7 @@
               <!-- Output JSON from filtered set -->
               <xsl:for-each select="exsl:node-set($filteredObservations)/ccda:observation">
                 <xsl:variable name="questionCode" select="ccda:code/@code"/>
-                <xsl:variable name="encounterEffectiveTime">
+                <xsl:variable name="observationEffectiveTimeGprouper">
                     <xsl:choose>
                         <xsl:when test="ccda:effectiveTime/@value">
                             <xsl:call-template name="formatDateTime">
@@ -1517,25 +1514,22 @@
                         <xsl:when test="$encounterEffectiveTimeValue">
                             <xsl:value-of select="$encounterEffectiveTimeValue"/>
                         </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="$currentTimestamp"/>
-                        </xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
 
-                <xsl:variable name="encounterEffectiveTimeDigits" select="translate($encounterEffectiveTime, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
+                <xsl:variable name="observationEffectiveTimeGrouperDigits" select="translate($observationEffectiveTimeGprouper, '-:TZ', '')"/> <!-- Remove non-digit characters for ID generation -->
 
-                <xsl:variable name="observationIdSource">
+                <xsl:variable name="HMobservationIdSource">
                   <xsl:choose>
                     <!-- Use extension if present and not empty -->
                     <xsl:when test="ccda:id/@extension and normalize-space(ccda:id/@extension) != ''">
                       <xsl:value-of select="concat($questionCode, '-', ccda:id/@extension)"/>
                     </xsl:when>
 
-                    <!-- Fallback: questionCode + encounterEffectiveTime -->
+                    <!-- Fallback: questionCode + observation EffectiveTime -->
                     <xsl:otherwise>
                       <xsl:value-of
-                        select="concat($questionCode, '-', $encounterEffectiveTimeDigits)"/>
+                        select="concat($questionCode, '-', $observationEffectiveTimeGrouperDigits)"/>
                     </xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>
@@ -1543,7 +1537,7 @@
                 <xsl:variable name="observationResourceId">
                   <xsl:call-template name="generateFixedLengthResourceId">
                     <xsl:with-param name="prefixString" select="concat($facilityID, '-')"/>
-                    <xsl:with-param name="sha256ResourceId" select="$observationIdSource"/>
+                    <xsl:with-param name="sha256ResourceId" select="$HMobservationIdSource"/>
                   </xsl:call-template>
                 </xsl:variable>
 
@@ -1556,47 +1550,6 @@
             "url": "<xsl:value-of select='$baseFhirUrl'/>/Observation/<xsl:value-of select='$grouperObservationResourceId'/>"
           }
         }
-      </xsl:for-each>
     </xsl:if>
   </xsl:template>
-
-  <!-- Template to format an address -->
-  <!-- <xsl:template name="format-address">
-      <xsl:param name="addr"/>
-
-      <xsl:variable name="street">
-          <xsl:for-each select="$addr/ccda:streetAddressLine[not(@nullFlavor) and normalize-space(.) != '']">
-              <xsl:value-of select="normalize-space(.)"/>
-              <xsl:if test="position() != last()">, </xsl:if>
-          </xsl:for-each>
-      </xsl:variable>
-
-      <xsl:variable name="city"  select="normalize-space($addr/ccda:city[not(@nullFlavor) and normalize-space(.) != ''])"/>
-      <xsl:variable name="state" select="normalize-space($addr/ccda:state[not(@nullFlavor) and normalize-space(.) != ''])"/>
-      <xsl:variable name="zip"   select="normalize-space($addr/ccda:postalCode[not(@nullFlavor) and normalize-space(.) != ''])"/>
-
-      <xsl:variable name="fullAddress">
-          <xsl:if test="string-length(normalize-space($street)) &gt; 0">
-              <xsl:value-of select="$street"/>
-          </xsl:if>
-
-          <xsl:if test="$city != ''">
-              <xsl:if test="normalize-space($street) != ''">, </xsl:if>
-              <xsl:value-of select="$city"/>
-          </xsl:if>
-
-          <xsl:if test="$state != ''">
-              <xsl:if test="$city != '' or normalize-space($street) != ''">, </xsl:if>
-              <xsl:value-of select="$state"/>
-          </xsl:if>
-
-          <xsl:if test="$zip != ''">
-              <xsl:text> </xsl:text>
-              <xsl:value-of select="$zip"/>
-          </xsl:if>
-      </xsl:variable>
-
-      <xsl:value-of select="normalize-space($fullAddress)"/>
-  </xsl:template> -->
-
 </xsl:stylesheet>

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-fhir-bundle.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.14 -->
+<!-- Version : 0.1.15 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
                 xmlns:ccda="urn:hl7-org:v3"
                 xmlns:fhir="http://hl7.org/fhir"
@@ -38,7 +38,6 @@
   <xsl:param name="consentResourceId"/>
   <xsl:param name="organizationResourceId"/>
   <xsl:param name="questionnaireResourceId"/>
-  <xsl:param name="observationResourceSha256Id"/>
   <xsl:param name="sexualOrientationResourceId"/>
   <xsl:param name="questionnaireResponseResourceSha256Id"/>
   <xsl:param name="grouperObservationResourceSha256Id"/> 
@@ -49,6 +48,7 @@
   <xsl:param name="X-TechBD-Part2"/>
   <xsl:param name="X-TechBD-OMH"/>
   <xsl:param name="X-TechBD-OPWDD"/>
+  <xsl:param name="organizationName"/>
 
   <!-- Parameters to get FHIR resource profile URLs -->
   <xsl:param name="baseFhirUrl"/>
@@ -111,6 +111,8 @@
   </xsl:variable>
   <!-- Remove unwanted space,if any -->
   <xsl:variable name="encounterEffectiveTimeValue" select="normalize-space($encounterEffTimeValue)"/>
+
+  <!-- <xsl:variable name="organizationName" select="/ccda:ClinicalDocument/ccda:author/ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/> -->
 
   <xsl:template match="/">
   {
@@ -1005,7 +1007,7 @@
           ],
         </xsl:if>
         "name" : "<xsl:call-template name="string-trim">
-                    <xsl:with-param name="text" select="ccda:assignedAuthor/ccda:representedOrganization/ccda:name"/>
+                    <xsl:with-param name="text" select="$organizationName"/>
                   </xsl:call-template>"
 
         <xsl:if test="ccda:assignedAuthor/ccda:representedOrganization/ccda:telecom[not(@nullFlavor)]">

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-athenahealth.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-athenahealth.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.1 -->
+<!-- Version : 0.1.3 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -47,17 +47,92 @@
             <xsl:copy-of select="hl7:legalAuthenticator"/>
             <xsl:copy-of select="hl7:documentationOf"/>
 
-            <!-- Consent (same style as Epic for easy diff) -->
+            <!-- Consent details are in Social History section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value (Yes/No)  -->            
+            <xsl:variable name="observationConsent" select="
+                                    hl7:component/hl7:structuredBody/hl7:component
+                                    /hl7:section[hl7:code[@code='29762-2']]
+                                    /hl7:entry/hl7:observation/hl7:entryRelationship
+                                    /hl7:observation[
+                                        hl7:code/@code = '105511-0'
+                                        and
+                                        hl7:value[
+                                            translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT'
+                                            or
+                                            @code='LA33-6'
+                                        ]
+                                    ]
+                                "/>
+
+            <xsl:variable name="consentPermitObservation" select="
+                                    hl7:component/hl7:structuredBody/hl7:component
+                                    /hl7:section[hl7:code[@code='29762-2']]
+                                    /hl7:entry/hl7:observation/hl7:entryRelationship
+                                    /hl7:observation[
+                                        hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.86']
+                                        and
+                                        hl7:value[
+                                            ( translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT' )
+                                            and
+                                            @xsi:type='CD'
+                                        ]
+                                    ]
+                                "/>
+
+            <xsl:variable name="authorizationConsent" select="
+                                    hl7:authorization/hl7:consent[
+                                        hl7:code[
+                                            @code='59284-0'
+                                            and
+                                            (translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'YES' 
+                                            or 
+                                            translate(normalize-space(@displayName), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 'PERMIT')
+                                        ]
+                                    ]
+                                "/>
+
             <xsl:choose>
-                <xsl:when test="hl7:authorization/hl7:consent[hl7:code[@code='59284-0']]">
+                <!-- Case 1 or Case 2 : Consent is in Social History section -->
+                <xsl:when test="$observationConsent or $consentPermitObservation">
+                    <authorization>
+                        <consent>
+                            <id root="2.16.840.1.113883.3.227.2845.10.41.1.1"/>
+                            <code
+                                code="105511-0"
+                                codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC"
+                                displayName="permit"/>
+
+                            <xsl:choose>
+                                <xsl:when test="$observationConsent">
+                                    <xsl:copy-of select="$observationConsent/hl7:statusCode"/>
+                                </xsl:when>
+
+                                <xsl:when test="$consentPermitObservation">
+                                    <xsl:copy-of select="$consentPermitObservation/hl7:statusCode"/>
+                                </xsl:when>
+
+                                <xsl:otherwise>
+                                    <statusCode code="completed"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </consent>
+                    </authorization>                    
+                </xsl:when>
+
+                <!-- Case 3 : Consent is in authorization section -->
+                <xsl:when test="$authorizationConsent">
                     <xsl:copy-of select="hl7:authorization"/>
                 </xsl:when>
+
+                <!-- Default -->
                 <xsl:otherwise>
-                    <!-- keep Epic-style explicit deny node so diffs clearly show consent differences -->
                     <authorization>
                         <consent>
                             <id root="2.16.840.1.113883.3.933"/>
-                            <code code="59284-0" codeSystem="2.16.840.1.113883.6.1" displayName="deny"/>
+                            <code
+                                code="59284-0"
+                                codeSystem="2.16.840.1.113883.6.1"
+                                displayName="deny"/>
                             <statusCode code="completed"/>
                         </consent>
                     </authorization>

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-epic.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-epic.xslt
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Version : 0.1.1 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-medent.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter-medent.xslt
@@ -44,7 +44,7 @@
             <xsl:copy-of select="hl7:legalAuthenticator"/>
             <xsl:copy-of select="hl7:documentationOf"/>
 
-            <!-- Medent - always have consent details in Procedures section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value (Yes/No)  -->
+            <!-- Medent - always have consent details in Procedures section with  Entry.observation.entryRelationship.observation.code = "105511-0" and answer in Entry.observation.entryRelationship.observation.value.code (LA33-6 = Yes/ LA33-8 = No)   -->
             <xsl:variable name="consent" select="
                 hl7:component/hl7:structuredBody/hl7:component
                 /hl7:section[hl7:code[@code='47519-4']]
@@ -54,7 +54,18 @@
             <xsl:if test="$consent">
                 <xsl:variable name="consentDisplay">
                     <xsl:choose>
-                        <xsl:when test="$consent/hl7:value/@displayName = 'Yes'">permit</xsl:when>
+                        <!-- <xsl:when test="$consent/hl7:value/@displayName = 'Yes'">permit</xsl:when> -->
+                        <xsl:when test="
+                            normalize-space($consent/hl7:value/@code) = 'LA33-6'
+                            or
+                            translate(
+                                normalize-space($consent/hl7:value/@displayName),
+                                'abcdefghijklmnopqrstuvwxyz',
+                                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                            ) = 'YES'
+                            ">
+                            permit
+                        </xsl:when>
                         <xsl:otherwise>deny</xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
@@ -131,20 +142,67 @@
                     <xsl:if test="$observations">
                         <component>
                             <section ID="observations">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:templateId"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:code"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:title"/>
-                                <entry>
-                                    <observation classCode="OBS" moodCode="EVN">
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:templateId"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:id"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:code"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:statusCode"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:effectiveTime"/>
-                                        <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:entry/hl7:observation/hl7:value"/>
-                                        <xsl:copy-of select="$observations" />
-                                    </observation>
-                                </entry>
+
+                                <!-- Copy section-level metadata only once -->
+                                <xsl:copy-of select="
+                                    hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:templateId
+                                    | hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:code
+                                    | hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='47519-4']]/hl7:title
+                                "/>
+
+                                <!-- Loop through each parent observation -->
+                                <xsl:for-each select="
+                                    hl7:component
+                                    /hl7:structuredBody
+                                    /hl7:component
+                                    /hl7:section[hl7:code[@code='47519-4']]
+                                    /hl7:entry
+                                    /hl7:observation[hl7:code[not(@code='76690-7')]]
+                                ">
+                                    <entry>
+                                        <observation classCode="OBS" moodCode="EVN">
+
+                                            <!-- Copy only current observation data -->
+                                            <xsl:copy-of select="hl7:templateId 
+                                                                | hl7:id 
+                                                                | hl7:code 
+                                                                | hl7:statusCode 
+                                                                | hl7:effectiveTime 
+                                                                | hl7:value"/>
+
+                                            <!-- Copy only valid entryRelationships -->
+                                            <xsl:copy-of select="
+                                                hl7:entryRelationship[
+                                                    hl7:observation[
+                                                        (
+                                                            hl7:code[
+                                                                (@codeSystemName = 'LOINC' or @codeSystemName = 'SNOMED' or @codeSystemName = 'SNOMED CT')
+                                                                and not(@code='UNK') and string-length(@code) > 0
+                                                            ]
+                                                            and (
+                                                                hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer'
+                                                                or hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-declined'
+                                                                or hl7:value[
+                                                                        not(@code='UNK') 
+                                                                        and string-length(@code) > 0 
+                                                                        and string-length(@nullFlavor)=0
+                                                                    ]
+                                                            )
+                                                        )
+                                                        or
+                                                        (
+                                                            hl7:code[@code='95614-4'] 
+                                                            and string-length(hl7:value/@value) > 0
+                                                        )
+                                                    ]
+                                                ]
+                                            "/>
+
+                                        </observation>
+                                    </entry>
+
+                                </xsl:for-each>
+
                             </section>
                         </component>
                     </xsl:if>

--- a/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter.xslt
+++ b/support/specifications/ccda/ccda-techbd-schema-files/cda-phi-filter.xslt
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Version : 0.1.0 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -1055,7 +1055,7 @@
               </xsl:variable>
 
         <xsl:if test="string($categoryCode)">
-            <xsl:variable name="observationEffectiveTimeBase">
+                <xsl:variable name="observationEffectiveTimeBase">
                     <xsl:choose>
                         <xsl:when test="ccda:observation/ccda:effectiveTime/@value">
                             <xsl:call-template name="formatDateTime">

--- a/support/specifications/develop/ccda/cda-phi-filter-epic.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-epic.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.0 -->
+<!-- Version : 0.1.1 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Version : 0.1.1 -->
+<!-- Version : 0.1.3 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns:hl7="urn:hl7-org:v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
Moved updated XSLT and Channel files to integration artifacts.
- Resolved CCDA XSD validation failures by selecting only the first Grouper Observation entry when multiple Grouper and related Observation entries are present in Medent CCDA files
- Updated XSLT files to add one more consent Permit condition for AthenaHealth CCDA files
- Updated XSLT and channel files to add Organization name while generating the Organization resource ID in Epic, AthenaHealth and Medent CCDA files
- Removed the fallback to currentTimeStamp from Encounter Effective Date while generating the Observation Resource in Medent CCDA files
- Updated database functions to save start time, finish time, user agent and client ip address from payload for user hub UI interactions