### PR TITLE
fix: restrict the Consent status to be populated only once, and retrieve it from any Observation regardless of its position while genrating the PHI-filtered C-CDA file for Medent and AthenaHealth #3210

### DIFF
--- a/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-athenahealth.xslt
@@ -51,7 +51,7 @@
             <xsl:variable name="observationConsent" select="
                                     hl7:component/hl7:structuredBody/hl7:component
                                     /hl7:section[hl7:code[@code='29762-2']]
-                                    /hl7:entry[1]/hl7:observation/hl7:entryRelationship
+                                    /hl7:entry/hl7:observation/hl7:entryRelationship
                                     /hl7:observation[
                                         hl7:code/@code = '105511-0'
                                         and
@@ -66,7 +66,7 @@
             <xsl:variable name="consentPermitObservation" select="
                                     hl7:component/hl7:structuredBody/hl7:component
                                     /hl7:section[hl7:code[@code='29762-2']]
-                                    /hl7:entry[1]/hl7:observation/hl7:entryRelationship
+                                    /hl7:entry/hl7:observation/hl7:entryRelationship
                                     /hl7:observation[
                                         hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.86']
                                         and
@@ -104,11 +104,11 @@
 
                             <xsl:choose>
                                 <xsl:when test="$observationConsent">
-                                    <xsl:copy-of select="$observationConsent/hl7:statusCode"/>
+                                    <xsl:copy-of select="$observationConsent[1]/hl7:statusCode"/>
                                 </xsl:when>
 
                                 <xsl:when test="$consentPermitObservation">
-                                    <xsl:copy-of select="$consentPermitObservation/hl7:statusCode"/>
+                                    <xsl:copy-of select="$consentPermitObservation[1]/hl7:statusCode"/>
                                 </xsl:when>
 
                                 <xsl:otherwise>

--- a/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
+++ b/support/specifications/develop/ccda/cda-phi-filter-medent.xslt
@@ -48,7 +48,7 @@
             <xsl:variable name="consent" select="
                 hl7:component/hl7:structuredBody/hl7:component
                 /hl7:section[hl7:code[@code='47519-4']]
-                /hl7:entry[1]/hl7:observation/hl7:entryRelationship
+                /hl7:entry/hl7:observation/hl7:entryRelationship
                 /hl7:observation[hl7:code/@code = '105511-0']
             "/>   
             <xsl:if test="$consent">
@@ -75,7 +75,7 @@
                         <code code="105511-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
                             <xsl:attribute name="displayName"><xsl:value-of select="$consentDisplay"/></xsl:attribute>
                         </code>
-                        <xsl:copy-of select="$consent/hl7:statusCode"/>
+                        <xsl:copy-of select="$consent[1]/hl7:statusCode"/>
                     </consent>
                 </authorization>
             </xsl:if>


### PR DESCRIPTION
Restrict the Consent status to be populated only once, and retrieve it from any Observation regardless of its position while genrating the PHI-filtered C-CDA file for Medent and AthenaHealth.