### PR TITLE
feat: implement Historical Replay Bundle API with configurable Data Ledger processing and OperationOutcome filtering #3330

### DIFF
--- a/hub-core-lib/src/main/java/org/techbd/config/Constants.java
+++ b/hub-core-lib/src/main/java/org/techbd/config/Constants.java
@@ -100,4 +100,11 @@ public interface Constants {
     public static final String COOKIES = "cookies";
     public static final String TECHBD_VERSION = "techBdVersion";
     public static final String CLIENT_IP_ADDRESS = "CLIENT_IP_ADDRESS";
+
+    // Constants for historical-replay endpoint 
+    public static final String HISTORICAL_REPLAY_DATA_LEDGER = "historicalReplayDataLedger";
+    public static final String HISTORICAL_REPLAY_OO_SIZE = "historicalReplayOoSize";
+    public static final String OO_SIZE_FULL = "full";
+    public static final String OO_SIZE_LITE = "lite";
+    public static final String OO_SIZE_NONE = "none";
 }

--- a/hub-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
+++ b/hub-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
@@ -164,9 +164,14 @@ public class FHIRService {
                 throw new IllegalArgumentException("Interaction ID must be provided in the request parameters.");
             }
 				final String bundleId = CoreFHIRUtil.extractBundleId(payload, tenantId);
