### PR TITLE
feat: add Birth Sex and Gender Identity extensions to the Patient resource #3205

### DIFF
--- a/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-athenahealth.xslt
@@ -231,7 +231,7 @@
     , "entry": [
         <xsl:apply-templates select="/ccda:ClinicalDocument/ccda:recordTarget/ccda:patientRole
                                 | /ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter
-                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation
+                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']
                                 | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship/ccda:observation
                                 | /ccda:ClinicalDocument/ccda:authorization/ccda:consent
                                 | /ccda:ClinicalDocument/ccda:author
@@ -497,15 +497,71 @@
           }
         </xsl:if>
 
-        <!-- GenderCode extension -->
-        <xsl:if test="string(ccda:patient/ccda:administrativeGenderCode/@code)">
-          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
-        {
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
-            "valueCode": "<xsl:call-template name='mapAdministrativeGenderCode'>
-                              <xsl:with-param name='genderCode' select='ccda:patient/ccda:administrativeGenderCode/@code'/>
-                          </xsl:call-template>"
-        }
+        <!-- birthSex extension -->
+        <xsl:variable name="birthSexEntry"
+                              select="/ccda:ClinicalDocument
+                                    /ccda:component
+                                    /ccda:structuredBody
+                                    /ccda:component
+                                    /ccda:section[@ID='sexualOrientation']
+                                    /ccda:entry
+                                    /ccda:observation[
+                                        ccda:code/@code='76689-9'
+                                        and (
+                                            string-length(normalize-space(ccda:value/@code)) > 0
+                                            or
+                                            string-length(normalize-space(ccda:value/@displayName)) > 0
+                                        )
+                                    ]"/>
+        <xsl:if test="$birthSexEntry">
+              <xsl:variable name="birthSex">
+                  <xsl:choose>
+                      <xsl:when test="$birthSexEntry/ccda:value/@code">
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@code"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@displayName"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+							<xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
+              {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
+                  "valueCode": "<xsl:call-template name="mapAdministrativeGenderCode">
+                                    <xsl:with-param name="genderCode" select="$birthSex"/>
+                                </xsl:call-template>"
+              }
+        </xsl:if>
+
+        <!-- Gender Identity extension -->
+        <xsl:variable name="genderIdentityEntry" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76691-5']"/>
+        <xsl:if test="$genderIdentityEntry">
+          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code or string($birthSexEntry)">,</xsl:if>
+          {
+              "url" : "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/shinny-gender-identity",
+              "valueCodeableConcept" : {
+                "coding" : [ {
+                  "code" : "<xsl:choose>
+                              <xsl:when test='$genderIdentityEntry/ccda:value/@code'><xsl:value-of select='$genderIdentityEntry/ccda:value/@code'/></xsl:when>
+                              <xsl:otherwise> <xsl:value-of select='$genderIdentityEntry/ccda:value/@nullFlavor'/> </xsl:otherwise>
+                            </xsl:choose>",
+                  "system" : "<xsl:choose>
+                                  <xsl:when test="$genderIdentityEntry/ccda:value/@code and $genderIdentityEntry/ccda:value/@code != 'UNK'">http://snomed.info/sct</xsl:when>
+                                  <xsl:otherwise>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</xsl:otherwise>
+                              </xsl:choose>",
+                  "display" : "<xsl:choose>
+                                  <xsl:when test='$genderIdentityEntry/ccda:value/@displayName'><xsl:value-of select='$genderIdentityEntry/ccda:value/@displayName'/></xsl:when>
+                                  <xsl:otherwise>
+                                    <xsl:call-template name='mapGenderIdentityCodeDisplay'>
+                                      <xsl:with-param name='genderIdentityCode' select='$genderIdentityEntry/ccda:value/@code'/>
+                                      <xsl:with-param name='genderIdentityNullFlavor' select='$genderIdentityEntry/ccda:value/@nullFlavor'/>
+                                    </xsl:call-template>
+                                  </xsl:otherwise>
+                                </xsl:choose>"
+                } ]
+              }
+          }
         </xsl:if>
       ]
       </xsl:if>
@@ -969,7 +1025,7 @@
   </xsl:template>
 
   <!-- Sexual orientation Observation Template -->
-  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation">
+  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']">
     <xsl:if test="string(ccda:code/@code) = '76690-7'">
 
       <xsl:variable name="resourceUUID">
@@ -1351,7 +1407,8 @@
                 </xsl:when>    
 
                 <!-- Default valueCodeableConcept -->
