### PR TITLE
fix: update interceptor configuration to exclude stateless API URLs #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/Constant.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/Constant.java
@@ -52,6 +52,9 @@ public class Constant {
         "/js/**",
         "/images/**",
         "/webjars/**",
+        "/Bundles/status/Bundle", "/Bundles/status/Bundle/**",
+        "/ccda/Bundle/**",
+        "/hl7v2/Bundle/**",
         "/fonts/**"
 };
 

--- a/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SecurityConfig.java
@@ -208,7 +208,8 @@ public class SecurityConfig {
             public void addInterceptors(InterceptorRegistry registry) {
                 registry.addInterceptor(rolePermissionInterceptor)
                         .addPathPatterns("/**")
-                        .excludePathPatterns(Constant.INTERCEPTOR_EXCLUDED_URLS);
+                        .excludePathPatterns(Constant.INTERCEPTOR_EXCLUDED_URLS)
+                        .excludePathPatterns(Constant.STATELESS_API_URLS);
             }
         };
     }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.1199.0</revision>
+        <revision>0.2000.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION


**Summary**

Fix the interceptor configuration to exclude stateless API endpoints from RolePermissionInterceptor.#1687

**Changes**
- Updated the interceptor configuration to exclude all stateless API URLs using Constant.STATELESS_API_URLS.
- Added missing CCDA and HL7v2 Bundle endpoints to INTERCEPTOR_EXCLUDED_URLS.
- Ensured REST/FHIR, CSV, CCDA, HL7v2, and other stateless APIs are not intercepted by session-based role permission validation.
- Prevented unintended redirects (/login, /logout, or Access Denied) for stateless endpoints.