### PR TITLE
fix: update tenant session handling and role access visibility #1687

### DIFF
--- a/hub-prime/src/main/java/org/techbd/service/InteractionService.java
+++ b/hub-prime/src/main/java/org/techbd/service/InteractionService.java
@@ -59,10 +59,13 @@ public class InteractionService {
                 LOG.info("REGISTER State None : BEGIN for  interaction id : {} tenant id : {}",
                 rre.interactionId().toString(), rre.tenant());
                 final var tenant = rre.tenant();
-                String resolvedTenantNames = Optional.ofNullable(tenant)
-                        .map(Interactions.Tenant::tenantId)
+                String activeTenant = Optional.ofNullable(origRequest.getSession(false))
+                        .map(session -> (String) session.getAttribute("activeTenant"))
                         .filter(value -> value != null && !value.isBlank())
-                        .orElse("N/A");
+                        .orElseGet(() -> Optional.ofNullable(tenant)
+                                .map(Interactions.Tenant::tenantId)
+                                .filter(value -> value != null && !value.isBlank())
+                                .orElse("N/A"));
 
                 rihr.setPInteractionId(rre.interactionId().toString());
                 rihr.setPContentType(MimeTypeUtils.APPLICATION_JSON_VALUE);
@@ -96,11 +99,6 @@ public class InteractionService {
                             if (faUser != null) {
                                 curUserName = Optional.ofNullable(faUser.name()).orElse("NO_DATA");
                                 userId = Optional.ofNullable(faUser.fusionAuthId()).orElse("NO_DATA");
-                                resolvedTenantNames = Optional.ofNullable(faUser.tenantNames())
-                                        .filter(tenantNames -> !tenantNames.isEmpty())
-                                        .map(tenantNames -> tenantNames.get(0))
-                                        .filter(value -> value != null && !value.isBlank())
-                                        .orElse(resolvedTenantNames);
                             }
 
                             userRole = ((FusionAuthUserAuthorizationFilter.AuthenticatedUser) user)
@@ -134,7 +132,7 @@ public class InteractionService {
                     rihr.setPUserRole(userRole);
                     rihr.setPNature((JsonNode)Configuration.objectMapper.valueToTree(
                             Map.of("nature", RequestResponseEncountered.class.getName(), "tenant_id",
-                                    resolvedTenantNames)));
+                                    activeTenant)));
                 } else {
                     LOG.info("User details are not saved with Interaction as saveUserDataToInteractions: "
                             + saveUserDataToInteractions);
@@ -143,7 +141,7 @@ public class InteractionService {
                 if (!saveUserDataToInteractions) {
                     rihr.setPNature((JsonNode)Configuration.objectMapper.valueToTree(
                             Map.of("nature", RequestResponseEncountered.class.getName(), "tenant_id",
-                                    resolvedTenantNames)));
+                                    activeTenant)));
                 }
 
                 rihr.execute(primaryDslContext.configuration());

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DataQualityController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/DataQualityController.java
@@ -138,10 +138,10 @@ public class DataQualityController {
         return presentation.populateModel("page/diagnostics/ig-publication-issues", model, request);
     }
 
-    @GetMapping("/data-quality/fhir-rules")
-    @RouteMapping(label = "FHIR Rules", title = "FHIR Rules", siblingOrder = 80)
-    public String fhirRules(final Model model, final HttpServletRequest request) {
-        return presentation.populateModel("page/diagnostics/fhir-rules", model, request);
-    }
+    // @GetMapping("/data-quality/fhir-rules")
+    // @RouteMapping(label = "FHIR Rules", title = "FHIR Rules", siblingOrder = 80)
+    // public String fhirRules(final Model model, final HttpServletRequest request) {
+    //     return presentation.populateModel("page/diagnostics/fhir-rules", model, request);
+    // }
 
 }

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/SettingsController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/ux/SettingsController.java
@@ -4,6 +4,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,36 +23,61 @@ public class SettingsController {
         this.presentation = presentation;
     }
 