-                <xsl:otherwise>
+                <!-- <xsl:otherwise> -->
+                <xsl:when test="string(ccda:value/@code) != 'UNK' and string-length(ccda:value/@code) > 0">
                     "valueCodeableConcept" : {
                       "coding": [{
                         "system": "http://loinc.org",
@@ -1367,7 +1424,8 @@
                         </xsl:when>
                       </xsl:choose>
                     },
-                </xsl:otherwise>
+                </xsl:when>
+                <!-- </xsl:otherwise> -->
               </xsl:choose>
 
               "subject": {

--- a/support/specifications/develop/ccda/cda-fhir-bundle-common-utils.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-common-utils.xslt
@@ -283,6 +283,35 @@
   </xsl:choose>
 </xsl:template>
 
+<xsl:template name="mapGenderIdentityCodeDisplay">
+  <xsl:param name="genderIdentityCode"/>
+  <xsl:param name="genderIdentityNullFlavor"/>
+
+  <xsl:choose>
+    <xsl:when test="$genderIdentityCode = '446141000124107'">Identifies as female gender</xsl:when>
+    <xsl:when test="$genderIdentityCode = '446151000124109'">Identifies as male gender</xsl:when>
+    <xsl:when test="$genderIdentityCode = '446131000124105'">Identifies as non-binary gender</xsl:when>
+    <xsl:when test="$genderIdentityCode = '407377005'">Female-to-Male (FTM) / Transgender Male / Trans Man</xsl:when>
+    <xsl:when test="$genderIdentityCode = '407376001'">Male-to-Female (MTF) / Transgender Female / Trans Woman</xsl:when>
+    <xsl:when test="$genderIdentityCode = '446131000124102'">Identifies as non-conforming gender</xsl:when>
+    <xsl:otherwise>
+      <!-- If code is not present or doesn't match known values, check nullFlavor -->
+      <xsl:variable name="cleanCode"
+        select="translate(normalize-space(string($genderIdentityNullFlavor)),
+                          'abcdefghijklmnopqrstuvwxyz',
+                          'ABCDEFGHIJKLMNOPQRSTUVWXYZ')" />
+
+      <xsl:choose>
+        <xsl:when test="$cleanCode = 'ASKU'">Asked But Unknown</xsl:when>
+        <xsl:when test="$cleanCode = 'NASK'">Not Asked</xsl:when>
+        <xsl:when test="$cleanCode = 'OTH'">Other</xsl:when>
+        <xsl:when test="$cleanCode = 'NA'">Not Applicable</xsl:when>
+        <xsl:otherwise>Unknown</xsl:otherwise>
+      </xsl:choose>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
 <xsl:template name="mapObservationCategoryCodes">
   <xsl:param name="questionCode"/>
   <xsl:choose>

--- a/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-epic.xslt
@@ -206,7 +206,7 @@
     , "entry": [
       <xsl:apply-templates select="/ccda:ClinicalDocument/ccda:recordTarget/ccda:patientRole 
                                 | /ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter 
-                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation
+                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']
                                 | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship/ccda:observation/ccda:entryRelationship
                                 | /ccda:ClinicalDocument/ccda:authorization/ccda:consent 
                                 | /ccda:ClinicalDocument/ccda:author
@@ -472,15 +472,71 @@
           }
         </xsl:if>
 
-        <!-- GenderCode extension -->
-        <xsl:if test="string(ccda:patient/ccda:administrativeGenderCode/@code)">
-          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
-        {
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
-            "valueCode": "<xsl:call-template name='mapAdministrativeGenderCode'>
-                              <xsl:with-param name='genderCode' select='ccda:patient/ccda:administrativeGenderCode/@code'/>
-                          </xsl:call-template>"
-        }
+        <!-- birthSex extension -->
+        <xsl:variable name="birthSexEntry"
+                              select="/ccda:ClinicalDocument
+                                    /ccda:component
+                                    /ccda:structuredBody
+                                    /ccda:component
+                                    /ccda:section[@ID='sexualOrientation']
+                                    /ccda:entry
+                                    /ccda:observation[
+                                        ccda:code/@code='76689-9'
+                                        and (
+                                            string-length(normalize-space(ccda:value/@code)) > 0
+                                            or
+                                            string-length(normalize-space(ccda:value/@displayName)) > 0
+                                        )
+                                    ]"/>
+        <xsl:if test="$birthSexEntry">
+              <xsl:variable name="birthSex">
+                  <xsl:choose>
+                      <xsl:when test="$birthSexEntry/ccda:value/@code">
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@code"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@displayName"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+							<xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
+              {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
+                  "valueCode": "<xsl:call-template name="mapAdministrativeGenderCode">
+                                    <xsl:with-param name="genderCode" select="$birthSex"/>
+                                </xsl:call-template>"
+              }
+        </xsl:if>
+
+        <!-- Gender Identity extension -->
+        <xsl:variable name="genderIdentityEntry" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76691-5']"/>
+        <xsl:if test="$genderIdentityEntry">
+          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code or string($birthSexEntry)">,</xsl:if>
+          {
+              "url" : "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/shinny-gender-identity",
+              "valueCodeableConcept" : {
+                "coding" : [ {
+                  "code" : "<xsl:choose>
+                              <xsl:when test='$genderIdentityEntry/ccda:value/@code'><xsl:value-of select='$genderIdentityEntry/ccda:value/@code'/></xsl:when>
+                              <xsl:otherwise> <xsl:value-of select='$genderIdentityEntry/ccda:value/@nullFlavor'/> </xsl:otherwise>
+                            </xsl:choose>",
+                  "system" : "<xsl:choose>
+                                  <xsl:when test="$genderIdentityEntry/ccda:value/@code and $genderIdentityEntry/ccda:value/@code != 'UNK'">http://snomed.info/sct</xsl:when>
+                                  <xsl:otherwise>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</xsl:otherwise>
+                              </xsl:choose>",
+                  "display" : "<xsl:choose>
+                                  <xsl:when test='$genderIdentityEntry/ccda:value/@displayName'><xsl:value-of select='$genderIdentityEntry/ccda:value/@displayName'/></xsl:when>
+                                  <xsl:otherwise>
+                                    <xsl:call-template name='mapGenderIdentityCodeDisplay'>
+                                      <xsl:with-param name='genderIdentityCode' select='$genderIdentityEntry/ccda:value/@code'/>
+                                      <xsl:with-param name='genderIdentityNullFlavor' select='$genderIdentityEntry/ccda:value/@nullFlavor'/>
+                                    </xsl:call-template>
+                                  </xsl:otherwise>
+                                </xsl:choose>"
+                } ]
+              }
+          }
         </xsl:if>
       ]
       </xsl:if>
@@ -1081,7 +1137,7 @@
   </xsl:template>
 
   <!-- Sexual orientation Observation Template -->
-  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation">
+  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']">
     <xsl:if test="string(ccda:code/@code) = '76690-7'">
 
       <xsl:variable name="resourceUUID">
@@ -1462,7 +1518,8 @@
                           ],
                         </xsl:if>
                     </xsl:when>    
