### PR TITLE
feat: add tenant selection functionality and update navigation for tenant management #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/TenantController.java
+++ b/hub-prime/src/main/java/org/techbd/controller/http/hub/prime/api/TenantController.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.techbd.service.TenantService;
 
@@ -17,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 
 @RestController
 @Tag(name = "Tech by Design Hub Tenant Endpoints", description = "Tech by Design Hub Tenant Endpoints")
@@ -54,5 +58,17 @@ public class TenantController {
                     interactionId, e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    @PostMapping("/tenant/select")
+    @ResponseBody
+    public ResponseEntity<Void> selectTenant(@RequestBody Map<String, String> body, HttpSession session) {
+        String tenant = body.get("tenantName");
+
+        if (tenant != null && !tenant.isBlank()) {
+            session.setAttribute("activeTenant", tenant);
+            LOG.info("TENANT-CONTROLLER Selected tenant {} for session {}", tenant, session.getId());
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/FusionAuthUsersService.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.jooq.DSLContext;
-import org.jooq.JSONB;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,11 +35,7 @@ public class FusionAuthUsersService {
 
     @Value("${ORG_TECHBD_SERVICE_HTTP_FUSIONAUTH_BASE_URL}")
     private String fusionAuthBaseUrl;
-
-    @Value("${FUSIONAUTH_API_KEY}")
-     private String fusionAuthApiKey;
-
-
+    
     private static final Logger LOG = LoggerFactory.getLogger(FusionAuthUsersService.class);
     private static final ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new JavaTimeModule());
@@ -64,6 +59,7 @@ public class FusionAuthUsersService {
             List<String> roles,
             List<String> tenantIds,
             List<String> tenantNames,
+            String activeTenant,
             Boolean isSuperRole
             ) {
         }
@@ -79,6 +75,7 @@ public class FusionAuthUsersService {
                enrichedAttributes.put("role", user.roles());              
                enrichedAttributes.put("avatar_url", createAvatarUrl(oAuth2User));
                enrichedAttributes.put("authProvider", "fusionauth");
+               enrichedAttributes.put("activeTenant", user.activeTenant());
 
              
                DefaultOAuth2User enrichedOAuth2User = new DefaultOAuth2User(
@@ -118,27 +115,20 @@ public class FusionAuthUsersService {
     
     List<String> roles = Optional.ofNullable((List<String>) oAuth2User.getAttribute("roles"))
             .orElse(List.of());
-    // List<String> tenantIds =
-    //     Optional.ofNullable((List<String>) oAuth2User.getAttribute("tenantIds"))
-    //             .orElse(List.of());
+    List<String> tenantIds =
+        Optional.ofNullable((List<String>) oAuth2User.getAttribute("tenantIds"))
+                .orElse(List.of());
 
-    // List<String> tenantNames =
-    //     Optional.ofNullable((List<String>) oAuth2User.getAttribute("tenantNames"))
-    //             .orElse(List.of());
-      List<String> tenantIds = List.of(
-        "742a1edf-1662-4220-ac0c-b7093dc5db43",
-        "33e471a2-e4b5-4e58-9958-99fd7435766a",
-        "9cce8ca1-89d1-4793-8d9d-8f1bcfe004fd"
-            );
- 
-        List<String> tenantNames = List.of(
-            "netspective",
-            "netspective-dev",
-            "netspective-qa"
-        );    
+    List<String> tenantNames =
+        Optional.ofNullable((List<String>) oAuth2User.getAttribute("tenantNames"))
+                .orElse(List.of());
+
+    String activeTenant = tenantNames.isEmpty()
+        ? null
+        : tenantNames.get(0);
 
     LOG.info("oAuth2User attributes: {}", oAuth2User.getAttributes());
-                return new AuthorizedUser(userId, email, name, roles, tenantIds, tenantNames, isSuperRole);
+                return new AuthorizedUser(userId, email, name, roles, tenantIds, tenantNames, activeTenant, isSuperRole);
    } 
  
 
@@ -206,23 +196,23 @@ public static String createAvatarUrl(DefaultOAuth2User oAuth2User) {
     //     public String name;
     // }
 
-      public String setRoleBasedOnFusionToken(String tokenJson) {
-    try {
-        // Convert the raw JSON string to jOOQ's JSONB type
-        JSONB jsonbToken = JSONB.valueOf(tokenJson);
+//       public String setRoleBasedOnFusionToken(String tokenJson) {
+//     try {
+//         // Convert the raw JSON string to jOOQ's JSONB type
+//         JSONB jsonbToken = JSONB.valueOf(tokenJson);
 
-        // Call the PostgreSQL function
-        String role = dsl.select(
-                DSL.field("techbd_udi_ingress.set_role_based_on_fusion_token({0})", String.class, jsonbToken)
-        ).fetchOneInto(String.class);
+//         // Call the PostgreSQL function
+//         String role = dsl.select(
+//                 DSL.field("techbd_udi_ingress.set_role_based_on_fusion_token({0})", String.class, jsonbToken)
+//         ).fetchOneInto(String.class);
 
-        LOG.info("Postgres role set via FusionAuth token: {}", role);
-        return role;
-    } catch (Exception e) {
-        LOG.error("Error calling set_role_based_on_fusion_token with token: {}", tokenJson, e);
-        throw e;
-    }
-}
+//         LOG.info("Postgres role set via FusionAuth token: {}", role);
+//         return role;
+//     } catch (Exception e) {
+//         LOG.error("Error calling set_role_based_on_fusion_token with token: {}", tokenJson, e);
+//         throw e;
+//     }
+// }
 
 public Map<String, List<ScreenPermission>> getRolePermissions(String roleName) {
 
@@ -246,15 +236,20 @@ public Map<String, List<ScreenPermission>> getRolePermissions(String roleName) {
             throw new RuntimeException("Failed to parse role permissions JSON from DB", e);
         }
     }
-    public void setRoleFromCurrentUser(DefaultOAuth2User user) {
+    public void setRoleFromCurrentUser(DefaultOAuth2User user , String selectedTenant) {
     try {
-        String tokenJson = objectMapper.writeValueAsString(user.getAttributes());
-
-        setRole(dsl, tokenJson);
+          
+       String activeTenant = selectedTenant;
+        if(activeTenant == null){
+            activeTenant = user.getAttribute("activeTenant");
+        }
+        List<String> roles = user.getAttribute("roles");
+        Boolean isSuperRole = user.getAttribute("isSuperRole");
+        setRole(dsl, activeTenant, roles, isSuperRole);
 
             // Set role on reader (if enabled)
             if (secondaryDsl != null) {
-                setRole(secondaryDsl, tokenJson);
+                setRole(secondaryDsl, activeTenant, roles, isSuperRole);
             }
 
     } catch (Exception e) {
@@ -263,12 +258,21 @@ public Map<String, List<ScreenPermission>> getRolePermissions(String roleName) {
     }
 }
 
-  private void setRole(DSLContext dsl, String tokenJson) {
-        dsl.fetch(
-            "SELECT techbd_udi_ingress.set_role_based_on_fusion_token(?::jsonb)",
-            tokenJson
-        );
-    }
+        private void setRole( DSLContext dsl, String activeTenant, List<String> roles, Boolean isSuperRole){
+
+            dsl.fetch(
+                """
+                SELECT techbd_udi_ingress.set_role_based_on_fusion_token(
+                    ?,
+                    ?::text[],
+                    ?
+                )
+                """,
+                activeTenant,
+                roles.toArray(new String[0]),
+                isSuperRole
+            );
+        }
 
   public void resetDatabaseSession() {
 

--- a/hub-prime/src/main/java/org/techbd/service/http/TenantRequest.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/TenantRequest.java
@@ -1,0 +1,6 @@
+package org.techbd.service.http;
+
+public record TenantRequest(
+    String tenantName
+) {}
+

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/RlsInitializationFilter.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/RlsInitializationFilter.java
@@ -17,6 +17,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,21 +41,16 @@ public class RlsInitializationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         try {
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            HttpSession session = request.getSession();
+            String selectedTenant =(String) session.getAttribute("activeTenant");
             if (auth instanceof OAuth2AuthenticationToken token
                     && token.getPrincipal() instanceof DefaultOAuth2User user) {
-                fusionAuthUsersService.setRoleFromCurrentUser(user);
+                fusionAuthUsersService.setRoleFromCurrentUser(user,selectedTenant);
             }
             filterChain.doFilter(request, response);
         } catch (Exception e) {
             LOG.error("Error in RLS initialization filter", e);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error in RLS initialization filter");
         }
-        // finally {
-            // try {
-            //     fusionAuthUsersService.resetDatabaseSession();
-            // } catch (Exception e) {
-            //     LOG.error("Failed to reset PostgreSQL session", e);
-            // }
-        // }
     }
 }

--- a/hub-prime/src/main/resources/templates/fragments/nav.html
+++ b/hub-prime/src/main/resources/templates/fragments/nav.html
@@ -37,13 +37,117 @@
                     </div>
                 </div>
                 <div class="hidden md:block">
-                    <div class="ml-4 mt-2 flex items-center md:ml-6">
-                        <a class="text-gray-300 border border-gray-600 hover:bg-gray-700 hover:text-white rounded-md ml-2 font-semibold md:px-6 px-2 py-1 shadow-none text-sm px-5 py-2.5 text-center inline-flex items-center dark:focus:ring-[#3b5998]/55 me-2 mb-2" href="https://github.com/tech-by-design/help-desk-non-phi/issues" target="_blank">
+                    <div class="ml-4 flex items-center   md:ml-6">
+                        <a class="h-10 text-gray-300 border border-gray-600 hover:bg-gray-700 hover:text-white rounded-md ml-2 font-semibold md:px-6 px-2 py-1 shadow-none text-sm px-5 text-center inline-flex items-center dark:focus:ring-[#3b5998]/55 me-2" href="https://github.com/tech-by-design/help-desk-non-phi/issues" target="_blank">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 me-2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
                             </svg>
                             Help Desk Issues
-                        </a>                       
+                        </a>  
+                       <div class="relative ml-2"
+                            id="tenantDropdown"
+                            th:if="${!session.isSuperRole and #authentication.principal.attributes['authProvider'] != 'github'}"> 
+                            <button class="inline-flex h-10 items-center justify-between rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-semibold text-gray-300 shadow-none transition hover:bg-gray-700 hover:text-white focus:outline-none dark:focus:ring-[#3b5998]/55" id="tenantBtn" type="button" aria-haspopup="true" aria-expanded="false" style="min-width: 180px;">
+                                <span id="selectedTenant" class="truncate text-left"></span>
+                                <svg class="ml-3 h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.38a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                                </svg>
+                            </button>
+
+                            <ul class="absolute right-0 top-full z-50 mt-2 hidden min-w-[180px] rounded-md border border-gray-200 bg-white py-1 shadow-lg" id="tenantMenu" role="menu"></ul>
+                        </div>
+                        <script th:inline="javascript">
+                            /*<![CDATA[*/
+                            const tenantNamesFromAuth = /*[[${#authentication.principal.attributes['tenantNames']}]]*/ null;
+                            const sessionActiveTenant = /*[[${session.activeTenant != null ? session.activeTenant : ''}]]*/ '';
+                            const authActiveTenant = /*[[${#authentication.principal.attributes['activeTenant']}]]*/ null;
+                            const initialActiveTenant = sessionActiveTenant || authActiveTenant;
+                            const tenants = tenantNamesFromAuth && tenantNamesFromAuth.length > 0
+                                ? tenantNamesFromAuth
+                                : ['Default Tenant'];
+                            /*]]>*/
+
+                            document.addEventListener('DOMContentLoaded', function () {
+                                const tenantDropdown = document.getElementById('tenantDropdown');
+                                const tenantBtn = document.getElementById('tenantBtn');
+                                const tenantMenu = document.getElementById('tenantMenu');
+                                const selectedTenant = document.getElementById('selectedTenant');
+
+                                if (!tenantDropdown || !tenantBtn || !tenantMenu || !selectedTenant) return;
+
+                                const renderTenants = () => {
+                                    tenantMenu.innerHTML = '';
+
+                                    const defaultTenant = initialActiveTenant && tenants.includes(initialActiveTenant)
+                                        ? initialActiveTenant
+                                        : tenants[0];
+
+                                    selectedTenant.textContent = defaultTenant;
+
+                                    tenants.forEach((tenant) => {
+                                        const item = document.createElement('li');
+                                        const link = document.createElement('button');
+
+                                        link.type = 'button';
+                                        link.textContent = tenant;
+                                        link.className = 'block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100';
+
+                                        if (tenant === defaultTenant) {
+                                            link.classList.add('bg-gray-100');
+                                        }
+
+                                        link.setAttribute('role', 'menuitem');
+
+                                        link.addEventListener('click', async () => {
+                                            selectedTenant.textContent = tenant;
+
+                                            tenantMenu.querySelectorAll('button')
+                                                .forEach(btn => btn.classList.remove('bg-gray-100'));
+
+                                            link.classList.add('bg-gray-100');
+
+                                            tenantMenu.classList.add('hidden');
+
+                                            try {
+                                                await fetch('/tenant/select', {
+                                                    method: 'POST',
+                                                    headers: {
+                                                        'Content-Type': 'application/json'
+                                                    },
+                                                    body: JSON.stringify({
+                                                        tenantName: tenant
+                                                    })
+                                                });
+
+                                                window.location.href = '/home';
+                                            } catch (e) {
+                                                console.error(e);
+                                            }
+                                        });
+
+                                        item.appendChild(link);
+                                        tenantMenu.appendChild(item);
+                                    });
+                                };
+
+                                tenantBtn.addEventListener('click', function (event) {
+                                    event.stopPropagation();
+                                    tenantMenu.classList.toggle('hidden');
+                                    tenantBtn.setAttribute('aria-expanded', String(!tenantMenu.classList.contains('hidden')));
+                                });
+
+                                document.addEventListener('click', function () {
+                                    tenantMenu.classList.add('hidden');
+                                    tenantBtn.setAttribute('aria-expanded', 'false');
+                                });
+
+                                tenantMenu.addEventListener('click', function (event) {
+                                    event.stopPropagation();
+                                });
+
+                                renderTenants();
+                            });
+                        </script>                     
                         <div class="ml-8 text-gray-400">v<span th:text="${appVersion}"></span></div>
                         <button type="button" id="nav-prime-notification"
                             class="relative rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">

--- a/hub-prime/src/main/resources/templates/page/home.html
+++ b/hub-prime/src/main/resources/templates/page/home.html
@@ -65,7 +65,15 @@
                         <code th:text="${#authentication.principal.attributes['authProvider'] == 'fusionauth' ? 
                                         #strings.listJoin(#authentication.principal.attributes['role'], ', ') : 
                                         'admin'}">
-                        </code>.
+                        </code>
+                         <span th:if="${#authentication.principal.attributes['authProvider'] == 'fusionauth'
+                                    and !session.isSuperRole}">
+                            for tenant
+                            <code th:text="${session.activeTenant != null ?
+                                            session.activeTenant :
+                                            #authentication.principal.attributes['activeTenant']}">
+                            </code>
+                        </span>.
                     </div>
                 </div>
       <div sec:authorize="isAnonymous()">


### PR DESCRIPTION
## Summary

This PR introduces active tenant selection for FusionAuth users, enabling multi-tenant users to switch their active tenant and apply the selected tenant context across the application.

## Changes

- Added a tenant selection dropdown for non-super FusionAuth users.
- Populated the dropdown with all tenants assigned to the authenticated user.
- Introduced support for selecting and persisting the active tenant in the user session.
- Implemented tenant switching via the `/tenant/select` endpoint.
- Redirected users to the Home page after tenant selection to ensure the new tenant context is applied.
- Updated RLS initialization to use `activeTenant`, `roles`, and `isSuperRole` by invoking `set_role_based_on_fusion_token_1(...)`.
- Ensured the selected tenant is retained and displayed correctly after page refresh.
- Hide the tenant selection dropdown for GitHub users and FusionAuth super users.
- Displayed the active tenant in the user information section for eligible FusionAuth users.