### PR TITLE
feat: role-based navigation, dashboard visibility, and page redirection #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUserAuthorizationFilter.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUserAuthorizationFilter.java
@@ -1,9 +1,9 @@
 package org.techbd.service.http;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +86,7 @@ public class FusionAuthUserAuthorizationFilter extends OncePerRequestFilter {
                        if (!faUser.roles().isEmpty()) {
                             String role = faUser.roles().get(0);
                             // DB decides whether CONFIG pages should be included.
-                            Map<String, Set<String>> permissions =
+                           Map<String, List<ScreenPermission>> permissions =
                                     fusionAuthUsersService.getRolePermissions(role);
 
                             HttpSession session = request.getSession();

--- a/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
@@ -4,12 +4,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
@@ -216,8 +213,7 @@ public static String createAvatarUrl(DefaultOAuth2User oAuth2User) {
     }
 }
 
- @SuppressWarnings("null")
-public Map<String, Set<String>> getRolePermissions(String roleName) {
+public Map<String, List<ScreenPermission>> getRolePermissions(String roleName) {
 
             resetDatabaseSession();
            String sql = "techbd_udi_ingress.idp_get_login_role_permissions(?)::text";
@@ -232,14 +228,8 @@ public Map<String, Set<String>> getRolePermissions(String roleName) {
         }
 
         try {
-            Map<String, List<String>> parsed = objectMapper.readValue(response,
-                    new TypeReference<Map<String, List<String>>>() {});
-
-            return parsed.entrySet().stream()
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            e -> new HashSet<>(e.getValue())
-                    ));
+           return objectMapper.readValue(response,
+                new TypeReference<Map<String, List<ScreenPermission>>>() {} );
 
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse role permissions JSON from DB", e);

--- a/hub-prime/src/main/java/org/techbd/service/http/PermissionService.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/PermissionService.java
@@ -4,7 +4,6 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jooq.DSLContext;
@@ -13,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.techbd.service.http.RouteRegistry.RouteInfo;
 import org.techbd.service.http.hub.prime.route.RoutesTree.HtmlAnchor;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -99,16 +99,17 @@ public class PermissionService {
 
             String role = (String) session.getAttribute(Constant.USER_ROLE);
 
-            Map<String, Set<String>> allowedMenus = getAllowedMenus(session);
+            Map<String, List<ScreenPermission>> allowedMenus = getAllowedMenus(session);
 
             if (allowedMenus == null || allowedMenus.isEmpty()) {
                 LOG.warn("Role {} has no permissions configured. Returning empty links.", role);
                 return List.of();
             }
-            Set<String> allowedTopMenus = allowedMenus.keySet();
-            return allLinks.stream()
-                    .filter(link -> allowedTopMenus.contains(link.text()))
-                    .collect(Collectors.toList());
+           return allLinks.stream()
+            .filter(link ->
+                    "Dashboard".equals(link.text()) ||
+                    allowedMenus.containsKey(link.text()))
+            .collect(Collectors.toList());
 
         } catch (Exception e) {
             LOG.error("Error while filtering links by role", e);
@@ -116,6 +117,7 @@ public class PermissionService {
         }
     }
 
+    @SuppressWarnings("null")
     public boolean isAllowedForRole(String linkText, HttpServletRequest request) {
 
          if ("github".equalsIgnoreCase(authProvider)) {
@@ -131,19 +133,19 @@ public class PermissionService {
                 return false;
             }
 
-            // if (isSuperRole(session)) {
-            //     return true;
-            // }
             String role = (String) session.getAttribute(Constant.USER_ROLE);
 
-            Map<String, Set<String>> allowedMenus = getAllowedMenus(session);
+            Map<String, List<ScreenPermission>> allowedMenus = getAllowedMenus(session);
 
             if (allowedMenus == null || allowedMenus.isEmpty()) {
                 LOG.warn("Role {} has no permissions configured. Denying access to {}", role, linkText);
                 return false;
             }
-            return allowedMenus.values().stream()
-                    .anyMatch(subMenus -> subMenus.contains(linkText));
+           return allowedMenus.values().stream()
+            .flatMap(List::stream)
+            .anyMatch(permission ->
+                    permission.screen().equals(linkText) ||
+                    permission.children().contains(linkText));
 
         } catch (Exception e) {
             LOG.error("Error while checking access for link {}", linkText, e);
@@ -155,8 +157,21 @@ public class PermissionService {
         return Boolean.TRUE.equals(session.getAttribute(Constant.SUPER_ROLE));
     }
 
-    @SuppressWarnings("unchecked")
-    private Map<String, Set<String>> getAllowedMenus(HttpSession session) {
-        return (Map<String, Set<String>>) session.getAttribute(Constant.ROLE_PERMISSIONS);
+   @SuppressWarnings("unchecked")
+    private Map<String, List<ScreenPermission>> getAllowedMenus(HttpSession session) {
+        return (Map<String, List<ScreenPermission>>) session.getAttribute(Constant.ROLE_PERMISSIONS);
     }
+
+    public String getDefaultRoute(String parentPath, HttpServletRequest request) {
+           
+        List<RouteInfo> routes = RouteRegistry.getChildRoutes(parentPath);
+            for(RouteInfo route : routes) {
+                if(isAllowedForRole(
+                        route.mapping().label(),
+                        request)) {
+                    return route.path();
+                }
+            }
+            return "/home";
+        }
 }

--- a/hub-prime/src/main/java/org/techbd/service/http/RolePermissionInterceptor.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/RolePermissionInterceptor.java
@@ -1,7 +1,7 @@
 package org.techbd.service.http;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -52,14 +52,10 @@ public class RolePermissionInterceptor implements HandlerInterceptor {
             return false;
         }
 
-        // if (Boolean.TRUE.equals(isSuperRole)) {
-        //     return true;
-        // }
-
         String role = (String) session.getAttribute(Constant.USER_ROLE);
 
-        Map<String, Set<String>> rolePermissions = (Map<String, Set<String>>) session
-                .getAttribute(Constant.ROLE_PERMISSIONS);
+         Map<String, List<ScreenPermission>> rolePermissions =
+        (Map<String, List<ScreenPermission>>) session.getAttribute(Constant.ROLE_PERMISSIONS);
         RouteMapping rm = RouteRegistry.getRouteMapping(uri);
         if (rm != null) {
             String label = rm.label();
@@ -67,13 +63,6 @@ public class RolePermissionInterceptor implements HandlerInterceptor {
             if ("Settings".equals(label) || "Profile".equals(label)) {
                 return true;
             }
-
-            // Roles page is restricted to Super Admin only
-            // if ("Roles".equals(label)) {
-            //     LOG.warn("Access denied for role {} to Roles page", role);
-            //     response.sendRedirect("/settings/profile");
-            //     return false;
-            // }
         }
         if (rolePermissions == null || rolePermissions.isEmpty()) {
             LOG.warn("Role {} has no permissions, blocking access to {}", role, uri);
@@ -86,8 +75,10 @@ public class RolePermissionInterceptor implements HandlerInterceptor {
             return true; // allow non-annotated routes
         }
 
-        String label = rm.label(); // get the tab/menu name
-
+        String label = rm.label();
+        if(label.equals("Dashboard")) {
+            return true;
+        }
         // Check if label exists as a key in rolePermissions
         if (rolePermissions.containsKey(label)) {
             LOG.debug("Access granted for role {} to menu/tab '{}'", role, label);
@@ -95,16 +86,22 @@ public class RolePermissionInterceptor implements HandlerInterceptor {
         }
 
         // Check if label exists in any of the values (submenus) in rolePermissions
-        boolean allowedInValues = rolePermissions.values().stream()
-                .anyMatch(subMenus -> subMenus.contains(label));
+        @SuppressWarnings("null")
+       boolean allowed = rolePermissions.values().stream()
+        .flatMap(List::stream)
+        .anyMatch(permission ->
+                label.equals(permission.screen()) ||
+                (permission.children() != null &&
+                 permission.children().contains(label)));
 
-        if (allowedInValues) {
-            LOG.debug("Access granted for role {} to submenu '{}'", role, label);
-            return true;
-        }
 
-        LOG.warn("Access denied for role {} to tab '{}'", role, label);
-        response.sendRedirect("/home");
-        return false;
+            if (allowed) {
+                LOG.debug("Access granted for role {} to '{}'", role, label);
+                return true;
+            }
+
+            LOG.warn("Access denied for role {} to '{}'", role, label);
+            response.sendRedirect("/home");
+            return false;
     }
 }

--- a/hub-prime/src/main/java/org/techbd/service/http/RouteRegistry.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/RouteRegistry.java
@@ -1,7 +1,10 @@
 package org.techbd.service.http;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.aop.support.AopUtils;
@@ -18,30 +21,92 @@ import org.techbd.service.http.hub.prime.route.RouteMapping;
 @Component
 public class RouteRegistry implements ApplicationContextAware {
 
-    private static final Map<String, RouteMapping> routeLookup = new HashMap<>();
+
+    private static final Map<String, RouteMapping> routeLookup = new LinkedHashMap<>();
+    private static final Map<String, List<RouteInfo>> childRouteLookup = new LinkedHashMap<>();
+
+    public record RouteInfo(
+            String path,
+            RouteMapping mapping) {
+    }
 
     @Override
-    public void setApplicationContext(ApplicationContext context) throws BeansException {
+    public void setApplicationContext(ApplicationContext context)
+            throws BeansException {
+
         Map<String, Object> controllers = context.getBeansWithAnnotation(Controller.class);
 
         for (Object controller : controllers.values()) {
+
             Class<?> targetClass = AopUtils.getTargetClass(controller);
 
-            for (Method m : targetClass.getDeclaredMethods()) {
-                RouteMapping rm = AnnotationUtils.findAnnotation(m, RouteMapping.class);
-                GetMapping gm = AnnotationUtils.findAnnotation(m, GetMapping.class);
+            for (Method method : targetClass.getDeclaredMethods()) {
 
-                if (rm != null && gm != null && gm.value().length > 0) {
-                    String path = gm.value()[0]; // e.g. "/console/schema"
-                    routeLookup.put(path, rm);
+                RouteMapping routeMapping = AnnotationUtils.findAnnotation(
+                        method,
+                        RouteMapping.class);
 
-                    System.out.println("Mapped route: " + path + " -> " + rm);
+                GetMapping getMapping = AnnotationUtils.findAnnotation(
+                        method,
+                        GetMapping.class);
+
+                if (routeMapping != null
+                        && getMapping != null
+                        && getMapping.value().length > 0) {
+
+                    String path = getMapping.value()[0];
+
+                    routeLookup.put(path, routeMapping);
+                    registerChildRoute(path, routeMapping);
+
+                    System.out.println(
+                            "Mapped route: "
+                                    + path
+                                    + " -> "
+                                    + routeMapping);
                 }
             }
         }
     }
 
+    private void registerChildRoute(
+            String path,
+            RouteMapping mapping) {
+
+        String parentPath = getParentPath(path);
+
+        if (parentPath == null) {
+            return;
+        }
+
+        childRouteLookup
+                .computeIfAbsent(
+                        parentPath,
+                        key -> new ArrayList<>()) .add(new RouteInfo(path, mapping));
+
+        childRouteLookup
+                .get(parentPath)
+                .sort(Comparator.comparingInt( route -> route.mapping().siblingOrder()));
+    }
+
+    private String getParentPath(String path) {
+
+        int index = path.lastIndexOf('/');
+
+        if (index <= 0) {
+            return null;
+        }
+        return path.substring(0, index);
+    }
+
+
     public static RouteMapping getRouteMapping(String uri) {
         return routeLookup.get(uri);
+    }
+
+    public static List<RouteInfo> getChildRoutes(String parentPath) {
+
+        return childRouteLookup
+                .getOrDefault(parentPath, List.of());
     }
 }

--- a/hub-prime/src/main/java/org/techbd/service/http/ScreenPermission.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/ScreenPermission.java
@@ -1,0 +1,8 @@
+package org.techbd.service.http;
+
+import java.util.List;
+
+public record ScreenPermission(
+        String screen,
+        List<String> children
+) {}

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/ConsoleController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/ConsoleController.java
@@ -2,9 +2,14 @@ package org.techbd.service.http.hub.prime.ux;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.techbd.service.http.PermissionService;
 import org.techbd.service.http.hub.prime.route.RouteMapping;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,16 +30,31 @@ public class ConsoleController {
             .build();
 
     private final Presentation presentation;
+    private final PermissionService permissionService;
 
-    public ConsoleController(final Presentation presentation) throws Exception {
+    public ConsoleController(final Presentation presentation, final PermissionService permissionService) throws Exception {
         this.presentation = presentation;
+        this.permissionService = permissionService;
     }
 
     @RouteMapping(label = "Console", siblingOrder = 80)
     @GetMapping("/console")
-    public String docs() {
+    public String docs(HttpServletRequest request) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof OAuth2AuthenticationToken token
+            && token.getPrincipal() instanceof DefaultOAuth2User user) {
+
+        String authProvider = (String) user.getAttribute("authProvider");
+
+        if ("github".equalsIgnoreCase(authProvider)) {
         return "redirect:/console/health-info";
+        }
     }
+        return "redirect:" +
+           permissionService.getDefaultRoute(
+                "/console",
+                request
+           );    }
 
      @RouteMapping(label = "Health Information", title = "Health Information", siblingOrder = 30)
     @GetMapping("/console/health-info")

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/ContentController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/ContentController.java
@@ -5,10 +5,15 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.techbd.orchestrate.sftp.SftpManager;
+import org.techbd.service.http.PermissionService;
 import org.techbd.service.http.SandboxHelpers;
 import org.techbd.service.http.hub.prime.route.RouteMapping;
 
@@ -23,11 +28,13 @@ public class ContentController {
     private static final Logger LOG = LoggerFactory.getLogger(DataQualityController.class.getName());
 
     private final Presentation presentation;
-
+    private final PermissionService permissionService;
     public ContentController(final Presentation presentation,
             @SuppressWarnings("PMD.UnusedFormalParameter") final SftpManager sftpManager,
-            @SuppressWarnings("PMD.UnusedFormalParameter") final SandboxHelpers sboxHelpers) {
+            @SuppressWarnings("PMD.UnusedFormalParameter") final SandboxHelpers sboxHelpers,
+            final PermissionService permissionService) {
         this.presentation = presentation;
+        this.permissionService = permissionService;
     }
 
     public List<String> getValuesForField(String field) {
@@ -37,8 +44,23 @@ public class ContentController {
 
     @GetMapping("/content")
     @RouteMapping(label = "Content", siblingOrder = 9)
-    public String fhirContent() {
+    public String fhirContent( final HttpServletRequest request) {
+    
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof OAuth2AuthenticationToken token
+            && token.getPrincipal() instanceof DefaultOAuth2User user) {
+
+        String authProvider = (String) user.getAttribute("authProvider");
+
+        if ("github".equalsIgnoreCase(authProvider)) {
         return "redirect:/content/screenings";
+        }
+    }
+    return "redirect:" +
+           permissionService.getDefaultRoute(
+                "/content",
+                request
+           );
     }
 
     @GetMapping("/content/screenings")

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DataQualityController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DataQualityController.java
@@ -5,10 +5,15 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.techbd.orchestrate.sftp.SftpManager;
+import org.techbd.service.http.PermissionService;
 import org.techbd.service.http.SandboxHelpers;
 import org.techbd.service.http.hub.prime.route.RouteMapping;
 
@@ -22,11 +27,14 @@ public class DataQualityController {
     private static final Logger LOG = LoggerFactory.getLogger(DataQualityController.class.getName());
 
     private final Presentation presentation;
+    private final PermissionService permissionService;
 
     public DataQualityController(final Presentation presentation,
             @SuppressWarnings("PMD.UnusedFormalParameter") final SftpManager sftpManager,
-            @SuppressWarnings("PMD.UnusedFormalParameter") final SandboxHelpers sboxHelpers) {
+            @SuppressWarnings("PMD.UnusedFormalParameter") final SandboxHelpers sboxHelpers,
+            final PermissionService permissionService) {
         this.presentation = presentation;
+        this.permissionService = permissionService;
     }
 
     public List<String> getValuesForField(String field) {
@@ -36,10 +44,24 @@ public class DataQualityController {
 
     @GetMapping("/data-quality")
     @RouteMapping(label = "Data Quality", siblingOrder = 10)
-    public String adminDiagnostics() {
-        return "redirect:/data-quality/needs-attention";
-    }
+    public String adminDiagnostics(HttpServletRequest request) {
 
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof OAuth2AuthenticationToken token
+            && token.getPrincipal() instanceof DefaultOAuth2User user) {
+
+        String authProvider = (String) user.getAttribute("authProvider");
+
+        if ("github".equalsIgnoreCase(authProvider)) {
+        return "redirect:/data-quality/needs-attention";
+        }
+     }
+        return "redirect:" +
+           permissionService.getDefaultRoute(
+                "/data-quality",
+                request
+           );
+    }
     @GetMapping("/data-quality/needs-attention")
     @RouteMapping(label = "Needs Attention", title = "Needs Attention", siblingOrder = 5)
     public String diagnosticsFhirNeedsAttention(final Model model, final HttpServletRequest request) {

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DocsController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DocsController.java
@@ -16,11 +16,16 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.techbd.service.DocResourcesService;
+import org.techbd.service.http.PermissionService;
 import org.techbd.service.http.hub.prime.route.RouteMapping;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -48,17 +53,31 @@ public class DocsController {
 
     private final Presentation presentation;
     private final DocResourcesService drs;
+    private final PermissionService permissionService;
 
-    public DocsController(final Presentation presentation, final DocResourcesService drs) throws Exception {
+    public DocsController(final Presentation presentation, final DocResourcesService drs, final PermissionService permissionService) throws Exception {
         this.presentation = presentation;
         this.drs = drs;
+        this.permissionService = permissionService;
     }
 
     @RouteMapping(label = "Documentation", siblingOrder = 50)
     @GetMapping("/docs")
-    public String docs() {
-        return "redirect:/docs/swagger-ui/techbd-api";
+    public String docs(HttpServletRequest request) {
+  Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof OAuth2AuthenticationToken token
+            && token.getPrincipal() instanceof DefaultOAuth2User user) {
+
+        String authProvider = (String) user.getAttribute("authProvider");
+
+        if ("github".equalsIgnoreCase(authProvider)) {
+            return "redirect:/docs/swagger-ui/techbd-api";
+        }
     }
+
+    return "redirect:" +
+            permissionService.getDefaultRoute("/docs", request);
+    }    
 
     @RouteMapping(label = "Tech by Design Hub", title = "Business and Technology Documentation", siblingOrder = 0)
     @GetMapping("/docs/techbd-hub")

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/InteractionsController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/InteractionsController.java
@@ -5,10 +5,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.techbd.orchestrate.sftp.SftpManager;
+import org.techbd.service.http.PermissionService;
 import org.techbd.service.http.hub.prime.route.RouteMapping;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,24 +31,39 @@ public class InteractionsController {
     private final SftpManager sftpManager;
     private final DSLContext primaryDslContext;
     private final DSLContext secondaryDslContext;
-
+    private final PermissionService permissionService; 
    public InteractionsController(
         final Presentation presentation,
         final SftpManager sftpManager,
         @Qualifier("primaryDslContext") DSLContext primaryDslContext,
         @Autowired(required = false)
-        @Qualifier("secondaryDslContext") DSLContext secondaryDslContext) {
+        @Qualifier("secondaryDslContext") DSLContext secondaryDslContext,
+        final PermissionService permissionService) {
 
     this.presentation = presentation;
     this.sftpManager = sftpManager;
     this.primaryDslContext = primaryDslContext;
     this.secondaryDslContext = secondaryDslContext;
+    this.permissionService = permissionService;
 }
 
     @GetMapping("/interactions")
     @RouteMapping(label = "Interactions", siblingOrder = 20)
-    public String observeInteractions() {
-        return "redirect:/interactions/httpsfhir";
+    public String observeInteractions(HttpServletRequest request) {
+    
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof OAuth2AuthenticationToken token
+            && token.getPrincipal() instanceof DefaultOAuth2User user) {
+
+        String authProvider = (String) user.getAttribute("authProvider");
+
+        if ("github".equalsIgnoreCase(authProvider)) {
+            return "redirect:/interactions/httpsfhir";
+        }
+    }
+
+    return "redirect:" +
+            permissionService.getDefaultRoute("/interactions", request);
     }
 
     @GetMapping("/interactions/httpsfhir")
@@ -97,7 +117,19 @@ public class InteractionsController {
     @GetMapping("/interactions/observe")
     @RouteMapping(label = "Performance Overview", title = "Performance Overview", siblingOrder = 90)
     public String osberve(final Model model, final HttpServletRequest request) {
+
+     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+     if (authentication instanceof OAuth2AuthenticationToken token
+            && token.getPrincipal() instanceof DefaultOAuth2User user) {
+
+        String authProvider = (String) user.getAttribute("authProvider");
+
+        if ("github".equalsIgnoreCase(authProvider)) {
         return "redirect:/interactions/observe/api-performance";        
+        }
+    }
+    return "redirect:" +
+            permissionService.getDefaultRoute("/interactions/observe", request);
     }
 
     @GetMapping("/interactions/observe/api-performance")

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/Presentation.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/Presentation.java
@@ -91,9 +91,10 @@ public class Presentation {
             allowedLinks = permissionService.filterLinksByRole(navPrimeLinks, request);
         } else {
             // GitHub users should see the original navigation
-             allowedLinks = navPrimeLinks.stream()
-            .filter(link -> !"Settings".equals(link.text()))
-            .toList();        
+            allowedLinks = navPrimeLinks.stream()
+                    .filter(link -> !"Settings".equals(link.text()))
+                    .filter(link -> !shouldHideNavigationLink(link.text()))
+                    .toList();
         }
 
         model.addAttribute("navPrime", allowedLinks);
@@ -129,6 +130,13 @@ public class Presentation {
         return templateName;
     }
 
+    private boolean shouldHideNavigationLink(final String text) {
+        if (!"github".equalsIgnoreCase(authProvider)) {
+            return false;
+        }
+        return text != null && ("Monitoring".equalsIgnoreCase(text) || "Source Monitoring".equalsIgnoreCase(text));
+    }
+
     protected void registerActiveRoute(final Model model, final HttpServletRequest request) {
         final var activeRouteFound = navPrimeTree.findNode(request.getRequestURI());
         if (activeRouteFound.isEmpty()) {
@@ -156,6 +164,7 @@ public class Presentation {
                         .orElse(Integer.MAX_VALUE)))
                  .map(sibling -> new HtmlAnchor(sibling))
                 .filter(link -> permissionService.isAllowedForRole(link.text(), request))
+                .filter(link -> !shouldHideNavigationLink(link.text()))
                 .map(HtmlAnchor::intoMap)           
                 .collect(Collectors.toList());
 
@@ -165,6 +174,7 @@ public class Presentation {
                         .orElse(Integer.MAX_VALUE)))
                         .map(sibling -> new HtmlAnchor(sibling))
                         .filter(link -> permissionService.isAllowedForRole(link.text() , request))
+                        .filter(link -> !shouldHideNavigationLink(link.text()))
                         .map(HtmlAnchor::intoMap)
                         .collect(Collectors.toList()) : List.of();
 

--- a/hub-prime/src/main/resources/templates/page/home.html
+++ b/hub-prime/src/main/resources/templates/page/home.html
@@ -72,7 +72,9 @@
             <div>You're not logged in so you only have guest privileges.</div>
         </div>
 
-        <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl">
+        <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl"
+         th:if="${(#authentication.principal.attributes['authProvider'] == 'fusionauth'
+                    and #authentication.principal.attributes['isSuperRole']) or (#authentication.principal.attributes['authProvider'] == 'github')}">
             <div class="text-center font-bold">Recent Direct FHIR Bundles</div>
             <dl class="w-[100%] flex justify-between mt-5 grid gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
                 <div
@@ -93,7 +95,9 @@
             </dl>
         </div>
 
-        <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl">
+        <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl"
+         th:if="${(#authentication.principal.attributes['authProvider'] == 'fusionauth'
+                    and #authentication.principal.attributes['isSuperRole']) or (#authentication.principal.attributes['authProvider'] == 'github')}">
             <div class="text-center font-bold">Recent CSV FHIR Bundles</div>
             <dl class="w-[100%] flex justify-between mt-5 grid gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
                 <div
@@ -114,7 +118,9 @@
             </dl>
         </div>        
 
-         <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl">
+         <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl"
+          th:if="${(#authentication.principal.attributes['authProvider'] == 'fusionauth'
+                    and #authentication.principal.attributes['isSuperRole']) or (#authentication.principal.attributes['authProvider'] == 'github')}">
             <div class="text-center font-bold">Recent CCDA FHIR Bundles</div>
             <dl class="w-[100%] flex justify-between mt-5 grid gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
                 <div
@@ -135,7 +141,9 @@
             </dl>
         </div>  
 
-         <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl">
+         <div class="mt-8 flex flex-col justify-center pb-4 w-full max-w-9xl"
+          th:if="${(#authentication.principal.attributes['authProvider'] == 'fusionauth'
+                    and #authentication.principal.attributes['isSuperRole']) or (#authentication.principal.attributes['authProvider'] == 'github')}">
             <div class="text-center font-bold">Recent HL7v2 FHIR Bundles</div>
             <dl class="w-[100%] flex justify-between mt-5 grid gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
                 <div


### PR DESCRIPTION
## Summary

This PR enhances role-based navigation and access control for FusionAuth users.

### Changes
- Fixed page redirection to navigate users to the first permitted child page instead of always redirecting to the default page.
- Added support for child page redirection under nested menu structures (e.g., Performance Overview).
- Allowed Dashboard to be visible and accessible for all authenticated users.
- Restricted Home page tenant widgets to Super Admin and GitHub users, hiding them for normal users.
- Removed the Monitoring page for GitHub authenticated users.
- Updated navigation handling to support newly added child screens and their associated permissions.
- Improved route handling to support permission-aware navigation for parent and child menu items.