-                    <xsl:otherwise>
+                    <!-- <xsl:otherwise> -->
+                    <xsl:when test="string(ccda:observation/ccda:value/@code) != 'UNK' and string-length(ccda:observation/ccda:value/@code) > 0">
                         "valueCodeableConcept" : {
                           "coding": [{
                             "system": "http://loinc.org",
@@ -1478,7 +1535,8 @@
                             </xsl:when>
                           </xsl:choose>
                         },
-                    </xsl:otherwise>
+                    </xsl:when>
+                    <!-- </xsl:otherwise> -->
                   </xsl:choose>
                   "subject": {
                     "reference": "Patient/<xsl:value-of select='$patientResourceId'/>",

--- a/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle-medent.xslt
@@ -196,7 +196,7 @@
 
     , "entry": [
       <xsl:apply-templates select="/ccda:ClinicalDocument/ccda:recordTarget/ccda:patientRole
-                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation
+                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']
                                 | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry/ccda:observation/ccda:entryRelationship
                                 | /ccda:ClinicalDocument/ccda:authorization/ccda:consent 
                                 | /ccda:ClinicalDocument/ccda:author
@@ -461,15 +461,71 @@
           }
         </xsl:if>
 
-        <!-- GenderCode extension -->
-        <xsl:if test="string(ccda:patient/ccda:administrativeGenderCode/@code)">
-          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
-        {
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
-            "valueCode": "<xsl:call-template name='mapAdministrativeGenderCode'>
-                              <xsl:with-param name='genderCode' select='ccda:patient/ccda:administrativeGenderCode/@code'/>
-                          </xsl:call-template>"
-        }
+        <!-- birthSex extension -->
+        <xsl:variable name="birthSexEntry"
+                              select="/ccda:ClinicalDocument
+                                    /ccda:component
+                                    /ccda:structuredBody
+                                    /ccda:component
+                                    /ccda:section[@ID='sexualOrientation']
+                                    /ccda:entry
+                                    /ccda:observation[
+                                        ccda:code/@code='76689-9'
+                                        and (
+                                            string-length(normalize-space(ccda:value/@code)) > 0
+                                            or
+                                            string-length(normalize-space(ccda:value/@displayName)) > 0
+                                        )
+                                    ]"/>
+        <xsl:if test="$birthSexEntry">
+              <xsl:variable name="birthSex">
+                  <xsl:choose>
+                      <xsl:when test="$birthSexEntry/ccda:value/@code">
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@code"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@displayName"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+							<xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
+              {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
+                  "valueCode": "<xsl:call-template name="mapAdministrativeGenderCode">
+                                    <xsl:with-param name="genderCode" select="$birthSex"/>
+                                </xsl:call-template>"
+              }
+        </xsl:if>
+
+        <!-- Gender Identity extension -->
+        <xsl:variable name="genderIdentityEntry" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76691-5']"/>
+        <xsl:if test="$genderIdentityEntry">
+          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code or string($birthSexEntry)">,</xsl:if>
+          {
+              "url" : "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/shinny-gender-identity",
+              "valueCodeableConcept" : {
+                "coding" : [ {
+                  "code" : "<xsl:choose>
+                              <xsl:when test='$genderIdentityEntry/ccda:value/@code'><xsl:value-of select='$genderIdentityEntry/ccda:value/@code'/></xsl:when>
+                              <xsl:otherwise> <xsl:value-of select='$genderIdentityEntry/ccda:value/@nullFlavor'/> </xsl:otherwise>
+                            </xsl:choose>",
+                  "system" : "<xsl:choose>
+                                  <xsl:when test="$genderIdentityEntry/ccda:value/@code and $genderIdentityEntry/ccda:value/@code != 'UNK'">http://snomed.info/sct</xsl:when>
+                                  <xsl:otherwise>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</xsl:otherwise>
+                              </xsl:choose>",
+                  "display" : "<xsl:choose>
+                                  <xsl:when test='$genderIdentityEntry/ccda:value/@displayName'><xsl:value-of select='$genderIdentityEntry/ccda:value/@displayName'/></xsl:when>
+                                  <xsl:otherwise>
+                                    <xsl:call-template name='mapGenderIdentityCodeDisplay'>
+                                      <xsl:with-param name='genderIdentityCode' select='$genderIdentityEntry/ccda:value/@code'/>
+                                      <xsl:with-param name='genderIdentityNullFlavor' select='$genderIdentityEntry/ccda:value/@nullFlavor'/>
+                                    </xsl:call-template>
+                                  </xsl:otherwise>
+                                </xsl:choose>"
+                } ]
+              }
+          }
         </xsl:if>
       ]
       </xsl:if>
@@ -905,7 +961,7 @@
   </xsl:template>
 
   <!-- Sexual orientation Observation Template -->
-  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation">
+  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']">
     <xsl:if test="string(ccda:code/@code) = '76690-7'">
       
       <xsl:variable name="resourceUUID">
@@ -1293,7 +1349,8 @@
                             ],
                           </xsl:if>
                       </xsl:when>    
-                      <xsl:otherwise>
+                      <!-- <xsl:otherwise> -->
+                      <xsl:when test="string(ccda:observation/ccda:value/@code) != 'UNK' and string-length(ccda:observation/ccda:value/@code) > 0">
                           "valueCodeableConcept" : {
                             "coding": [{
                               "system": "http://loinc.org",
@@ -1309,7 +1366,8 @@
                               </xsl:when>
                             </xsl:choose>
                           },
-                      </xsl:otherwise>
+                      </xsl:when>
+                      <!-- </xsl:otherwise> -->
                 </xsl:choose>
                 "subject": {
                   "reference": "Patient/<xsl:value-of select='$patientResourceId'/>",

--- a/support/specifications/develop/ccda/cda-fhir-bundle.xslt
+++ b/support/specifications/develop/ccda/cda-fhir-bundle.xslt
@@ -160,7 +160,7 @@
     , "entry": [
       <xsl:apply-templates select="/ccda:ClinicalDocument/ccda:recordTarget/ccda:patientRole 
                                 | /ccda:ClinicalDocument/ccda:componentOf/ccda:encompassingEncounter 
-                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation
+                                | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']
                                 | /ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='observations']/ccda:entry
                                 | /ccda:ClinicalDocument/ccda:authorization/ccda:consent 
                                 | /ccda:ClinicalDocument/ccda:author
@@ -426,15 +426,71 @@
           }
         </xsl:if>
 
-        <!-- GenderCode extension -->
-        <xsl:if test="string(ccda:patient/ccda:administrativeGenderCode/@code)">
-          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
-        {
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
-            "valueCode": "<xsl:call-template name='mapAdministrativeGenderCode'>
-                              <xsl:with-param name='genderCode' select='ccda:patient/ccda:administrativeGenderCode/@code'/>
-                          </xsl:call-template>"
-        }
+        <!-- birthSex extension -->
+        <xsl:variable name="birthSexEntry"
+                              select="/ccda:ClinicalDocument
+                                    /ccda:component
+                                    /ccda:structuredBody
+                                    /ccda:component
+                                    /ccda:section[@ID='sexualOrientation']
+                                    /ccda:entry
+                                    /ccda:observation[
+                                        ccda:code/@code='76689-9'
+                                        and (
+                                            string-length(normalize-space(ccda:value/@code)) > 0
+                                            or
+                                            string-length(normalize-space(ccda:value/@displayName)) > 0
+                                        )
+                                    ]"/>
+        <xsl:if test="$birthSexEntry">
+              <xsl:variable name="birthSex">
+                  <xsl:choose>
+                      <xsl:when test="$birthSexEntry/ccda:value/@code">
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@code"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                          <xsl:value-of select="$birthSexEntry/ccda:value/@displayName"/>
+                      </xsl:otherwise>
+                  </xsl:choose>
+              </xsl:variable>
+
+							<xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code">,</xsl:if>
+              {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex", 
+                  "valueCode": "<xsl:call-template name="mapAdministrativeGenderCode">
+                                    <xsl:with-param name="genderCode" select="$birthSex"/>
+                                </xsl:call-template>"
+              }
+        </xsl:if>
+
+        <!-- Gender Identity extension -->
+        <xsl:variable name="genderIdentityEntry" select="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76691-5']"/>
+        <xsl:if test="$genderIdentityEntry">
+          <xsl:if test="ccda:patient/ccda:raceCode or ccda:patient/ccda:ethnicGroupCode/@code or string($birthSexEntry)">,</xsl:if>
+          {
+              "url" : "<xsl:value-of select='$baseFhirUrl'/>/StructureDefinition/shinny-gender-identity",
+              "valueCodeableConcept" : {
+                "coding" : [ {
+                  "code" : "<xsl:choose>
+                              <xsl:when test='$genderIdentityEntry/ccda:value/@code'><xsl:value-of select='$genderIdentityEntry/ccda:value/@code'/></xsl:when>
+                              <xsl:otherwise> <xsl:value-of select='$genderIdentityEntry/ccda:value/@nullFlavor'/> </xsl:otherwise>
+                            </xsl:choose>",
+                  "system" : "<xsl:choose>
+                                  <xsl:when test="$genderIdentityEntry/ccda:value/@code and $genderIdentityEntry/ccda:value/@code != 'UNK'">http://snomed.info/sct</xsl:when>
+                                  <xsl:otherwise>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</xsl:otherwise>
+                              </xsl:choose>",
+                  "display" : "<xsl:choose>
+                                  <xsl:when test='$genderIdentityEntry/ccda:value/@displayName'><xsl:value-of select='$genderIdentityEntry/ccda:value/@displayName'/></xsl:when>
+                                  <xsl:otherwise>
+                                    <xsl:call-template name='mapGenderIdentityCodeDisplay'>
+                                      <xsl:with-param name='genderIdentityCode' select='$genderIdentityEntry/ccda:value/@code'/>
+                                      <xsl:with-param name='genderIdentityNullFlavor' select='$genderIdentityEntry/ccda:value/@nullFlavor'/>
+                                    </xsl:call-template>
+                                  </xsl:otherwise>
+                                </xsl:choose>"
+                } ]
+              }
+          }
         </xsl:if>
       ]
       </xsl:if>
@@ -1061,7 +1117,7 @@
   </xsl:template>
 
   <!-- Sexual orientation Observation Template -->
-  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation">
+  <xsl:template name="SexualOrientation" match="/ccda:ClinicalDocument/ccda:component/ccda:structuredBody/ccda:component/ccda:section[@ID='sexualOrientation']/ccda:entry/ccda:observation[ccda:code/@code='76690-7']">
     <xsl:if test="string(ccda:code/@code) = '76690-7'">
 
       <xsl:variable name="resourceUUID">
@@ -1436,7 +1492,8 @@
                           ],
                         </xsl:if>
                     </xsl:when>    
-                    <xsl:otherwise>
+                    <!-- <xsl:otherwise> -->
+                    <xsl:when test="string(ccda:observation/ccda:value/@code) != 'UNK' and string-length(ccda:observation/ccda:value/@code) > 0">
                         "valueCodeableConcept" : {
                           "coding": [{
                             "system": "http://loinc.org",
@@ -1452,7 +1509,8 @@
                             </xsl:when>
                           </xsl:choose>
                         },
-                    </xsl:otherwise>
+                    </xsl:when>
+                    <!-- </xsl:otherwise> -->
                   </xsl:choose>
 
                   "subject": {

--- a/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
@@ -145,68 +145,112 @@
             <component>
                 <structuredBody>
                     <!-- Encounter -->
-                        <xsl:variable name="encounterEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='46240-8']]/hl7:entry[hl7:encounter]"/>
-                        <xsl:if test="$encounterEntry">
-                            <component>
-                                <section ID="encounters">
-                                    <xsl:copy-of select="//hl7:section[hl7:code[@code='46240-8']]/@*"/>
-                                    <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
-                                    <xsl:copy-of select="$encounterEntry"/>
-                                </section>
-                            </component>
-                        </xsl:if>
+                    <xsl:variable name="encounterSection"
+                        select="hl7:component
+                                /hl7:structuredBody
+                                /hl7:component
+                                /hl7:section[hl7:code[@code='46240-8']]"/>
+                    <xsl:variable name="encounterEntry" select="$encounterSection/hl7:entry[hl7:encounter]"/>
+                    <xsl:if test="$encounterEntry">
+                        <component>
+                            <section ID="encounters">
+                                <xsl:copy-of select="$encounterSection/@*"/>
+                                <xsl:copy-of select="$encounterSection/hl7:templateId"/>
+                                <xsl:copy-of select="$encounterSection/hl7:code"/>
+                                <xsl:copy-of select="$encounterSection/hl7:title"/>
+                                <xsl:copy-of select="$encounterEntry"/>
+                            </section>
+                        </component>
+                    </xsl:if>
                     
                     <!-- Observations -->
                     <!-- Athena: observations variable (returns hl7:entry nodes only; supports organizer/component/observation) -->
-                    <xsl:variable name="observations" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='29762-2']]/hl7:entry[
-                        hl7:observation/hl7:entryRelationship/hl7:observation[
-                            (
-                                hl7:code[
-                                    (@codeSystemName = 'LOINC' or @codeSystemName = 'SNOMED' or @codeSystemName = 'SNOMED CT')
-                                    and (not(@code = 'UNK') and string-length(@code) > 0)
-                                ]
-                                and (
-                                    hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer' 
-                                    or hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-declined'
-                                    or (
-                                        hl7:value[
-                                            not(@code = 'UNK')
-                                            and string-length(@code) > 0
-                                            and string-length(@nullFlavor) = 0
-                                        ]
+                    <xsl:variable name="observationSection"
+                        select="
+                            hl7:component
+                            /hl7:structuredBody
+                            /hl7:component
+                            /hl7:section[hl7:code[@code='29762-2']][1]
+                        "/>
+                    <xsl:variable name="observations"
+                        select="
+                            $observationSection
+                            /hl7:entry[
+                                hl7:observation
+                                /hl7:entryRelationship
+                                /hl7:observation[
+                                (
+                                    hl7:code[
+                                        (@codeSystemName = 'LOINC' or @codeSystemName = 'SNOMED' or @codeSystemName = 'SNOMED CT')
+                                        and (not(@code = 'UNK') and string-length(@code) > 0)
+                                    ]
+                                    and (
+                                        hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer' 
+                                        or hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-declined'
+                                        or (
+                                            hl7:value[
+                                                not(@code = 'UNK')
+                                                and string-length(@code) > 0
+                                                and string-length(@nullFlavor) = 0
+                                            ]
+                                        )
                                     )
                                 )
-                            )
-                            or (
-                                hl7:code[@code='95614-4']
-                                and string-length(hl7:value/@value) > 0
-                            )
-                        ]
-                    ]                    
-                    "/>
+                                or (
+                                    hl7:code[@code='95614-4']
+                                    and string-length(hl7:value/@value) > 0
+                                )
+                            ]
+                        ]                    
+                        "/>                    
                     <xsl:if test="$observations">
                         <component>
                             <section ID="observations">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:templateId"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:code"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:title"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/@*"/>
+                                <xsl:copy-of select="$observationSection/@*"/>
+                                <xsl:copy-of select="$observationSection/hl7:templateId"/>
+                                <xsl:copy-of select="$observationSection/hl7:code"/>
+                                <xsl:copy-of select="$observationSection/hl7:title"/>
                                 <xsl:copy-of select="$observations"/>
                             </section>
                         </component>
                     </xsl:if>
 
-                    <!-- Sexual Orientation -->
-                    <xsl:variable name="sexualOrientationEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='29762-2']]/hl7:entry[hl7:observation/hl7:code[@code='76690-7']]"/>
+                    <!-- Sexual Orientation, birthSex and Gender Identity-->
+                    <!-- 1. birthSex  - 76689-9
+                         2. Gender Identity  - 76691-5
+                         3. sexual orientation  - 76690-7 -->
+                    <xsl:variable name="sexualOrientationSection"
+                           select="hl7:component
+                                  /hl7:structuredBody
+                                  /hl7:component
+                                  /hl7:section
+                                        [hl7:code[@code='29762-2']]
+                                        [hl7:entry
+                                            [hl7:observation
+                                                /hl7:code
+                                                    [@code='76690-7' 
+                                                    or @code='76691-5' 
+                                                    or @code='76689-9']
+                                            ]
+                                        ]"/>
+                    <xsl:variable name="sexualOrientationEntry" select="$sexualOrientationSection/hl7:entry
+                                            [hl7:observation
+                                                /hl7:code
+                                                    [@code='76690-7' 
+                                                    or @code='76691-5' 
+                                                    or @code='76689-9']
+                                            ]"/>     
                     <xsl:if test="$sexualOrientationEntry">
                         <component>
                             <section ID="sexualOrientation">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='76690-7']]/@*"/>
-                                <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
+                                <xsl:copy-of select="$sexualOrientationSection/@*"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:templateId[1]"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:title[1]"/>
                                 <xsl:copy-of select="$sexualOrientationEntry"/>
                             </section>
                         </component>
                     </xsl:if>
+
                 </structuredBody>
             </component>
 

--- a/support/specifications/develop/ccda/cda-phi-filter-epic.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-epic.xslt
@@ -66,66 +66,112 @@
             <component>
                 <structuredBody>
                     <!-- Encounter -->
-                        <xsl:variable name="encounterEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='46240-8']]/hl7:entry[hl7:encounter]"/>
-                        <xsl:if test="$encounterEntry">
-                            <component>
-                                <section ID="encounters">
-                                    <xsl:copy-of select="//hl7:section[hl7:code[@code='46240-8']]/@*"/>
-                                    <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
-                                    <xsl:copy-of select="$encounterEntry"/>
-                                </section>
-                            </component>
-                        </xsl:if>
+                    <xsl:variable name="encounterSection"
+                        select="hl7:component
+                                /hl7:structuredBody
+                                /hl7:component
+                                /hl7:section[hl7:code[@code='46240-8']]"/>
+                    <xsl:variable name="encounterEntry" select="$encounterSection/hl7:entry[hl7:encounter]"/>
+                    <xsl:if test="$encounterEntry">
+                        <component>
+                            <section ID="encounters">
+                                <xsl:copy-of select="$encounterSection/@*"/>
+                                <xsl:copy-of select="$encounterSection/hl7:templateId"/>
+                                <xsl:copy-of select="$encounterSection/hl7:code"/>
+                                <xsl:copy-of select="$encounterSection/hl7:title"/>
+                                <xsl:copy-of select="$encounterEntry"/>
+                            </section>
+                        </component>
+                    </xsl:if>
                     
                     <!-- Observations -->
-                    <xsl:variable name="observations" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='29762-2']]/hl7:entry[
-                        hl7:observation/hl7:entryRelationship/hl7:observation/hl7:entryRelationship/hl7:observation[
-                            (
-                                hl7:code[
-                                    (@codeSystemName = 'LOINC' or @codeSystemName = 'SNOMED' or @codeSystemName = 'SNOMED CT')
-                                    and (not(@code = 'UNK') and string-length(@code) > 0)
-                                ]
-                                and (
-                                    hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer' 
-                                    or hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-declined'
-                                    or (
-                                        hl7:value[
-                                            not(@code = 'UNK')
-                                            and string-length(@code) > 0
-                                            and string-length(@nullFlavor) = 0
-                                        ]
+                    <xsl:variable name="observationSection"
+                        select="
+                            hl7:component
+                            /hl7:structuredBody
+                            /hl7:component
+                            /hl7:section[hl7:code[@code='29762-2']][1]
+                        "/>
+                    <xsl:variable name="observations"
+                        select="
+                            $observationSection
+                            /hl7:entry[
+                                hl7:observation
+                                /hl7:entryRelationship
+                                /hl7:observation
+                                /hl7:entryRelationship
+                                /hl7:observation[
+                                (
+                                    hl7:code[
+                                        (@codeSystemName = 'LOINC' or @codeSystemName = 'SNOMED' or @codeSystemName = 'SNOMED CT')
+                                        and (not(@code = 'UNK') and string-length(@code) > 0)
+                                    ]
+                                    and (
+                                        hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-unable-to-answer' 
+                                        or hl7:value/hl7:translation/@code = 'X-SDOH-FLO-1570000066-Patient-declined'
+                                        or (
+                                            hl7:value[
+                                                not(@code = 'UNK')
+                                                and string-length(@code) > 0
+                                                and string-length(@nullFlavor) = 0
+                                            ]
+                                        )
                                     )
                                 )
-                            )
-                            or (
-                                hl7:code[@code='95614-4']
-                                and string-length(hl7:value/@value) > 0
-                            )
-                        ]
-                    ]"/>
+                                or (
+                                    hl7:code[@code='95614-4']
+                                    and string-length(hl7:value/@value) > 0
+                                )
+                            ]
+                        ]"/>
                     <xsl:if test="$observations">
                         <component>
                             <section ID="observations">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:templateId"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:code"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:title"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/@*"/>
+                                <xsl:copy-of select="$observationSection/@*"/>
+                                <xsl:copy-of select="$observationSection/hl7:templateId"/>
+                                <xsl:copy-of select="$observationSection/hl7:code"/>
+                                <xsl:copy-of select="$observationSection/hl7:title"/>
                                 <xsl:copy-of select="$observations"/>
                             </section>
                         </component>
                     </xsl:if>
 
-                    <!-- Sexual Orientation -->
-                    <xsl:variable name="sexualOrientationEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='29762-2']]/hl7:entry[hl7:observation/hl7:code[@code='76690-7']]"/>
+                    <!-- Sexual Orientation, birthSex and Gender Identity-->
+                    <!-- 1. birthSex  - 76689-9
+                         2. Gender Identity  - 76691-5
+                         3. sexual orientation  - 76690-7 -->
+                    <xsl:variable name="sexualOrientationSection"
+                           select="hl7:component
+                                  /hl7:structuredBody
+                                  /hl7:component
+                                  /hl7:section
+                                        [hl7:code[@code='29762-2']]
+                                        [hl7:entry
+                                            [hl7:observation
+                                                /hl7:code
+                                                    [@code='76690-7' 
+                                                    or @code='76691-5' 
+                                                    or @code='76689-9']
+                                            ]
+                                        ]"/>
+                    <xsl:variable name="sexualOrientationEntry" select="$sexualOrientationSection/hl7:entry
+                                            [hl7:observation
+                                                /hl7:code
+                                                    [@code='76690-7' 
+                                                    or @code='76691-5' 
+                                                    or @code='76689-9']
+                                            ]"/>     
                     <xsl:if test="$sexualOrientationEntry">
                         <component>
                             <section ID="sexualOrientation">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='76690-7']]/@*"/>
