### PR TITLE
feat: add Swagger support for Historical Replay Bundle API and bump version to 0.2024.0 #3330

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/http/SwaggerConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SwaggerConfig.java
@@ -132,6 +132,7 @@ public class SwaggerConfig {
                 .pathsToMatch("/metadata", "/Bundles/status/nyec-submission-failed",
                 "/Bundles/status/operation-outcome",
                         "/Bundle", "/Bundle/**",
+                        "/historical-replay/Bundle", "/historical-replay/Bundle/**",
                         "/flatfile/csv/Bundle", "/flatfile/csv/Bundle/**",
                         "/api/expect/fhir/**","/tenants")
                 .addOpenApiCustomizer(openApi -> {

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/HistoricalReplayController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/HistoricalReplayController.java
@@ -40,7 +40,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.annotation.Nonnull;
 
 @Controller
-@Tag(name = "Historical Replay Endpoints", description = "Historical Replay FHIR Endpoints")
+@Tag(name = "Tech by Design Hub Historical Replay Endpoints", description = "Historical Replay FHIR Endpoints")
 public class HistoricalReplayController {
 
     private static final Logger LOG = LoggerFactory.getLogger(HistoricalReplayController.class);

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.2023.0</revision>
+        <revision>0.2024.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
- Added Swagger documentation for the Historical Replay Bundle API.
- Exposed optional request headers for Data Ledger processing and OperationOutcome filtering.
- Bumped project version to 0.2024.0.