-			if (!SourceType.CSV.name().equalsIgnoreCase(source)
+			final boolean skipDataLedger = isDataLedgerSkipped(requestParameters);
+            LOG.info("Historical Replay | interactionId={} | skipDataLedger={}",
+                    interactionId, skipDataLedger);
+			if (!skipDataLedger
+					&& !SourceType.CSV.name().equalsIgnoreCase(source)
 					&& !SourceType.CCDA.name().equalsIgnoreCase(source)
 					&& !SourceType.HL7V2.name().equalsIgnoreCase(source)) {
+                LOG.info("Historical Replay | RECEIVED Data Ledger ENABLED | interactionId={}", interactionId);
 				DataLedgerPayload dataLedgerPayload = null;
 				if (StringUtils.isNotEmpty(bundleId)) {
 					dataLedgerPayload = DataLedgerPayload.create(CoreDataLedgerApiClient.Actor.TECHBD.getValue(),
@@ -180,7 +185,9 @@ public class FHIRService {
 				final var dataLedgerProvenance = "%s.processBundle".formatted(FHIRService.class.getName());
 				coreDataLedgerApiClient.processRequest(dataLedgerPayload, interactionId, dataLedgerProvenance,
 						SourceType.FHIR.name(), null);
-			}
+			} else {
+                LOG.info("Historical Replay | RECEIVED Data Ledger SKIPPED | interactionId={}", interactionId);
+            }
             LOG.info("Bundle processing start at {} for interaction id {}.", interactionId);
 			if (!"true".equalsIgnoreCase(healthCheck != null ? healthCheck.trim() : null)) {
 				registerOriginalPayload(requestParameters,
@@ -262,6 +269,23 @@ public class FHIRService {
             span.end();
         }
     }
+
+	/**
+	 * Determines whether calls to the NYeC Data Ledger should be skipped for this
+	 * request. Driven by the {@code dataLedger} query parameter on the
+	 * historical-replay endpoint (see Issue #3330). Data Ledger calls proceed as
+	 * today (default) unless the parameter is explicitly set to {@code false}.
+	 *
+	 * @param requestParameters the request parameters map
+	 * @return true if Data Ledger calls should be skipped, false otherwise (default)
+	 */
+	public static boolean isDataLedgerSkipped(final Map<String, Object> requestParameters) {
+		if (requestParameters == null) {
+			return false;
+		}
+		final Object dataLedgerFlag = requestParameters.get(Constants.HISTORICAL_REPLAY_DATA_LEDGER);
+		return dataLedgerFlag != null && "false".equalsIgnoreCase(String.valueOf(dataLedgerFlag).trim());
+	}
 
 	@SuppressWarnings("unchecked")
 	public static boolean isActionDiscard(final Map<String, Object> payloadWithDisposition) {
@@ -1348,6 +1372,9 @@ public class FHIRService {
         LOG.debug(
                 "FHIRService:: sendToScoringEngine Post to scoring engine - BEGIN interaction id: {} tenantID :{}",
                 interactionId, tenantId);
+		final boolean skipDataLedger = isDataLedgerSkipped(requestParameters);
+            LOG.info("Historical Replay | interactionId={} | skipDataLedger={}",
+                    interactionId, skipDataLedger);
 		final DataLedgerPayload dataLedgerPayload = DataLedgerPayload.create(
 				CoreDataLedgerApiClient.Actor.TECHBD.getValue(), CoreDataLedgerApiClient.Action.SENT.getValue(),
 				CoreDataLedgerApiClient.Actor.NYEC.getValue(), bundleId);
@@ -1360,8 +1387,10 @@ public class FHIRService {
                 .retrieve()
                 .bodyToMono(String.class)
                 .doFinally(signalType -> {
-                    final var dataLedgerProvenance = "%s.sendPostRequest".formatted(FHIRService.class.getName());
-            		coreDataLedgerApiClient.processRequest(dataLedgerPayload,interactionId,masterInteractionId,groupInteractionId,dataLedgerProvenance,SourceType.FHIR.name(),null);
+                    if (!skipDataLedger) {
+                        final var dataLedgerProvenance = "%s.sendPostRequest".formatted(FHIRService.class.getName());
+                        coreDataLedgerApiClient.processRequest(dataLedgerPayload,interactionId,masterInteractionId,groupInteractionId,dataLedgerProvenance,SourceType.FHIR.name(),null);
+                    }
                 })
                 .subscribe(response -> {
                     handleResponse(response, interactionId, requestURI, tenantId,
@@ -1408,11 +1437,13 @@ public class FHIRService {
 					.retrieve()
 					.bodyToMono(String.class)
 					.doFinally(signalType -> {
-						final DataLedgerPayload dataLedgerPayload = DataLedgerPayload.create(
-							CoreDataLedgerApiClient.Actor.TECHBD.getValue(), CoreDataLedgerApiClient.Action.SENT.getValue(), 
-								CoreDataLedgerApiClient.Actor.NYEC.getValue(), bundleId);
-						final var dataLedgerProvenance = "%s.sendPostRequest".formatted(FHIRService.class.getName());
-						coreDataLedgerApiClient.processRequest(dataLedgerPayload,interactionId,masterInteractionId,groupInteractionId,dataLedgerProvenance,SourceType.FHIR.name(),null);
+						if (!isDataLedgerSkipped(requestParameters)) {
+							final DataLedgerPayload dataLedgerPayload = DataLedgerPayload.create(
+								CoreDataLedgerApiClient.Actor.TECHBD.getValue(), CoreDataLedgerApiClient.Action.SENT.getValue(),
+									CoreDataLedgerApiClient.Actor.NYEC.getValue(), bundleId);
+							final var dataLedgerProvenance = "%s.sendPostRequest".formatted(FHIRService.class.getName());
+							coreDataLedgerApiClient.processRequest(dataLedgerPayload,interactionId,masterInteractionId,groupInteractionId,dataLedgerProvenance,SourceType.FHIR.name(),null);
+						}
 					})
 					.subscribe(response -> {
 						handleResponse(response, interactionId, requestURI, tenantId,
@@ -2038,6 +2069,83 @@ public class FHIRService {
 			}
 		} finally {
 			span.end();
+		}
+	}
+
+	/**
+	 * Filters an OperationOutcome result map based on the {@code ooSize} parameter
+	 * (see Issue #3330).
+	 * <ul>
+	 *   <li>{@code full} (default) → no change; all issues (error, warning, information) returned as-is.</li>
+	 *   <li>{@code lite} → only {@code error}/{@code fatal} severity issues are retained; warnings and info are stripped.</li>
+	 *   <li>{@code none} → returns {@code null}; caller is expected to respond with a bare HTTP 200 and no body.</li>
+	 * </ul>
+	 *
+	 * @param result the OperationOutcome-wrapping result map produced by {@link #processBundle}
+	 * @param ooSize the requested OperationOutcome size: {@code full}, {@code lite}, or {@code none}
+	 * @return the (possibly filtered) result, or {@code null} when {@code ooSize=none}
+	 */
+	@SuppressWarnings("unchecked")
+	public Object applyOoSizeFilter(final Object result, final String ooSize) {
+		final String normalizedOoSize = Optional.ofNullable(ooSize)
+				.map(String::trim)
+				.filter(s -> !s.isEmpty())
+				.orElse(Constants.OO_SIZE_FULL);
+
+		if (Constants.OO_SIZE_FULL.equalsIgnoreCase(normalizedOoSize) || result == null) {
+			return result;
+		}
+		if (Constants.OO_SIZE_NONE.equalsIgnoreCase(normalizedOoSize)) {
+			return null;
+		}
+		if (!Constants.OO_SIZE_LITE.equalsIgnoreCase(normalizedOoSize) || !(result instanceof Map)) {
+			return result;
+		}
+
+		// lite: keep only error/fatal issues inside OperationOutcome.validationResults[*].operationOutcome.issue
+		try {
+			final Map<String, Object> root = new HashMap<>((Map<String, Object>) result);
+			final Object ooObj = root.get("OperationOutcome");
+			if (!(ooObj instanceof Map)) {
+				return result;
+			}
+			final Map<String, Object> oo = new HashMap<>((Map<String, Object>) ooObj);
+			final Object vrObj = oo.get("validationResults");
+			if (!(vrObj instanceof List)) {
+				return result;
+			}
+			final List<Object> filteredVr = new ArrayList<>();
+			for (final Object vrItem : (List<?>) vrObj) {
+				if (!(vrItem instanceof Map)) {
+					filteredVr.add(vrItem);
+					continue;
+				}
+				final Map<String, Object> vr = new HashMap<>((Map<String, Object>) vrItem);
+				final Object innerOoObj = vr.get("operationOutcome");
+				if (innerOoObj instanceof Map) {
+					final Map<String, Object> innerOo = new HashMap<>((Map<String, Object>) innerOoObj);
+					final Object issuesObj = innerOo.get("issue");
+					if (issuesObj instanceof List) {
+						final List<Map<String, Object>> errorsOnly = ((List<?>) issuesObj).stream()
+								.filter(Map.class::isInstance)
+								.map(i -> (Map<String, Object>) i)
+								.filter(i -> {
+									final String sev = String.valueOf(i.get("severity"));
+									return "error".equalsIgnoreCase(sev) || "fatal".equalsIgnoreCase(sev);
+								})
+								.collect(Collectors.toList());
+						innerOo.put("issue", errorsOnly);
+					}
+					vr.put("operationOutcome", innerOo);
+				}
+				filteredVr.add(vr);
+			}
+			oo.put("validationResults", filteredVr);
+			root.put("OperationOutcome", oo);
+			return root;
+		} catch (final Exception e) {
+			LOG.warn("applyOoSizeFilter failed, returning original unfiltered result: {}", e.getMessage());
+			return result;
 		}
 	}
 

--- a/hub-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
+++ b/hub-core-lib/src/main/java/org/techbd/service/fhir/FHIRService.java
@@ -273,7 +273,7 @@ public class FHIRService {
 	/**
 	 * Determines whether calls to the NYeC Data Ledger should be skipped for this
 	 * request. Driven by the {@code dataLedger} query parameter on the
-	 * historical-replay endpoint (see Issue #3330). Data Ledger calls proceed as
+	 * historical-replay endpoint. Data Ledger calls proceed as
 	 * today (default) unless the parameter is explicitly set to {@code false}.
 	 *
 	 * @param requestParameters the request parameters map
@@ -2074,7 +2074,6 @@ public class FHIRService {
 
 	/**
 	 * Filters an OperationOutcome result map based on the {@code ooSize} parameter
-	 * (see Issue #3330).
 	 * <ul>
 	 *   <li>{@code full} (default) → no change; all issues (error, warning, information) returned as-is.</li>
 	 *   <li>{@code lite} → only {@code error}/{@code fatal} severity issues are retained; warnings and info are stripped.</li>

--- a/hub-prime/src/main/java/org/techbd/service/http/Constant.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/Constant.java
@@ -9,6 +9,7 @@ public class Constant {
             "/Bundle", "/Bundle/**",
             "/flatfile/csv/Bundle", "/flatfile/csv/Bundle/**",
             "/Hl7/v2", "/Hl7/v2/",
+            "/historical-replay/Bundle/**",
             "/api/expect", "/api/expect/**",
             "/Bundles/**"
     };

--- a/hub-prime/src/main/java/org/techbd/service/http/SwaggerConfig.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/SwaggerConfig.java
@@ -132,6 +132,7 @@ public class SwaggerConfig {
                 .pathsToMatch("/metadata", "/Bundles/status/nyec-submission-failed",
                 "/Bundles/status/operation-outcome",
                         "/Bundle", "/Bundle/**",
+                        "/historical-replay/Bundle", "/historical-replay/Bundle/**",
                         "/flatfile/csv/Bundle", "/flatfile/csv/Bundle/**",
                         "/api/expect/fhir/**")
                 .addOpenApiCustomizer(openApi -> {

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/HistoricalReplayController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/HistoricalReplayController.java
@@ -1,0 +1,152 @@
+package org.techbd.service.http.hub.prime.api;
+
+import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.techbd.service.fhir.FHIRService;
+import org.techbd.service.http.hub.CustomRequestWrapper;
+import org.techbd.util.FHIRUtil;
+import org.techbd.util.fhir.CoreFHIRUtil;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.techbd.conf.Configuration;
+import org.techbd.config.Constants;
+import io.micrometer.common.util.StringUtils;
+import io.opentelemetry.api.trace.Span;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.annotation.Nonnull;
+
+@Controller
+@Tag(name = "Historical Replay Endpoints", description = "Historical Replay FHIR Endpoints")
+public class HistoricalReplayController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HistoricalReplayController.class);
+
+    private final FHIRService fhirService;
+    private final Tracer tracer;
+
+    public HistoricalReplayController(Tracer tracer, FHIRService fhirService) {
+        this.tracer = tracer;
+        this.fhirService = fhirService;
+    }
+
+    @PostMapping(value = { "/historical-replay/Bundle", "/historical-replay/Bundle/" }, consumes = {
+            MediaType.APPLICATION_JSON_VALUE, Constants.FHIR_CONTENT_TYPE_HEADER_VALUE })
+    @Operation(summary = "Historical replay endpoint: validates FHIR bundles against the current IG, with optional Data Ledger and OperationOutcome size controls.", description = """
+            Accepts FHIR bundles and validates them against the current version of the IG, same as <code>/Bundle</code>.
+            <ul>
+                <li><code>dataLedger</code>: defaults to <code>true</code> (Data Ledger calls proceed as-is). Set to <code>false</code> to prevent calls to the NYeC Data Ledger.</li>
+                <li><code>ooSize</code>: defaults to <code>full</code> (all errors, warnings, and info messages included in the OperationOutcome).
+                    Use <code>lite</code> to include only error/fatal issues, excluding warnings and info.
+                    Use <code>none</code> to receive a plain HTTP 200 with no OperationOutcome body.</li>
+            </ul>
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Request processed successfully."),
+            @ApiResponse(responseCode = "400", description = "Validation Error: Missing or invalid parameter."),
+            @ApiResponse(responseCode = "500", description = "An unexpected system error occurred.")
+    })
+    @ResponseBody
+    public Object historicalReplayBundle(
+            @Parameter(description = "FHIR Bundle payload.", required = true) final @RequestBody @Nonnull String payload,
+            @Parameter(description = "Tenant ID.", required = true) @RequestHeader(value = Configuration.Servlet.HeaderName.Request.TENANT_ID, required = true) String tenantId,
+            @Parameter(description = "Set to <code>false</code> to skip NYeC Data Ledger calls. Defaults to <code>true</code> (calls proceed as-is).", required = false) @RequestParam(value = "dataLedger", required = false, defaultValue = "true") String dataLedger,
+            @Parameter(description = "OperationOutcome size: <code>full</code> (default, all issues), <code>lite</code> (error/fatal only), <code>none</code> (HTTP 200 with no OperationOutcome — returns only <code>{ \\\"interactionId\\\": ... }</code> for tracking).", required = false) @RequestParam(value = "ooSize", required = false, defaultValue = "full") String ooSize,
+            @Parameter(description = "Optional correlation ID (UUID).", required = false) @RequestHeader(value = "X-Correlation-ID", required = false) String coRrelationId,
+            @Parameter(description = "Optional header to specify IG version.", required = false) @RequestHeader(value = "X-SHIN-NY-IG-Version", required = false) String requestedIgVersion,
+            HttpServletRequest request, HttpServletResponse response) throws SQLException, IOException {
+        Span span = tracer.spanBuilder("HistoricalReplayController.historicalReplayBundle").startSpan();
+        try {
+            if (tenantId == null || tenantId.trim().isEmpty()) {
+                LOG.error("HistoricalReplayController:HistoricalReplay:: Tenant ID is missing or empty");
+                throw new IllegalArgumentException("Tenant ID must be provided");
+            }
+            if (StringUtils.isNotEmpty(coRrelationId)) {
+                try {
+                    UUID.fromString(coRrelationId);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("X-Correlation-ID should be a valid UUID");
+                }
+            }
+            if (StringUtils.isNotEmpty(dataLedger)
+                    && !"true".equalsIgnoreCase(dataLedger.trim())
+                    && !"false".equalsIgnoreCase(dataLedger.trim())) {
+                throw new IllegalArgumentException("dataLedger must be either 'true' or 'false'");
+            }
+            final String normalizedOoSize = StringUtils.isNotEmpty(ooSize) ? ooSize.trim() : "full";
+            if (!"full".equalsIgnoreCase(normalizedOoSize) && !"lite".equalsIgnoreCase(normalizedOoSize)
+                    && !"none".equalsIgnoreCase(normalizedOoSize)) {
+                throw new IllegalArgumentException("ooSize must be one of 'full', 'lite', or 'none'");
+            }
+
+            final var provenance = "%s.historicalReplayBundle".formatted(HistoricalReplayController.class.getName());
+            request = new CustomRequestWrapper(request, payload);
+            Map<String, Object> headers = CoreFHIRUtil.buildHeaderParametersMap(tenantId, null,
+                    null, null, null, coRrelationId, provenance, requestedIgVersion);
+            Map<String, Object> requestDetailsMap = FHIRUtil.extractRequestDetails(request);
+            CoreFHIRUtil.buildRequestParametersMap(requestDetailsMap, null,
+                    null, "FHIR", null, null, request.getRequestURI());
+            requestDetailsMap.put(Constants.INTERACTION_ID, UUID.randomUUID().toString());
+            requestDetailsMap.put(Constants.OBSERVABILITY_METRIC_INTERACTION_START_TIME, Instant.now().toString());
+            requestDetailsMap.putAll(headers);
+            // Stash the historical-replay params so FHIRService can gate Data Ledger
+            // calls and the controller can shape the OperationOutcome response below.
+            requestDetailsMap.put(Constants.HISTORICAL_REPLAY_DATA_LEDGER, dataLedger);
+            requestDetailsMap.put(Constants.HISTORICAL_REPLAY_OO_SIZE, normalizedOoSize);
+
+            LOG.info(" Historical Replay START | interactionId={} | tenantId={} | dataLedger={} | ooSize={}",
+                    requestDetailsMap.get(Constants.INTERACTION_ID), tenantId, dataLedger, normalizedOoSize);
+
+            Map<String, Object> responseParameters = new HashMap<>();
+            final var result = fhirService.processBundle(payload, requestDetailsMap, responseParameters);
+
+            LOG.info(" Historical Replay processBundle COMPLETED | interactionId={}",
+                    requestDetailsMap.get(Constants.INTERACTION_ID));
+
+            CoreFHIRUtil.addCookieAndHeadersToResponse(response, responseParameters, requestDetailsMap);
+
+            LOG.info(" Historical Replay applying OperationOutcome filter | interactionId={} | ooSize={}",
+                    requestDetailsMap.get(Constants.INTERACTION_ID), normalizedOoSize);
+
+            final var filtered = fhirService.applyOoSizeFilter(result, normalizedOoSize);
+            if (filtered == null) {
+                String interactionId = (String) requestDetailsMap.get(Constants.INTERACTION_ID);
+                LOG.info(" Historical Replay returning HTTP 200 with EMPTY BODY | interactionId={}",
+                        interactionId);
+                return ResponseEntity.ok(
+                        Map.of("interactionId", interactionId));
+            }
+
+            LOG.info(" Historical Replay returning OperationOutcome | interactionId={} | ooSize={}",
+                    requestDetailsMap.get(Constants.INTERACTION_ID), normalizedOoSize);
+
+            return filtered;
+        } finally {
+            span.end();
+        }
+    }
+
+}

--- a/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/HistoricalReplayController.java
+++ b/hub-prime/src/main/java/org/techbd/service/http/hub/prime/api/HistoricalReplayController.java
@@ -40,7 +40,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.annotation.Nonnull;
 
 @Controller
-@Tag(name = "Historical Replay Endpoints", description = "Historical Replay FHIR Endpoints")
+@Tag(name = "Tech by Design Hub Historical Replay Endpoints", description = "Historical Replay FHIR Endpoints")
 public class HistoricalReplayController {
 
     private static final Logger LOG = LoggerFactory.getLogger(HistoricalReplayController.class);


### PR DESCRIPTION
## Summary

Implemented the Historical Replay Bundle API to support historical replay processing with configurable Data Ledger execution and OperationOutcome response handling.

## Changes

- Added the Historical Replay Bundle endpoint.
- Added support for the `dataLedger` query parameter to enable or disable Data Ledger processing during historical replay.
- Added support for the `ooSize` query parameter (`full`, `lite`, and `none`) to control the level of detail returned in the `OperationOutcome` response.
- Implemented OperationOutcome filtering based on the requested response size.
- Preserved the existing `/Bundle` endpoint behavior to maintain backward compatibility.
- Updated the security configuration to expose the Historical Replay Bundle endpoint.
- Added Swagger/OpenAPI support for the Historical Replay Bundle endpoint.