-                                <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
+                                <xsl:copy-of select="$sexualOrientationSection/@*"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:templateId[1]"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:title[1]"/>
                                 <xsl:copy-of select="$sexualOrientationEntry"/>
                             </section>
                         </component>
                     </xsl:if>
+
                 </structuredBody>
             </component>
 

--- a/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
@@ -95,15 +95,24 @@
             <component>
                 <structuredBody>                    
                     <!-- Extract and place the Encounter entry -->
-                        <xsl:variable name="encounterEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:code[@code='46240-8']]/hl7:entry[hl7:encounter]" />
-                        <xsl:if test="$encounterEntry">
-                            <component>
-                                <section ID="encounters">
-                                    <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
-                                    <xsl:copy-of select="$encounterEntry" />
-                                </section>
-                            </component>
-                        </xsl:if>
+                    <xsl:variable name="encounterSection"
+                        select="hl7:component
+                                /hl7:structuredBody
+                                /hl7:component
+                                /hl7:section
+                                    [hl7:code[@code='46240-8']]"/>
+                    <xsl:variable name="encounterEntry" select="$encounterSection/hl7:entry[hl7:encounter]"/>
+                    <xsl:if test="$encounterEntry">
+                        <component>
+                            <section ID="encounters">
+                                <xsl:copy-of select="$encounterSection/@*"/>
+                                <xsl:copy-of select="$encounterSection/hl7:templateId"/>
+                                <xsl:copy-of select="$encounterSection/hl7:code"/>
+                                <xsl:copy-of select="$encounterSection/hl7:title"/>
+                                <xsl:copy-of select="$encounterEntry"/>
+                            </section>
+                        </component>
+                    </xsl:if>
 
                     <!-- Extract and place all other observations -->
                     <xsl:variable name="observations" select="hl7:component
