### PR TITLE
fix: fix meta data save in csv and normalize empty header values to null #1115

### DIFF
--- a/csv-service/src/main/java/org/techbd/csv/controller/CsvController.java
+++ b/csv-service/src/main/java/org/techbd/csv/controller/CsvController.java
@@ -73,6 +73,7 @@ public class CsvController {
           "When using `immediate=false`, an interim response is returned containing a zipFileInteractionId. " +
           "The full operation outcome can be retrieved from Hub UI → Interactions → CSV via HTTP(s) tab using the provided zipFileInteractionId. " +
           "This option is useful for large ZIP files that may otherwise result in timeout issues.", required = false) @RequestParam(value = "immediate", required = false,defaultValue = "true") boolean isSync,
+       @Parameter(description = "Optional header to specify master interaction ID.", required = false) @RequestHeader(value = "X-TechBD-Interaction-ID", required = false) String masterInteractionId,
       HttpServletRequest request,
       HttpServletResponse response)
       throws Exception {
@@ -85,7 +86,12 @@ public class CsvController {
         null,null);   
     CoreFHIRUtil.buildRequestParametersMap(requestDetailsMap,null,
         null, null, null, null, request.getRequestURI());
-    requestDetailsMap.put(Constants.MASTER_INTERACTION_ID,UuidUtil.generateUuid());
+    requestDetailsMap.put(
+    Constants.MASTER_INTERACTION_ID,
+    (masterInteractionId == null || masterInteractionId.trim().isEmpty())
+      ? UuidUtil.generateUuid()
+      : masterInteractionId
+    );
     requestDetailsMap.put(Constants.IMMEDIATE, isSync);
     requestDetailsMap.put(Constants.OBSERVABILITY_METRIC_INTERACTION_START_TIME, Instant.now().toString());
     Map<String, Object> responseParameters = new HashMap<>();

--- a/csv-service/src/main/java/org/techbd/csv/service/CsvService.java
+++ b/csv-service/src/main/java/org/techbd/csv/service/CsvService.java
@@ -43,7 +43,7 @@ import org.techbd.csv.service.engine.CsvOrchestrationEngine;
 import org.techbd.csv.util.CsvConversionUtil;
 import org.techbd.udi.auto.jooq.ingress.routines.RegisterInteractionCsvRequest;
 import org.techbd.udi.auto.jooq.ingress.routines.SatInteractionCsvRequestUpserted;
-
+import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -291,7 +291,19 @@ public class CsvService {
             initRIHR.setPCsvZipFileName(file.getOriginalFilename());
             initRIHR.setPCreatedAt(forwardedAt);
             initRIHR.setPCsvStatus(state.name());
-            ObjectNode pElaboration = Configuration.objectMapper.createObjectNode();
+
+           Object headerObj = requestParameters.get(Constants.HEADERS);
+
+                if (headerObj instanceof Map<?, ?>) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> headers = (Map<String, Object>) headerObj;
+
+                headers.replaceAll((key, value) ->
+                        (value instanceof String && StringUtils.isBlank((String) value))
+                        ? null
+                        : value);
+                }
+            ObjectNode pElaboration = Configuration.objectMapper.createObjectNode();     
                 pElaboration.set(
                 "headers",
                 Configuration.objectMapper.valueToTree(requestParameters).path("headers")

--- a/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundle.xml
+++ b/integration-artifacts/flatfile/flatfile-techbd-channel-files/nexus-sandbox/FlatFileCsvBundle.xml
@@ -2,20 +2,15 @@
   <id>00340250-ce9b-4d83-a27b-a49a7cb1fa1f</id>
   <nextMetaDataId>2</nextMetaDataId>
   <name>FlatFileCsvBundle</name>
-  <description>Version: 0.9.28
-Changed message storage to Metadata mode.
-Added custom metadata for interaction id and all headers.
-Saved the custom metadata.
-Saved the headers to sat_interaction_zip_file_request table.</description>
-  <revision>11</revision>
+  <description>Version: 0.9.29
+Updated metadata handling to store all headers correctly.
+Defined severityLevel in the Source Transformer.</description>
+  <revision>32</revision>
   <sourceConnector version="26.3.1">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
       <pluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
-  <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
   <sslEnabled>false</sslEnabled>
           <mutualTlsEnabled>true</mutualTlsEnabled>
@@ -46,6 +41,9 @@ Saved the headers to sat_interaction_zip_file_request table.</description>
           <pinnedLeafPins/>
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="26.3.1">
         <host>0.0.0.0</host>
@@ -146,19 +144,7 @@ if (incomingHeader !== &quot;&quot;) {
     for (var i = 0; i &lt; allowedUrls.length; i++) {
  
         var allowedUrl = String(allowedUrls[i]).trim();
-        logger.info(
- 
-            &quot;Comparing incoming=[&quot; +
- 
-            incomingHeader +
- 
-            &quot;] with allowed=[&quot; +
- 
-            allowedUrl +
- 
-            &quot;]&quot;
- 
-        );
+       
         if (incomingHeader === allowedUrl) {
  
             isAllowed = true;
@@ -205,6 +191,7 @@ if (incomingHeader !== &quot;&quot;) {
  
 }
 channelMap.put(&quot;DATALAKE_API_URL&quot;, datalakeApiUrl);&#xd;
+channelMap.put(&quot;dataLakeApiUrl&quot;, datalakeApiUrl);
 
 /********************************************
     FETCH DEFAULT DATALAKE API URL (Plain text)
@@ -279,6 +266,7 @@ try {
     var dataLedgerTracking = LookupHelper.get(&quot;Config&quot;, &quot;DATA_LEDGER_TRACKING&quot;);
    
     channelMap.put(&quot;DATA_LEDGER_TRACKING&quot;, dataLedgerTracking);
+    channelMap.put(&quot;dataLedgerTracking&quot;, dataLedgerTracking);
     globalMap.put(&quot;DATA_LEDGER_TRACKING&quot;, dataLedgerTracking);
 
     logger.info(&quot; DataLedger Tracking loaded into channelMap&quot;+ dataLedgerTracking);
@@ -296,6 +284,7 @@ try {
     var dataLedgerDiagnostics = LookupHelper.get(&quot;Config&quot;, &quot;DATA_LEDGER_DIAGNOSTICS&quot;);
    
     channelMap.put(&quot;DATA_LEDGER_DIAGNOSTICS&quot;, dataLedgerDiagnostics);
+    channelMap.put(&quot;dataLedgerDiagnostics&quot;, dataLedgerDiagnostics);
     globalMap.put(&quot;DATA_LEDGER_DIAGNOSTICS&quot;, dataLedgerDiagnostics);
 
     logger.info(&quot; DataLedger diagnostics loaded into channelMap&quot;+ dataLedgerDiagnostics);
@@ -322,6 +311,7 @@ else {
     interactionId = generateUuid();
 }
 channelMap.put(&apos;interactionId&apos;, interactionId);
+logger.info(&quot;[CHANNEL: &quot;+ channelName +&quot;] interactionId: &quot; + interactionId);
 var tenantId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Tenant-ID&apos;);
 channelMap.put(&apos;tenantId&apos;, tenantId);
 var userAgent = $(&apos;headers&apos;).getHeader(&apos;User-Agent&apos;);
@@ -367,8 +357,8 @@ var customBaseFhirUrl = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Base-FHI
     if (customBaseFhirUrl !== null &amp;&amp; customBaseFhirUrl.trim() != &quot;&quot;) {
  
     if (validUrls.includes(customBaseFhirUrl)) {
-      
-    channelMap.put(&apos;TechBdBaseFhirurl&apos;,customBaseFhirUrl);&#xd;    channelMap.put(&apos;baseFhirurl&apos;, customBaseFhirUrl);&#xd;  
+    	
+    channelMap.put(&apos;techBdBaseFhirUrl&apos;,customBaseFhirUrl);&#xd;    channelMap.put(&apos;baseFhirurl&apos;, customBaseFhirUrl);&#xd;  
    } else {&#xd;   		logger.info(&quot;ERROR&quot;);
 			var errorMessage = &apos;The provided X-TechBD-Base-FHIR-URL is invalid. Base-FHIR-URL taken from the environment variable.&apos;;
 			logger.error(errorMessage);
@@ -528,6 +518,12 @@ if (!hasCsvFile) {
     setErrorResponse(400, errorMessage);
     throw errorMessage;
 }
+
+
+var severityLevel =
+    String($(&apos;headers&apos;).getHeader(&apos;X-TechBD-Validation-Severity-Level&apos;) || &quot;&quot;).trim();
+
+channelMap.put(&quot;severityLevel&quot;, severityLevel || &quot;error&quot;);
 ///////////////////////////////////////////////////////////////////////////</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
         <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
@@ -599,7 +595,6 @@ var multipartFile = new SimpleMultipartFile(filename, &apos;application/zip&apos
 /* ----------------- 8. Build multipart/form-data body ----------------- */
 
 var uuid = generateUuid();
-logger.info(&quot;Generated UUID v7: &quot; + uuid);
 var multipartBoundary = &quot;----MirthBoundary&quot; + uuid;
 var header = &quot;--&quot; + multipartBoundary + &quot;\r\n&quot; +
              &apos;Content-Disposition: form-data; name=&quot;file&quot;; filename=&quot;&apos; + filename + &apos;&quot;\r\n&apos; +
@@ -806,7 +801,7 @@ var tenantId = channelMap.get(&apos;tenantId&apos;) || &apos;defaultTenant&apos;
 var userAgent = channelMap.get(&apos;userAgent&apos;) || &apos;MirthConnector/1.0&apos;;
 var sourceParam = &apos;CSV&apos;;
 
-var baseFhirurl =  channelMap.get(&apos;baseFhirurl&apos;); &#xd;logger.info(&quot;baseFhirurl&quot; +baseFhirurl);&#xd;&#xd;var techBdBaseFhirUrl =  channelMap.get(&apos;TechBdBaseFhirurl&apos;); &#xd;logger.info(&quot;techBdBaseFhirUrl&quot; +techBdBaseFhirUrl);&#xd;
+var baseFhirurl =  channelMap.get(&apos;baseFhirurl&apos;); &#xd;logger.info(&quot;baseFhirurl&quot; +baseFhirurl);&#xd;&#xd;var techBdBaseFhirUrl =  channelMap.get(&apos;techBdBaseFhirUrl&apos;);&#xd;logger.info(&quot;techBdBaseFhirUrl&quot; +techBdBaseFhirUrl);&#xd;
 
 // Read &apos;immediate&apos; parameter from request and default invalid values to true.
 var immediateParamRaw = $(&apos;parameters&apos;).get(&apos;immediate&apos;);
@@ -859,7 +854,7 @@ channelMap.put(&apos;uri&apos;, sourceMap.get(&apos;uri&apos;));
 var uri = channelMap.get(&apos;uri&apos;) || &apos;/flatfile/csv/Bundle/&apos;;
 
 var severityLevel = String($(&apos;headers&apos;).getHeader(&apos;X-TechBD-Validation-Severity-Level&apos;) || &quot;&quot;).trim();
-channelMap.put(&apos;SeverityLevel&apos;, severityLevel || &quot;error&quot;);
+//channelMap.put(&apos;SeverityLevel&apos;, severityLevel || &quot;error&quot;);
 
 var dataLakeApiUrl = channelMap.get(&apos;DATALAKE_API_URL&apos;);
 var techbdBlBaseUrl = channelMap.get(&apos;techbdBlBaseUrl&apos;);
@@ -1074,459 +1069,19 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1782103308689</time>
+        <time>1783345238339</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
         <archiveEnabled>true</archiveEnabled>
         <pruneErroredMessages>false</pruneErroredMessages>
       </pruningSettings>
-      <userId>6</userId>
+      <userId>11</userId>
     </metadata>
-    <codeTemplateLibraries>
-      <codeTemplateLibrary version="26.3.1">
-        <id>66cf0efd-4f83-4c42-8b8e-71a5c57d9b11</id>
-        <name>TechBD Functions</name>
-        <revision>188</revision>
-        <lastModified>
-          <time>1781934314652</time>
-          <timezone>America/New_York</timezone>
-        </lastModified>
-        <description></description>
-        <includeNewChannels>true</includeNewChannels>
-        <enabledChannelIds class="sorted-set">
-          <string>00340250-ce9b-4d83-a27b-a49a7cb1fa1f</string>
-          <string>04ef5b0d-3120-4dd4-ba3f-fd7ec1ab1fdb</string>
-          <string>0bf51702-45a6-4f42-adc2-69345112767e</string>
-          <string>0f01102b-8ef8-4237-a8c8-0e79c35be41d</string>
-          <string>101406b4-312a-4517-ab69-686051a91483</string>
-          <string>12467de6-360c-47c1-83af-09aae915eb8c</string>
-          <string>140795e4-5d41-4769-885b-b815c18bbc62</string>
-          <string>158a1edb-a782-4fb4-bc18-f05f40ce3e18</string>
-          <string>1886486f-4cbd-4e25-9057-ebd6cc6f6478</string>
-          <string>19069366-0852-4caa-875c-1c503461f8a1</string>
-          <string>1908260b-7361-46dc-a9c9-e7114b06e698</string>
-          <string>1c406954-d304-4882-b05d-b513d699785b</string>
-          <string>207ba60a-9430-4126-9553-8c8eb588f419</string>
-          <string>20d4fc56-4e53-408c-a8a0-20ef046f9fa5</string>
-          <string>2154b64c-8539-4320-86f4-8a0b9b706ad0</string>
-          <string>2240d25e-de1d-4c6f-904c-832e7f68a574</string>
-          <string>29316ddf-46cc-4d33-813d-2b71a8b41902</string>
-          <string>29d0e04a-e2be-43ad-b814-bfe242963c90</string>
-          <string>2b4ff91f-4f33-48c2-ba05-2f0cdfd1120b</string>
-          <string>2d6fac85-49e1-4aa8-b39f-b4e39f12597e</string>
-          <string>32ad2913-1c3d-43d8-b5f8-2672f3325557</string>
-          <string>330819e8-5e01-45b0-9d7d-b87048a8813a</string>
-          <string>353f2542-73dd-44df-bb8b-361756233a37</string>
-          <string>35ee3e0b-ad66-44c5-bf30-6ebe8ff7c7ec</string>
-          <string>38c30482-47ef-41e0-b6f3-fa56e8bc76ae</string>
-          <string>39491051-e8fb-4f70-aea5-82ed1a454324</string>
-          <string>3acb72be-f9c1-4721-b990-ff0486b038fc</string>
-          <string>3bc69658-cba9-4fa2-8d32-438ab4660c2a</string>
-          <string>3bfca654-f2c7-4c5e-bb88-1ab68cd32f44</string>
-          <string>3cbc2ace-4a86-4ef9-839a-2aa4feac2ee3</string>
-          <string>3f3f6dcd-2923-4f09-89c3-1e248c1556b3</string>
-          <string>3fabdfd3-3a99-4dec-a769-b9c8e87978d8</string>
-          <string>423ef464-a171-4cb9-ae32-616aca66ea05</string>
-          <string>45c0836b-0e92-4861-9e58-16898e1e0835</string>
-          <string>4cd30607-97b1-44ad-9d8f-4cfc7dfa4028</string>
-          <string>4d4a6df4-774e-4cbd-b7aa-4ce0314d8faa</string>
-          <string>4dd74674-782c-4b6a-8782-11352b7bdcad</string>
-          <string>520ded48-a0be-4492-8cba-4fad5a227afd</string>
-          <string>548ec946-51d0-4c8b-a402-78345d8f0242</string>
-          <string>576131f3-aa5b-4453-929f-1e07d7534e82</string>
-          <string>5cf24505-f00b-4002-a769-836686016c37</string>
-          <string>60a18eb3-bf79-4c99-9bec-55fe0df4813f</string>
-          <string>61730c66-eedd-4c67-bb98-71c867be56a4</string>
-          <string>6432709e-b815-40a3-91a8-f77570d3273e</string>
-          <string>6504ba62-2e9e-42cc-9b65-09e832b1f27a</string>
-          <string>657d9972-aa59-406d-b248-22f39bbceed2</string>
-          <string>66b6457a-d8a4-40fb-bf4a-7fd09c941285</string>
-          <string>6a2535d6-2995-4464-a455-8bb815ec76bb</string>
-          <string>6ba3d163-f959-4b4f-9aca-f9bcdc5e7887</string>
-          <string>6db40d54-c29f-47e3-aaf8-fc99cb2e53b6</string>
-          <string>715fe7c8-223a-4949-a669-f1defb24cd95</string>
-          <string>71d75aee-a90e-4800-86cd-ec4d4ff8ba0c</string>
-          <string>789c27f9-3fbd-4c76-9252-833d4f388d81</string>
-          <string>78fd5c66-613e-46dd-bd45-c3dd0021a5fb</string>
-          <string>7bfc4fca-cf0a-4caf-b297-b4579d23684c</string>
-          <string>7f9360b4-e80f-4bbb-951f-58347ab2ca5a</string>
-          <string>7ffeeda4-e8e9-4534-8cf0-28eb8ce65510</string>
-          <string>8255fb74-da31-4573-ba36-1da03f1bfc27</string>
-          <string>829b3dbc-9d02-41b4-aa52-e9cbcc0f727b</string>
-          <string>869c806f-d639-44ea-93d7-9efbe211cc3c</string>
-          <string>87d008ec-f78d-4f2f-b986-cb1a4d926540</string>
-          <string>89def8c9-d8d2-46e2-a254-6345b05cfcb4</string>
-          <string>8ad98540-6ea5-4008-98f7-7f7769ae5e6b</string>
-          <string>8af30ec7-ad08-4ac8-9604-3ddd35f6d8b2</string>
-          <string>8be2be72-35cf-44a6-8b6e-5e37bd770672</string>
-          <string>8ca393c1-16ac-4b77-b78f-a8fca05ae3d6</string>
-          <string>8ff42419-20be-4845-b40c-77853eb27b35</string>
-          <string>91adead5-81ab-44f2-b3ac-f875a620846c</string>
-          <string>92bad760-5de9-4b86-91f4-33011e68ca43</string>
-          <string>94d93cc7-9346-4ed6-81f0-767364a29138</string>
-          <string>95b30942-c7ab-4267-8dc8-7e9436e0f470</string>
-          <string>96bd9c4c-3490-4ed9-9efe-4179e3d7d33d</string>
-          <string>96e9f4cf-2505-4620-b232-542e62dc0a1a</string>
-          <string>9a7e7b61-5745-4e29-a7e1-43a7d61b60ba</string>
-          <string>9c85680a-7b06-43fb-9d12-01db1d9c0448</string>
-          <string>9cbcd82b-a20e-4120-9d81-7c6698dfc1dd</string>
-          <string>9f99a5c7-84d9-4dc2-aa7f-451096b5bb8b</string>
-          <string>a0b29ee9-cd50-4228-8de1-c890131f4350</string>
-          <string>a1a84018-fd6b-4e23-80c8-3bc046c95d4c</string>
-          <string>a1bf0b83-9809-4841-b748-41ee68cb1765</string>
-          <string>a4d249da-533e-4b9f-917c-3ad75d22767f</string>
-          <string>a5b2ab2c-b422-4614-ac3c-c7b0876c8579</string>
-          <string>a7141bac-fe8d-4df6-81cd-dee54b0d09be</string>
-          <string>ab20f626-8de4-4845-8080-0f2c6b80669a</string>
-          <string>abe04006-4dc5-462a-88f6-93fdefb35933</string>
-          <string>ac361d6f-fc34-44f1-9029-589b680d7a2a</string>
-          <string>ac75ecb3-2a29-4a75-b056-61895a4ccc0c</string>
-          <string>af622c7c-a713-4fe6-a12c-3d8b199efc75</string>
-          <string>b84ee0f0-dfed-40bd-8a9e-af052b60860e</string>
-          <string>b947708e-312d-4458-aef3-93761eb9fe9c</string>
-          <string>bafa98dd-04f2-48ef-babb-4a3bedbcb0ed</string>
-          <string>bb812d5c-9a11-4e21-a134-c369f39dc5b3</string>
-          <string>bbf0fb0d-7a57-43c4-b3b0-2e0d257ae92b</string>
-          <string>bbfc8cdc-e671-46da-bae3-75de9ae91b85</string>
-          <string>c00e53b6-6165-4bb3-bd47-7f1e5d9708d4</string>
-          <string>c09ea42f-cb4b-4f67-92cd-830a1ab4c51c</string>
-          <string>c156a7a7-d1ac-49ce-a70f-cb2c1eb800cf</string>
-          <string>c1f9232a-b3c0-4c95-bf75-8eeaafd92d6f</string>
-          <string>c45aaeca-50e4-4674-8294-8bae37a0e431</string>
-          <string>c50e41d7-9fb2-4899-84f8-38909d092722</string>
-          <string>c79799dd-a972-4d99-beba-1331ed5e49a2</string>
-          <string>c9f1cab2-3a34-488a-9a55-6a4b01369ff0</string>
-          <string>cc1fe1c8-04cd-4b08-9797-0cb34491208b</string>
-          <string>d320f5d3-7af1-4de1-b618-6ed11e84390d</string>
-          <string>d341dceb-069e-49ab-8efa-c45398145216</string>
-          <string>d5c743d6-4c79-46da-b6be-754973d7a735</string>
-          <string>d8205661-526c-4762-bef0-0cb8414424cb</string>
-          <string>d85d0014-300a-46f9-81b7-ad6c6ef1516b</string>
-          <string>dc1d3367-14d7-4e36-a87e-d208d839fc78</string>
-          <string>dd22c442-ee54-4c80-b221-a2b30b889b79</string>
-          <string>dfa0f0a0-c211-4aa2-bb6c-444d5c23da7e</string>
-          <string>e3a5613e-0da0-4921-a270-b48cf72253de</string>
-          <string>e634b038-8196-4ac4-80fc-819a0a9c9bb1</string>
-          <string>eb2f5490-8909-4216-b65a-5947fb0f359e</string>
-          <string>f23e19b0-a0e0-422a-884c-caae6c52ecac</string>
-          <string>f2d185dd-96c3-4065-bbb9-5044afb7ba80</string>
-          <string>f376f9cc-b848-4868-ac1c-e2c011665fc5</string>
-          <string>fa2e04e2-8435-4a9c-bad2-ac65c1bb3a33</string>
-          <string>fa6d8035-8b04-4740-9eb0-4dbb71c69bb6</string>
-          <string>fe3c571f-3ac0-4de6-8de1-c23894f823d4</string>
-          <string>ff4672aa-a05f-428f-8427-3ad8033346cd</string>
-          <string>ffc6ec26-9bda-4da6-b9e5-20912920ab83</string>
-        </enabledChannelIds>
-        <disabledChannelIds class="sorted-set"/>
-        <codeTemplates>
-          <codeTemplate version="26.3.1">
-            <id>030add36-72d6-4bb4-8db4-aa0cc8b906c9</id>
-            <name>setErrorResponse</name>
-            <revision>15</revision>
-            <lastModified>
-              <time>1779700772800</time>
-              <timezone>America/New_York</timezone>
-            </lastModified>
-            <contextSet>
-              <delegate class="sorted-set">
-                <contextType>GLOBAL_DEPLOY</contextType>
-                <contextType>GLOBAL_UNDEPLOY</contextType>
-                <contextType>GLOBAL_PREPROCESSOR</contextType>
-                <contextType>GLOBAL_POSTPROCESSOR</contextType>
-                <contextType>CHANNEL_DEPLOY</contextType>
-                <contextType>CHANNEL_UNDEPLOY</contextType>
-                <contextType>CHANNEL_PREPROCESSOR</contextType>
-                <contextType>CHANNEL_POSTPROCESSOR</contextType>
-                <contextType>CHANNEL_ATTACHMENT</contextType>
-                <contextType>CHANNEL_BATCH</contextType>
-                <contextType>SOURCE_RECEIVER</contextType>
-                <contextType>SOURCE_FILTER_TRANSFORMER</contextType>
-                <contextType>DESTINATION_FILTER_TRANSFORMER</contextType>
-                <contextType>DESTINATION_DISPATCHER</contextType>
-                <contextType>DESTINATION_RESPONSE_TRANSFORMER</contextType>
-              </delegate>
-            </contextSet>
-            <properties class="com.mirth.connect.model.codetemplates.BasicCodeTemplateProperties">
-              <type>FUNCTION</type>
-              <code>/**
-	Util function to set error response.
-
-	@param {Any} statusCode - 
-	@param {Any} errorMessage - 
-	@param {Any} map - 
-	@return {Any} 
-*/
-function setErrorResponse(statusCode, errorMessage, map) {
-    var targetMap = map || responseMap;
-
-    var json = createJsonResponse(statusCode, errorMessage);
-    targetMap.put(&apos;status&apos;, String(statusCode));
-    targetMap.put(&apos;responseStatusCode&apos;, statusCode);
-    targetMap.put(&apos;fhirResponse&apos;, json);
-    targetMap.put(&apos;finalResponse&apos;, json);
-}
-/**
- Util function to generate json string wit hstatus and message
-*/
-function createJsonResponse(status, message) {
-    return JSON.stringify({ status: status, message: message });
-}</code>
-            </properties>
-          </codeTemplate>
-        </codeTemplates>
-      </codeTemplateLibrary>
-      <codeTemplateLibrary version="26.3.1">
-        <id>d56d125c-b75a-4803-9038-3a65e9bfbbb5</id>
-        <name>UuidUtil</name>
-        <revision>155</revision>
-        <lastModified>
-          <time>1781934314643</time>
-          <timezone>America/New_York</timezone>
-        </lastModified>
-        <description></description>
-        <includeNewChannels>false</includeNewChannels>
-        <enabledChannelIds class="sorted-set">
-          <string>00340250-ce9b-4d83-a27b-a49a7cb1fa1f</string>
-          <string>0bf51702-45a6-4f42-adc2-69345112767e</string>
-          <string>0f01102b-8ef8-4237-a8c8-0e79c35be41d</string>
-          <string>0f97d63c-b506-4b71-aa83-bfe95b9c08a5</string>
-          <string>10127606-0967-4ced-ae19-1686228f545d</string>
-          <string>101406b4-312a-4517-ab69-686051a91483</string>
-          <string>1152ba78-3231-4a99-8ec3-319c0f69e011</string>
-          <string>12467de6-360c-47c1-83af-09aae915eb8c</string>
-          <string>140795e4-5d41-4769-885b-b815c18bbc62</string>
-          <string>14db49f5-496c-4b12-a5e9-f9b33b30ba94</string>
-          <string>1886486f-4cbd-4e25-9057-ebd6cc6f6478</string>
-          <string>19069366-0852-4caa-875c-1c503461f8a1</string>
-          <string>1908260b-7361-46dc-a9c9-e7114b06e698</string>
-          <string>1b228707-c844-4b09-b9e4-55878038d31f</string>
-          <string>1e3ad8e1-3be1-44d2-b2da-bf5750a353c8</string>
-          <string>1ec01527-8a44-4184-a05a-2a91c04f37df</string>
-          <string>1f0f044e-687d-41d6-b19f-9935b8b9936d</string>
-          <string>207ba60a-9430-4126-9553-8c8eb588f419</string>
-          <string>20d4fc56-4e53-408c-a8a0-20ef046f9fa5</string>
-          <string>2154b64c-8539-4320-86f4-8a0b9b706ad0</string>
-          <string>29316ddf-46cc-4d33-813d-2b71a8b41902</string>
-          <string>29d0e04a-e2be-43ad-b814-bfe242963c90</string>
-          <string>30c99bf7-8d1a-45c6-b391-e2b88b1103ea</string>
-          <string>32a3cbc1-921f-441c-8e68-3bda27e63ee6</string>
-          <string>32ad2913-1c3d-43d8-b5f8-2672f3325557</string>
-          <string>3300d437-9001-4bd1-9ca8-31635d1dc92a</string>
-          <string>330819e8-5e01-45b0-9d7d-b87048a8813a</string>
-          <string>353f2542-73dd-44df-bb8b-361756233a37</string>
-          <string>35ee3e0b-ad66-44c5-bf30-6ebe8ff7c7ec</string>
-          <string>39491051-e8fb-4f70-aea5-82ed1a454324</string>
-          <string>3acb72be-f9c1-4721-b990-ff0486b038fc</string>
-          <string>3bc69658-cba9-4fa2-8d32-438ab4660c2a</string>
-          <string>3bfca654-f2c7-4c5e-bb88-1ab68cd32f44</string>
-          <string>3cbc2ace-4a86-4ef9-839a-2aa4feac2ee3</string>
-          <string>3f02fbc3-ac50-40cc-a9bd-6c57a921c920</string>
-          <string>3fabdfd3-3a99-4dec-a769-b9c8e87978d8</string>
-          <string>423ef464-a171-4cb9-ae32-616aca66ea05</string>
-          <string>45c0836b-0e92-4861-9e58-16898e1e0835</string>
-          <string>461db608-904d-41c3-a9f5-d1c23a450ce9</string>
-          <string>48098091-34dc-4d63-b9a9-c6201f0c0fa4</string>
-          <string>4cd30607-97b1-44ad-9d8f-4cfc7dfa4028</string>
-          <string>4d14f82e-6781-4b35-9a2d-b5424903d1db</string>
-          <string>4d4a6df4-774e-4cbd-b7aa-4ce0314d8faa</string>
-          <string>4dd74674-782c-4b6a-8782-11352b7bdcad</string>
-          <string>520ded48-a0be-4492-8cba-4fad5a227afd</string>
-          <string>548ec946-51d0-4c8b-a402-78345d8f0242</string>
-          <string>576131f3-aa5b-4453-929f-1e07d7534e82</string>
-          <string>5857b379-7fd2-4000-b627-57b89f33892e</string>
-          <string>58670b9c-5015-4e1b-ba6f-6e025c9b884c</string>
-          <string>5cf24505-f00b-4002-a769-836686016c37</string>
-          <string>5fe06d80-d0e4-473e-89ff-11cc69bbf4bc</string>
-          <string>60a18eb3-bf79-4c99-9bec-55fe0df4813f</string>
-          <string>61730c66-eedd-4c67-bb98-71c867be56a4</string>
-          <string>6432709e-b815-40a3-91a8-f77570d3273e</string>
-          <string>6504ba62-2e9e-42cc-9b65-09e832b1f27a</string>
-          <string>66b6457a-d8a4-40fb-bf4a-7fd09c941285</string>
-          <string>66bd741d-7d06-4fce-84ee-aff81a32606f</string>
-          <string>6a2535d6-2995-4464-a455-8bb815ec76bb</string>
-          <string>6ba3d163-f959-4b4f-9aca-f9bcdc5e7887</string>
-          <string>6d5b9010-726f-44b6-b81a-2bd2c6a17003</string>
-          <string>6db40d54-c29f-47e3-aaf8-fc99cb2e53b6</string>
-          <string>6df6b37f-e6df-4648-a7e1-67715a4e3157</string>
-          <string>715fe7c8-223a-4949-a669-f1defb24cd95</string>
-          <string>71d75aee-a90e-4800-86cd-ec4d4ff8ba0c</string>
-          <string>734712b9-75bb-4eb5-b31e-0951c9287df3</string>
-          <string>789c27f9-3fbd-4c76-9252-833d4f388d81</string>
-          <string>7b87138a-7964-457e-a1df-e14fffac8163</string>
-          <string>7bfc4fca-cf0a-4caf-b297-b4579d23684c</string>
-          <string>7c9a7dc3-d5f3-4477-9298-4c927e0e0f9f</string>
-          <string>7f9360b4-e80f-4bbb-951f-58347ab2ca5a</string>
-          <string>7ffeeda4-e8e9-4534-8cf0-28eb8ce65510</string>
-          <string>8255fb74-da31-4573-ba36-1da03f1bfc27</string>
-          <string>829b3dbc-9d02-41b4-aa52-e9cbcc0f727b</string>
-          <string>82b69ddf-fe55-4127-8e9a-8af05c09c91e</string>
-          <string>869c806f-d639-44ea-93d7-9efbe211cc3c</string>
-          <string>893ca03e-5b1d-4aa0-9fbe-705d7e0ed910</string>
-          <string>89def8c9-d8d2-46e2-a254-6345b05cfcb4</string>
-          <string>8ad98540-6ea5-4008-98f7-7f7769ae5e6b</string>
-          <string>8af30ec7-ad08-4ac8-9604-3ddd35f6d8b2</string>
-          <string>8be2be72-35cf-44a6-8b6e-5e37bd770672</string>
-          <string>8ff42419-20be-4845-b40c-77853eb27b35</string>
-          <string>91adead5-81ab-44f2-b3ac-f875a620846c</string>
-          <string>92bad760-5de9-4b86-91f4-33011e68ca43</string>
-          <string>94d93cc7-9346-4ed6-81f0-767364a29138</string>
-          <string>95deaa8d-3907-4b7e-bd01-bbf5d507a474</string>
-          <string>96bd9c4c-3490-4ed9-9efe-4179e3d7d33d</string>
-          <string>96e9f4cf-2505-4620-b232-542e62dc0a1a</string>
-          <string>9a7e7b61-5745-4e29-a7e1-43a7d61b60ba</string>
-          <string>9c85680a-7b06-43fb-9d12-01db1d9c0448</string>
-          <string>9cbcd82b-a20e-4120-9d81-7c6698dfc1dd</string>
-          <string>9f99a5c7-84d9-4dc2-aa7f-451096b5bb8b</string>
-          <string>a042f8c0-b45a-491e-aaff-1c30aca5d9b4</string>
-          <string>a0b29ee9-cd50-4228-8de1-c890131f4350</string>
-          <string>a1a84018-fd6b-4e23-80c8-3bc046c95d4c</string>
-          <string>a1baa618-66f4-4c94-8cd9-5a4789641978</string>
-          <string>a1bf0b83-9809-4841-b748-41ee68cb1765</string>
-          <string>a37c9500-353f-4cec-828a-4b377007e7fa</string>
-          <string>a3ed3ccb-86a4-432f-82b4-e90e10e148db</string>
-          <string>a4742eec-0523-45be-a37e-1f3c03b80f20</string>
-          <string>a498cdfc-84a5-43fd-aad8-2487de0def89</string>
-          <string>a4d249da-533e-4b9f-917c-3ad75d22767f</string>
-          <string>a5b2ab2c-b422-4614-ac3c-c7b0876c8579</string>
-          <string>a6980fc6-a738-4a01-9868-79bc098175cb</string>
-          <string>a7141bac-fe8d-4df6-81cd-dee54b0d09be</string>
-          <string>abe04006-4dc5-462a-88f6-93fdefb35933</string>
-          <string>ac361d6f-fc34-44f1-9029-589b680d7a2a</string>
-          <string>ac75ecb3-2a29-4a75-b056-61895a4ccc0c</string>
-          <string>af622c7c-a713-4fe6-a12c-3d8b199efc75</string>
-          <string>b84ee0f0-dfed-40bd-8a9e-af052b60860e</string>
-          <string>b947708e-312d-4458-aef3-93761eb9fe9c</string>
-          <string>bb812d5c-9a11-4e21-a134-c369f39dc5b3</string>
-          <string>bbf0fb0d-7a57-43c4-b3b0-2e0d257ae92b</string>
-          <string>bbfc8cdc-e671-46da-bae3-75de9ae91b85</string>
-          <string>bd874ffb-6649-4374-91d8-0506a3bce00c</string>
-          <string>c00e53b6-6165-4bb3-bd47-7f1e5d9708d4</string>
-          <string>c09ea42f-cb4b-4f67-92cd-830a1ab4c51c</string>
-          <string>c156a7a7-d1ac-49ce-a70f-cb2c1eb800cf</string>
-          <string>c1f9232a-b3c0-4c95-bf75-8eeaafd92d6f</string>
-          <string>c45aaeca-50e4-4674-8294-8bae37a0e431</string>
-          <string>c50e41d7-9fb2-4899-84f8-38909d092722</string>
-          <string>c803772f-c1a5-4aee-ac52-f2cddc53c690</string>
-          <string>c9f1cab2-3a34-488a-9a55-6a4b01369ff0</string>
-          <string>cae36153-f409-4659-a031-fa40ebb8f7da</string>
-          <string>cbf715dc-b53b-47bb-910c-433f58588fd3</string>
-          <string>d320f5d3-7af1-4de1-b618-6ed11e84390d</string>
-          <string>d341dceb-069e-49ab-8efa-c45398145216</string>
-          <string>d8205661-526c-4762-bef0-0cb8414424cb</string>
-          <string>dc1d3367-14d7-4e36-a87e-d208d839fc78</string>
-          <string>dd22c442-ee54-4c80-b221-a2b30b889b79</string>
-          <string>dfa0f0a0-c211-4aa2-bb6c-444d5c23da7e</string>
-          <string>e0db16bd-35c7-4cc9-9874-79b6fb154472</string>
-          <string>e3a5613e-0da0-4921-a270-b48cf72253de</string>
-          <string>e59911f1-dff0-41de-b8ee-89f466f47a15</string>
-          <string>eb2f5490-8909-4216-b65a-5947fb0f359e</string>
-          <string>edfa461f-e71c-491e-a3cb-e9a2cdb49418</string>
-          <string>edfea1b1-a0d7-46b3-913a-61b50ddadf1f</string>
-          <string>f23e19b0-a0e0-422a-884c-caae6c52ecac</string>
-          <string>f376f9cc-b848-4868-ac1c-e2c011665fc5</string>
-          <string>f4770f98-f7b8-4070-be28-ebd8e3919864</string>
-          <string>fa2e04e2-8435-4a9c-bad2-ac65c1bb3a33</string>
-          <string>fa6d8035-8b04-4740-9eb0-4dbb71c69bb6</string>
-          <string>fbb1665a-1e80-482a-adb5-719687ffabaf</string>
-          <string>ff4672aa-a05f-428f-8427-3ad8033346cd</string>
-          <string>ffc6ec26-9bda-4da6-b9e5-20912920ab83</string>
-        </enabledChannelIds>
-        <disabledChannelIds class="sorted-set">
-          <string>00389d41-c2ce-45c7-a702-353b449b1026</string>
-          <string>01fbb835-f605-4376-84eb-9c4affcf159e</string>
-          <string>04ef5b0d-3120-4dd4-ba3f-fd7ec1ab1fdb</string>
-          <string>158a1edb-a782-4fb4-bc18-f05f40ce3e18</string>
-          <string>1c406954-d304-4882-b05d-b513d699785b</string>
-          <string>2240d25e-de1d-4c6f-904c-832e7f68a574</string>
-          <string>2b4ff91f-4f33-48c2-ba05-2f0cdfd1120b</string>
-          <string>2d6fac85-49e1-4aa8-b39f-b4e39f12597e</string>
-          <string>3322c442-7c6e-46b4-b6d1-f0cff8c4741d</string>
-          <string>38c30482-47ef-41e0-b6f3-fa56e8bc76ae</string>
-          <string>3f3f6dcd-2923-4f09-89c3-1e248c1556b3</string>
-          <string>4c2ba30f-c175-44b4-a740-0297048c7969</string>
-          <string>50e1c70e-7b48-4ed0-be9e-309710a85195</string>
-          <string>657d9972-aa59-406d-b248-22f39bbceed2</string>
-          <string>784f3cf4-180a-4ea3-b519-f12626b33dcc</string>
-          <string>78fd5c66-613e-46dd-bd45-c3dd0021a5fb</string>
-          <string>87d008ec-f78d-4f2f-b986-cb1a4d926540</string>
-          <string>89118684-3b07-4336-ab6e-c06a1d9c0440</string>
-          <string>8ca393c1-16ac-4b77-b78f-a8fca05ae3d6</string>
-          <string>95b30942-c7ab-4267-8dc8-7e9436e0f470</string>
-          <string>9608b1d8-a780-4093-a7b2-14412f61e0ea</string>
-          <string>a2eede47-0ee3-4345-b6c2-92c07c553950</string>
-          <string>ab20f626-8de4-4845-8080-0f2c6b80669a</string>
-          <string>ac705673-f0a4-4cc1-aa75-8a92badefe1a</string>
-          <string>b1be1080-160c-42e5-a1fb-b82439b1757e</string>
-          <string>bafa98dd-04f2-48ef-babb-4a3bedbcb0ed</string>
-          <string>bfe53f29-12c4-4575-856b-64c5700f2564</string>
-          <string>c56c8654-6ece-4975-bdad-29ef940c7081</string>
-          <string>c79799dd-a972-4d99-beba-1331ed5e49a2</string>
-          <string>cd224bbd-4d5c-46b7-99c5-ed3ec89e6d06</string>
-          <string>d3a8414c-8bcd-40c8-b806-5d163a5dbab1</string>
-          <string>d5c743d6-4c79-46da-b6be-754973d7a735</string>
-          <string>d85d0014-300a-46f9-81b7-ad6c6ef1516b</string>
-          <string>e634b038-8196-4ac4-80fc-819a0a9c9bb1</string>
-          <string>f26f4d16-f640-4f02-b654-3d5ef8f9dc54</string>
-          <string>f2d185dd-96c3-4065-bbb9-5044afb7ba80</string>
-          <string>fe3c571f-3ac0-4de6-8de1-c23894f823d4</string>
-        </disabledChannelIds>
-        <codeTemplates>
-          <codeTemplate version="26.3.1">
-            <id>5094a1a4-a8c6-4818-b26f-2a773e673ef3</id>
-            <name>Uuid Generator Instance</name>
-            <revision>1</revision>
-            <lastModified>
-              <time>1776844786916</time>
-              <timezone>America/New_York</timezone>
-            </lastModified>
-            <contextSet>
-              <delegate class="sorted-set">
-                <contextType>GLOBAL_DEPLOY</contextType>
-                <contextType>GLOBAL_UNDEPLOY</contextType>
-                <contextType>GLOBAL_PREPROCESSOR</contextType>
-                <contextType>GLOBAL_POSTPROCESSOR</contextType>
-                <contextType>CHANNEL_DEPLOY</contextType>
-                <contextType>CHANNEL_UNDEPLOY</contextType>
-                <contextType>CHANNEL_PREPROCESSOR</contextType>
-                <contextType>CHANNEL_POSTPROCESSOR</contextType>
-                <contextType>CHANNEL_ATTACHMENT</contextType>
-                <contextType>CHANNEL_BATCH</contextType>
-                <contextType>SOURCE_RECEIVER</contextType>
-                <contextType>SOURCE_FILTER_TRANSFORMER</contextType>
-                <contextType>DESTINATION_FILTER_TRANSFORMER</contextType>
-                <contextType>DESTINATION_DISPATCHER</contextType>
-                <contextType>DESTINATION_RESPONSE_TRANSFORMER</contextType>
-              </delegate>
-            </contextSet>
-            <properties class="com.mirth.connect.model.codetemplates.BasicCodeTemplateProperties">
-              <type>FUNCTION</type>
-              <code>function getUuidGenerator() {
-    var generator = globalMap.get(&apos;UUID_GENERATOR&apos;);
-
-    if (generator == null) {
-        var Generators = Packages.com.fasterxml.uuid.Generators;
-        generator = Generators.timeBasedEpochGenerator();
-
-        globalMap.put(&apos;UUID_GENERATOR&apos;, generator);
-        logger.info(&apos;UUID Generator initialized ONCE&apos;);
-    }
-
-    return generator;
-}
-
-function generateUuid() {
-    return getUuidGenerator().generate().toString();
-}</code>
-            </properties>
-          </codeTemplate>
-        </codeTemplates>
-      </codeTemplateLibrary>
-    </codeTemplateLibraries>
     <channelTags>
       <channelTag>
-        <id>d67bd48a-1bda-42de-87bc-9346a7ef2b25</id>
-        <name>0_9_28</name>
+        <id>6e1e8780-4772-4778-abe3-3d6c974c70b5</id>
+        <name>0_9_29</name>
         <channelIds>
           <string>00340250-ce9b-4d83-a27b-a49a7cb1fa1f</string>
         </channelIds>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -38,9 +38,9 @@
     {
       "type": "FLAT FILE",
       "channel": "FlatFileCsvBundle.xml",
-      "version": "0.9.28",
-      "editedby": "abhiramisanthosh90",
-      "date": "2026-06-22"
+      "version": "0.9.29",
+      "editedby": "Nikhithaprojects9696",
+      "date": "2026-07-07"
     },
     {
       "type": "FLAT FILE",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1187.0</revision>
+        <revision>0.1188.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Fixed empty header values to be stored as null instead of empty strings in metadata.
- Corrected Base FHIR URL, Data Ledger Tracking,Data ledger diagnostics, Severity Level and Data Lake API URL header values to be stored and displayed correctly.
- Fixed Interaction ID display issue in the CSV Validate flow.
- Normalized request header metadata handling for consistent elaboration data storage.