### PR TITLE
fix: FusionAuth PostgreSQL RLS initialization for pooled database connections #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
@@ -150,7 +150,7 @@ public static String createAvatarUrl(DefaultOAuth2User oAuth2User) {
         String jsonAttributes = objectMapper.writerWithDefaultPrettyPrinter()
                 .writeValueAsString(oAuth2User.getAttributes());
         LOG.info("oAuth2User attributes (JSON):\n{}", jsonAttributes);
-        setRoleBasedOnFusionToken(jsonAttributes);
+        // setRoleBasedOnFusionToken(jsonAttributes);
 
     } catch (Exception e) {
         LOG.error("Failed to serialize attributes to JSON", e);

--- a/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
@@ -24,6 +24,8 @@ import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.techbd.service.http.hub.RlsInitializationFilter;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
  
@@ -39,6 +41,8 @@ public class SecurityConfig {
 
     @Autowired(required = false)
     private GitHubUserAuthorizationFilter gitHubUserAuthorizationFilter;
+    @Autowired
+private RlsInitializationFilter rlsInitializationFilter;
 
     public SecurityConfig(RolePermissionInterceptor rolePermissionInterceptor) {
         this.rolePermissionInterceptor = rolePermissionInterceptor;
@@ -118,7 +122,11 @@ public class SecurityConfig {
 
                     if (gitHubUserAuthorizationFilter != null) {
                         http.addFilterAfter(gitHubUserAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
-                    }    
+                    }   
+                    
+                    http.addFilterAfter(
+                           rlsInitializationFilter,
+            FusionAuthUserAuthorizationFilter.class);
         // allow us to show our own content in IFRAMEs (e.g. Swagger, etc.)
         http.headers(headers -> {
             headers.frameOptions(frameOptions -> frameOptions.sameOrigin());

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/RlsInitializationFilter.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/RlsInitializationFilter.java
@@ -1,0 +1,49 @@
+package org.techbd.service.http.hub;
+import java.io.IOException;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.techbd.service.http.FusionAuthUserAuthorizationFilter;
+import org.techbd.service.http.FusionAuthUsersService;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class RlsInitializationFilter extends OncePerRequestFilter {
+
+    private final FusionAuthUsersService fusionAuthUsersService;
+    private static final Logger LOG = LoggerFactory.getLogger(FusionAuthUserAuthorizationFilter.class);
+
+    public RlsInitializationFilter(FusionAuthUsersService fusionAuthUsersService) {
+        this.fusionAuthUsersService = fusionAuthUsersService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain)
+            throws ServletException, IOException {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof OAuth2AuthenticationToken token &&
+            token.getPrincipal() instanceof DefaultOAuth2User user) {
+
+            fusionAuthUsersService.setRoleFromCurrentUser(user);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1193.0</revision>
+        <revision>0.1194.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION

## Summary
This PR fixes PostgreSQL RLS initialization when using Hikari connection pooling with FusionAuth authentication.

## Changes
- Added `RlsInitializationFilter` to initialize the PostgreSQL session for every authenticated request.
- Executes `set_role_based_on_fusion_token()` using the authenticated FusionAuth user before database access.
- Registered the filter in the Spring Security filter chain after OAuth2 authentication.
- Removed RLS initialization logic from `RolePermissionInterceptor` to avoid authentication/session timing issues.

## Problem
With Hikari connection pooling, database connections are reused between requests. Since the PostgreSQL role and JWT claims are stored per database session, pooled connections could retain a previous user's security context, resulting in incorrect RLS behavior.

## Solution
The database role and JWT claims are now initialized for every authenticated request, ensuring the correct tenant and role are applied regardless of which pooled connection is borrowed.