@@ -208,35 +217,66 @@
                     </xsl:if>
 
                     <!-- Extract and place all Procedures -->
-                    <xsl:variable name="procedures" select="hl7:component
-                            /hl7:structuredBody
-                            /hl7:component
-                            /hl7:section[hl7:code[@code='47519-4']]
-                            /hl7:entry
-                            [hl7:procedure
-                                [hl7:code
-                                    [(not(@code = 'UNK') and string-length(@code) > 0)]
-                                ]
-                            ]"/>
-                                        
+                    <xsl:variable name="procedureSection"
+                        select="hl7:component
+                                /hl7:structuredBody
+                                /hl7:component
+                                /hl7:section[hl7:code[@code='47519-4']]"/>
+
+                    <xsl:variable name="procedures"
+                        select="$procedureSection
+                                /hl7:entry[
+                                    hl7:procedure[
+                                        hl7:code[
+                                            not(@code='UNK') and string-length(@code) > 0
+                                        ]
+                                    ]
+                                ]"/>
+
                     <xsl:if test="$procedures">
                         <component>
                             <section ID="procedures">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:templateId"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:code"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='47519-4']]/hl7:title"/>
-                                <xsl:copy-of select="$procedures" />
+                                <xsl:copy-of select="$procedureSection/@*"/>
+                                <xsl:copy-of select="$procedureSection/hl7:templateId"/>
+                                <xsl:copy-of select="$procedureSection/hl7:code"/>
+                                <xsl:copy-of select="$procedureSection/hl7:title"/>
+                                <xsl:copy-of select="$procedures"/>
                             </section>
                         </component>
                     </xsl:if>
 