-    @RouteMapping(label = "Settings", siblingOrder = 90)
-    @GetMapping("/settings")
-    public String docs() {
-        return "redirect:/settings/role-access-management";
-    }
+        @RouteMapping(label = "Settings", siblingOrder = 90)
+        @GetMapping("/settings")
+        public String settings(HttpServletRequest request) {
 
-    // @RouteMapping(label = "Profile", siblingOrder = 100)
-    // @GetMapping("/settings/profile")
-    // public String users(final Model model, final HttpServletRequest request) {
+            Authentication authentication =
+                    SecurityContextHolder.getContext().getAuthentication();
 
-    //     HttpSession session = request.getSession(false);
-    //     Object sessionUser = session != null ? session.getAttribute("authenticatedUser") : null;
-    //     model.addAttribute("sessionUser", sessionUser);
+            if (authentication instanceof OAuth2AuthenticationToken token
+                    && token.getPrincipal() instanceof DefaultOAuth2User user) {
 
-    //     return presentation.populateModel("page/settings/profile", model, request);
-    // }
+                String authProvider = user.getAttribute("authProvider");
 
-    @RouteMapping(label = "Role Access Management", siblingOrder = 110)
-    @GetMapping("/settings/role-access-management")
-    public String rolePermissions(final Model model, final HttpServletRequest request) {
-        HttpSession session = request.getSession(false);
+                // GitHub users should only see FHIR Rules
+                if ("github".equalsIgnoreCase(authProvider)) {
+                    return "redirect:/settings/fhir-rules";
+                }
+            }
 
-      Boolean configAccess = session != null
-                ? (Boolean) session.getAttribute("configAccess")
-                : false;
+            HttpSession session = request.getSession(false);
 
-        if (!Boolean.TRUE.equals(configAccess)) {
+            Boolean configAccess = session != null
+                    ? (Boolean) session.getAttribute("configAccess")
+                    : false;
+
+            if (Boolean.TRUE.equals(configAccess)) {
+                return "redirect:/settings/role-access-management";
+            }
+
             return "redirect:/profile/profile";
         }
-        return presentation.populateModel("page/settings/role-access-management", model, request);
+
+    @RouteMapping(label = "Role Access Management", siblingOrder = 100)
+    @GetMapping("/settings/role-access-management")
+    public String rolePermissions(final Model model, final HttpServletRequest request) {
+  HttpSession session = request.getSession(false);
+
+    Boolean configAccess = session != null
+            ? (Boolean) session.getAttribute("configAccess")
+            : false;
+
+    if (!Boolean.TRUE.equals(configAccess)) {
+        return "redirect:/settings/fhir-rules";
+    }
+
+    return presentation.populateModel(
+            "page/settings/role-access-management",
+            model,
+            request);
+    }
+
+    @RouteMapping(label = "FHIR Rules", siblingOrder = 110)
+    @GetMapping("/settings/fhir-rules")
+    public String fhirRules(final Model model,
+                            final HttpServletRequest request) {
+        return presentation.populateModel("page/diagnostics/fhir-rules", model, request);
     }
 
 }

--- a/hub-prime/src/main/resources/templates/fragments/nav.html
+++ b/hub-prime/src/main/resources/templates/fragments/nav.html
@@ -212,7 +212,7 @@
                                     id="user-menu-item-0">My Profile</a>
                                 <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1"
                                     id="user-menu-item-1">Settings</a> -->
-                                <form th:if="${session.configAccess == true}"
+                                <form th:if="${session.configAccess == true  or #authentication.principal.attributes['authProvider'] == 'github'}"
                                         action="/settings"
                                         method="get">
                                     <button type="submit"
@@ -395,10 +395,10 @@
                             <a href="/data-quality/ig-publication-issues" class="hover:underline">IG Publication Issues</a>
                         </li>
 
-                        <li class="mb-4"
+                        <!-- <li class="mb-4"
                             th:if="${session.isSuperRole == true or (session.rolePermissions['Data Quality'] != null and #lists.contains(session.rolePermissions['Data Quality'].![screen], 'FHIR Rules'))}">
                             <a href="/data-quality/fhir-rules" class="hover:underline">FHIR Rules</a>
-                        </li>
+                        </li> -->
 
                     </ul>
                 </div>

--- a/hub-prime/src/main/resources/templates/layout/prime.html
+++ b/hub-prime/src/main/resources/templates/layout/prime.html
@@ -59,7 +59,7 @@
             <div class="mx-auto max-w-9xl py-2 sm:px-6 lg:px-8">
                 <div class="w-full mx-auto bg-white p-8 rounded-lg shadow-lg">
                     <ul th:if="${siblingLinks.size()} > 0" class="flex flex-wrap border-b border-gray-200">
-                        <li th:each="link : ${siblingLinks}" class="mr-2">
+                        <li th:each="link : ${siblingLinks}" th:if="${!(link.text == 'Role Access Management'and #authentication.principal.attributes['authProvider'] == 'github')}"class="mr-2">
                             <a th:href="@{${link.href}}" th:text="${link.text}" th:attr="for=${activeRoutePath}"
                                 th:class="${link.href == activeRoutePath
                                             ? 'inline-block bg-gray-100 text-blue-600 rounded-t-lg py-2 px-4 text-sm font-medium text-center active' 


### PR DESCRIPTION
**Summary**
- Fixed the User Session module to save session data against the currently active tenant instead of always using the primary tenant.
- Moved the FHIR Rules page from Data Quality to Settings and updated the navigation accordingly.
- Added FHIR Rules visibility for GitHub-authenticated users while restricting FusionAuth-specific configuration pages.
- Hid the Role Access Management tab for GitHub-authenticated users.
- Kept FHIR Rules visible and accessible for GitHub users.
- Kept Role Access Management available for eligible FusionAuth users.
- Retained controller-level authorization validation to prevent unauthorized direct access to the Role Access Management page.