-                    <!-- Extract and place the single Sexual Orientation entry -->
-                    <xsl:variable name="sexualOrientationEntry" select="//hl7:section[hl7:code[@code='29762-2']]/hl7:entry[hl7:observation/hl7:code[@code='76690-7']]" />
+                    <!-- Sexual Orientation, birthSex and Gender Identity-->
+                    <!-- 1. birthSex  - 76689-9
+                         2. Gender Identity  - 76691-5
+                         3. sexual orientation  - 76690-7 -->
+                    <xsl:variable name="sexualOrientationSection"
+                           select="hl7:component
+                                  /hl7:structuredBody
+                                  /hl7:component
+                                  /hl7:section
+                                        [hl7:code[@code='29762-2']]
+                                        [hl7:entry
+                                            [hl7:observation
+                                                /hl7:code
+                                                    [@code='76690-7' 
+                                                    or @code='76691-5' 
+                                                    or @code='76689-9']
+                                            ]
+                                        ]"/>
+                    <xsl:variable name="sexualOrientationEntry" select="$sexualOrientationSection/hl7:entry
+                                            [hl7:observation
+                                                /hl7:code
+                                                    [@code='76690-7' 
+                                                    or @code='76691-5' 
+                                                    or @code='76689-9']
+                                            ]"/>    
                     <xsl:if test="$sexualOrientationEntry">
                         <component>
                             <section ID="sexualOrientation">
-                                <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
-                                <xsl:copy-of select="$sexualOrientationEntry" />
+                                <xsl:copy-of select="$sexualOrientationSection/@*"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:templateId[1]"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:title[1]"/>
+                                <xsl:copy-of select="$sexualOrientationEntry"/>
                             </section>
                         </component>
                     </xsl:if>

--- a/support/specifications/develop/ccda/cda-phi-filter.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter.xslt
@@ -59,12 +59,34 @@
                 <structuredBody>
                     <!-- Extract and place the Encounter entry -->
                     <xsl:if test="not(hl7:componentOf/hl7:encompassingEncounter)">
-                        <xsl:variable name="encounterEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section/hl7:entry/hl7:observation/hl7:entryRelationship/hl7:encounter"/>
+                        <xsl:variable name="encounterSection"
+                            select="
+                                hl7:component
+                                /hl7:structuredBody
+                                /hl7:component
+                                /hl7:section[
+                                    hl7:entry
+                                    /hl7:observation
+                                    /hl7:entryRelationship
+                                    /hl7:encounter
+                                ][1]
+                            "/>
+                        <xsl:variable name="encounterEntry"
+                            select="
+                                $encounterSection
+                                /hl7:entry
+                                /hl7:observation
+                                /hl7:entryRelationship
+                                /hl7:encounter
+                            "/>
+
                         <xsl:if test="$encounterEntry">
                             <component>
                                 <section ID="encounters">
-                                    <xsl:copy-of select="@*"/>
-                                    <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
+                                    <xsl:copy-of select="$encounterSection/@*"/>
+                                    <xsl:copy-of select="$encounterSection/hl7:templateId"/>
+                                    <xsl:copy-of select="$encounterSection/hl7:code"/>
+                                    <xsl:copy-of select="$encounterSection/hl7:title"/>
                                     <xsl:copy-of select="$encounterEntry"/>
                                 </section>
                             </component>
@@ -87,35 +109,47 @@
                     <xsl:if test="$observations">
                         <component>
                             <section ID="observations">
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:templateId"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:code"/>
-                                <xsl:copy-of select="//hl7:section[hl7:code[@code='29762-2']]/hl7:title"/>
-                                <xsl:copy-of select="@*"/>
+                                <xsl:copy-of select="hl7:component/hl7:structuredBody/hl7:component/hl7:section/@*"/>
                                 <xsl:copy-of select="$observations"/>
                             </section>
                         </component>
                     </xsl:if>
 
-                    <!-- Extract and place the single Sexual Orientation entry -->
-                    <xsl:variable name="sexualOrientationEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section/hl7:entry[hl7:observation/hl7:code[@code='76690-7']]" />
+                    <!-- Sexual Orientation, birthSex and Gender Identity-->
+                    <!-- 1. birthSex  - 76689-9
+                         2. Gender Identity  - 76691-5
+                         3. sexual orientation  - 76690-7 -->
+                    <xsl:variable name="sexualOrientationSection"
+                           select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:entry[hl7:observation/hl7:code[@code='76690-7' or @code='76691-5' or @code='76689-9']]]"/>
+                    <xsl:variable name="sexualOrientationEntry" select="$sexualOrientationSection/hl7:entry"/>     
                     <xsl:if test="$sexualOrientationEntry">
                         <component>
                             <section ID="sexualOrientation">
-                                <xsl:copy-of select="@*"/>
-                                <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
-                                <xsl:copy-of select="$sexualOrientationEntry" />
+                                <xsl:copy-of select="$sexualOrientationSection/@*"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:templateId[1]"/>
+                                <xsl:copy-of select="$sexualOrientationSection/hl7:title[1]"/>
+                                <xsl:copy-of select="$sexualOrientationEntry"/>
                             </section>
                         </component>
                     </xsl:if>
 
                     <!-- Extract and place the Questionnaire entries -->
-                    <xsl:variable name="questionnaireEntry" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:templateId[@root='2.16.840.1.113883.19.1000.2.1']]/hl7:entry" />
+                    <xsl:variable name="questionnaireSection" select="hl7:component/hl7:structuredBody/hl7:component/hl7:section[hl7:templateId[@root='2.16.840.1.113883.19.1000.2.1']]"/>
+                    <xsl:variable name="questionnaireEntry" select="$questionnaireSection/hl7:entry"/>
+
                     <xsl:if test="$questionnaireEntry">
                         <component>
                             <section ID="questionnaire">
-                                <xsl:copy-of select="@*"/>
-                                <xsl:copy-of select="hl7:templateId |hl7:code | hl7:title"/>
-                                <xsl:copy-of select="$questionnaireEntry" />
+                                <!-- Copy section attributes -->
+                                <xsl:copy-of select="$questionnaireSection/@*"/>
+
+                                <!-- Copy questionnaire metadata -->
+                                <xsl:copy-of select="$questionnaireSection/hl7:templateId"/>
+                                <xsl:copy-of select="$questionnaireSection/hl7:title"/>
+                                <xsl:copy-of select="$questionnaireSection/hl7:code"/>
+
+                                <!-- Copy entries -->
+                                <xsl:copy-of select="$questionnaireEntry"/>
                             </section>
                         </component>
                     </xsl:if>


### PR DESCRIPTION
Updated XSLT files used for creating PHI filtered XML files and FHIR Bundles to add Birth Sex and Gender Identity extension details from CCDA files.