### PR TITLE
feat: add Historical FHIR Bundle Replay submission support in Nexus #1515

### DIFF
--- a/integration-artifacts/Router/RouterChannel.xml
+++ b/integration-artifacts/Router/RouterChannel.xml
@@ -1,16 +1,16 @@
-<channel version="26.3.1">
+<channel version="26.6.0">
   <id>576131f3-aa5b-4453-929f-1e07d7534e82</id>
   <nextMetaDataId>4</nextMetaDataId>
   <name>RouterChannel</name>
-  <description>Version: 0.2.25
-Implemented tenant get api in router channel</description>
-  <revision>98</revision>
-  <sourceConnector version="26.3.1">
+  <description>Version: 0.2.26
+Implemented support for Historical fhir bundle replay api in router channel</description>
+  <revision>4</revision>
+  <sourceConnector version="26.6.0">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
-    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.3.1">
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.6.0">
       <pluginProperties>
-        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.6.0">
   <sslEnabled>true</sslEnabled>
           <mutualTlsEnabled>false</mutualTlsEnabled>
           <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -40,15 +40,15 @@ Implemented tenant get api in router channel</description>
           <pinnedLeafPins/>
           <subjectSanFilterPatterns/>
         </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.3.1">
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.6.0">
   <authType>NONE</authType>
         </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
-      <listenerConnectorProperties version="26.3.1">
+      <listenerConnectorProperties version="26.6.0">
         <host>0.0.0.0</host>
         <port>9000</port>
       </listenerConnectorProperties>
-      <sourceConnectorProperties version="26.3.1">
+      <sourceConnectorProperties version="26.6.0">
         <responseVariable>commonResponse</responseVariable>
         <respondAfterProcessing>true</respondAfterProcessing>
         <processBatch>false</processBatch>
@@ -86,9 +86,9 @@ Implemented tenant get api in router channel</description>
         </com.mirth.connect.connectors.http.HttpStaticResource>
       </staticResources>
     </properties>
-    <transformer version="26.3.1">
+    <transformer version="26.6.0">
       <elements>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
           <name>mTLS filter disabled guard</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -105,7 +105,7 @@ if (String(mtlsEnabled) !== &apos;true&apos;) {
 	return;
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
           <name>pass original headers</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -160,7 +160,7 @@ if (isHl7UploadEndpoint &amp;&amp; hasMultipartContentType) {
     }
 }</script>
         </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
-        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
           <name>redirection</name>
           <sequenceNumber>2</sequenceNumber>
           <enabled>true</enabled>
@@ -209,16 +209,22 @@ else if (requestedPath == &quot;/hl7v2/Bundle/&quot; || requestedPath == &quot;/
 	logger.info(logPrefix + &quot;HL7 submission  RouterChannel &quot;);
 }
 
-
-
 else if (requestedPath == &quot;/hl7v2/Bundle/$validate/&quot; || requestedPath == &quot;/hl7v2/Bundle/$validate&quot;) {
 	channelMap.put(&apos;destinationUrl&apos;, &quot;http://localhost:9006&quot; + requestedPath);	
 	logger.info(logPrefix + &quot;HL7 validation  RouterChannel &quot;);
 }
+
 else if (requestedPath == &quot;/Bundle/replay/&quot; || requestedPath == &quot;/Bundle/replay&quot;) {
 	channelMap.put(&apos;destinationUrl&apos;, &quot;http://localhost:9005&quot; + requestedPath);	
 	logger.info(logPrefix + &quot;Replay validation  RouterChannel &quot;);
 }
+
+else if (requestedPath == &quot;/historical-replay/Bundle/&quot; ||
+         requestedPath == &quot;/historical-replay/Bundle&quot;) {
+	channelMap.put(&apos;destinationUrl&apos;, &quot;http://localhost:8002&quot; + requestedPath);
+     logger.info(logPrefix + &quot;Historical Replay Bundle RouterChannel&quot;);
+}
+
 else{
 	return;
 }
@@ -233,22 +239,22 @@ logger.info(fhirJson);</script>
       <outboundTemplate encoding="base64"></outboundTemplate>
       <inboundDataType>RAW</inboundDataType>
       <outboundDataType>RAW</outboundDataType>
-      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </inboundProperties>
-      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
           <splitType>JavaScript</splitType>
           <batchScript></batchScript>
         </batchProperties>
       </outboundProperties>
     </transformer>
-    <filter version="26.3.1">
+    <filter version="26.6.0">
       <elements>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.6.0">
           <name>CORS-preflight-and-headers</name>
           <sequenceNumber>0</sequenceNumber>
           <enabled>true</enabled>
@@ -293,7 +299,7 @@ if (httpMethod === &apos;OPTIONS&apos;) {
 
 return true;</script>
         </com.mirth.connect.plugins.javascriptrule.JavaScriptRule>
-        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.6.0">
           <name>MTLS-client-cert-validation</name>
           <sequenceNumber>1</sequenceNumber>
           <enabled>true</enabled>
@@ -442,12 +448,12 @@ if (sourceType == &quot;CSV&quot;) {
     <waitForPrevious>true</waitForPrevious>
   </sourceConnector>
   <destinationConnectors>
-    <connector version="26.3.1">
+    <connector version="26.6.0">
       <metaDataId>1</metaDataId>
       <name>response_operationoutcome</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.1">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.6.0">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.6.0">
   <sslEnabled>true</sslEnabled>
             <mutualTlsEnabled>false</mutualTlsEnabled>
             <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -478,7 +484,7 @@ if (sourceType == &quot;CSV&quot;) {
             <subjectSanFilterPatterns/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="26.3.1">
+        <destinationConnectorProperties version="26.6.0">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -498,7 +504,7 @@ if (sourceType == &quot;CSV&quot;) {
           <queueBufferSize>1000</queueBufferSize>
           <reattachAttachments>true</reattachAttachments>
           <pluginProperties>
-            <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
+            <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.6.0">
   <sslEnabled>false</sslEnabled>
               <mutualTlsEnabled>false</mutualTlsEnabled>
               <mutualTlsMigrated>false</mutualTlsMigrated>
@@ -688,9 +694,9 @@ if (sourceType == &quot;CSV&quot;) {
         <charset>UTF-8</charset>
         <socketTimeout>300000</socketTimeout>
       </properties>
-      <transformer version="26.3.1">
+      <transformer version="26.6.0">
         <elements>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
             <name>pass headers to destination</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -783,41 +789,41 @@ return &apos;&apos;;</script>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.1">
+      <responseTransformer version="26.6.0">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.1">
+      <filter version="26.6.0">
         <elements>
-          <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
+          <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.6.0">
             <name>filter_get_apis</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -831,12 +837,12 @@ return contextPath != &quot;/tenants&quot;;</script>
       <enabled>true</enabled>
       <waitForPrevious>true</waitForPrevious>
     </connector>
-    <connector version="26.3.1">
+    <connector version="26.6.0">
       <metaDataId>3</metaDataId>
       <name>tenant_api</name>
-      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.3.1">
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.6.0">
         <pluginProperties>
-          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.6.0">
   <sslEnabled>true</sslEnabled>
             <mutualTlsEnabled>false</mutualTlsEnabled>
             <mutualTlsMigrated>true</mutualTlsMigrated>
@@ -867,7 +873,7 @@ return contextPath != &quot;/tenants&quot;;</script>
             <subjectSanFilterPatterns/>
           </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
         </pluginProperties>
-        <destinationConnectorProperties version="26.3.1">
+        <destinationConnectorProperties version="26.6.0">
           <queueEnabled>false</queueEnabled>
           <sendFirst>false</sendFirst>
           <retryIntervalMillis>10000</retryIntervalMillis>
@@ -887,7 +893,7 @@ return contextPath != &quot;/tenants&quot;;</script>
           <queueBufferSize>1000</queueBufferSize>
           <reattachAttachments>true</reattachAttachments>
           <pluginProperties>
-            <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.3.1">
+            <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.6.0">
   <sslEnabled>false</sslEnabled>
               <mutualTlsEnabled>false</mutualTlsEnabled>
               <mutualTlsMigrated>false</mutualTlsMigrated>
@@ -1077,9 +1083,9 @@ return contextPath != &quot;/tenants&quot;;</script>
         <charset>UTF-8</charset>
         <socketTimeout>300000</socketTimeout>
       </properties>
-      <transformer version="26.3.1">
+      <transformer version="26.6.0">
         <elements>
-          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.3.1">
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
             <name>pass headers to destination</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -1172,41 +1178,41 @@ return &apos;&apos;;</script>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </transformer>
-      <responseTransformer version="26.3.1">
+      <responseTransformer version="26.6.0">
         <elements/>
         <inboundTemplate encoding="base64"></inboundTemplate>
         <outboundTemplate encoding="base64"></outboundTemplate>
         <inboundDataType>RAW</inboundDataType>
         <outboundDataType>RAW</outboundDataType>
-        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </inboundProperties>
-        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.3.1">
-          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.3.1">
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
             <splitType>JavaScript</splitType>
             <batchScript></batchScript>
           </batchProperties>
         </outboundProperties>
       </responseTransformer>
-      <filter version="26.3.1">
+      <filter version="26.6.0">
         <elements>
-          <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.3.1">
+          <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.6.0">
             <name>pass get apis</name>
             <sequenceNumber>0</sequenceNumber>
             <enabled>true</enabled>
@@ -1503,7 +1509,7 @@ return;</deployScript>
   <undeployScript>// This script executes once when the channel is undeployed
 // You only have access to the globalMap and globalChannelMap here to persist data
 return;</undeployScript>
-  <properties version="26.3.1">
+  <properties version="26.6.0">
     <clearGlobalChannelMap>true</clearGlobalChannelMap>
     <messageStorageMode>METADATA</messageStorageMode>
     <encryptData>false</encryptData>
@@ -1531,7 +1537,7 @@ return;</undeployScript>
         <mappingName>interactionId</mappingName>
       </metaDataColumn>
     </metaDataColumns>
-    <attachmentProperties version="26.3.1">
+    <attachmentProperties version="26.6.0">
       <type>None</type>
       <properties/>
     </attachmentProperties>
@@ -1546,19 +1552,19 @@ return;</undeployScript>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1784538099203</time>
+        <time>1786122253663</time>
         <timezone>Asia/Calcutta</timezone>
       </lastModified>
       <pruningSettings>
         <archiveEnabled>true</archiveEnabled>
         <pruneErroredMessages>false</pruneErroredMessages>
       </pruningSettings>
-      <userId>6</userId>
+      <userId>10</userId>
     </metadata>
     <channelTags>
       <channelTag>
-        <id>3d136fe2-b8da-45cc-84f6-04e1938f8f7e</id>
-        <name>0_2_25</name>
+        <id>07dfa70f-b78d-4c94-8ebd-aacb29ea518d</id>
+        <name>0_2_26</name>
         <channelIds>
           <string>576131f3-aa5b-4453-929f-1e07d7534e82</string>
         </channelIds>

--- a/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundleHistoricalReplay.xml
+++ b/integration-artifacts/fhir/fhir-techbd-channel-files/nexus-sandbox/FhirBundleHistoricalReplay.xml
@@ -1,0 +1,2765 @@
+<channel version="26.6.0">
+  <id>e17a4c92-8f3d-4b6a-9c21-5d7f0a2b6e44</id>
+  <nextMetaDataId>7</nextMetaDataId>
+  <name>FhirBundleHistoricalReplay</name>
+  <description>Version: 1.0.0
+Historical Replay endpoint (port 8002), base path /historical-replay/Bundle. Validates FHIR bundles against the current IG version, same as FhirBundlleSubmission, but adds two optional query parameters:
+- dataLedger=true|false (default true): &quot;true&quot;/omitted behaves exactly as today (sends to NYeC Data Ledger, subject to DATA_LEDGER_TRACKING config); &quot;false&quot; skips the Data Ledger call entirely.
+- ooSize=full|lite|none (default full): &quot;full&quot; returns the complete OperationOutcome (errors, warnings, info) exactly as today; &quot;lite&quot; returns an OperationOutcome containing only fatal/error issues; &quot;none&quot; returns a plain HTTP 200 acknowledgement with no OperationOutcome body.
+Everything else (secrets/config lookups, FHIR validation forward, DataLake forward, DB registration, Data Ledger payload shape) is unchanged from FhirBundlleSubmission.</description>
+  <revision>14</revision>
+  <sourceConnector version="26.6.0">
+    <metaDataId>0</metaDataId>
+    <name>sourceConnector</name>
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="26.6.0">
+      <pluginProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="26.6.0">
+  <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
+        <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.6.0">
+  <sslEnabled>false</sslEnabled>
+          <mutualTlsEnabled>true</mutualTlsEnabled>
+          <mutualTlsMigrated>true</mutualTlsMigrated>
+          <clientCertValidationEnabled>true</clientCertValidationEnabled>
+          <clientCertOptionalEnabled>false</clientCertOptionalEnabled>
+          <serverCertValidationEnabled>true</serverCertValidationEnabled>
+          <verifyHostname>false</verifyHostname>
+          <keystorePath/>
+          <keystorePassword/>
+          <certAlias/>
+          <certPassword/>
+          <truststorePath/>
+          <truststorePassword/>
+          <tls13>true</tls13>
+          <tls12>true</tls12>
+          <tls11>false</tls11>
+          <keystoreType/>
+          <truststoreType/>
+          <keystoreSettingFromSystem>false</keystoreSettingFromSystem>
+          <keystoreUid/>
+          <myCertificateAlias/>
+          <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
+          <truststoreUid/>
+          <validationMode>pkix</validationMode>
+          <revocationMode>disabled</revocationMode>
+          <softFailIfResponderUnavailable>false</softFailIfResponderUnavailable>
+          <pinnedLeafPins/>
+          <subjectSanFilterPatterns/>
+        </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+      </pluginProperties>
+      <listenerConnectorProperties version="26.6.0">
+        <host>0.0.0.0</host>
+        <port>8002</port>
+      </listenerConnectorProperties>
+      <sourceConnectorProperties version="26.6.0">
+        <responseVariable>finalResponse</responseVariable>
+        <respondAfterProcessing>true</respondAfterProcessing>
+        <processBatch>false</processBatch>
+        <firstResponse>false</firstResponse>
+        <processingThreads>1</processingThreads>
+        <resourceIds class="linked-hash-map">
+          <entry>
+            <string>Default Resource</string>
+            <string>[Default Resource]</string>
+          </entry>
+        </resourceIds>
+        <queueBufferSize>1000</queueBufferSize>
+      </sourceConnectorProperties>
+      <xmlBody>false</xmlBody>
+      <parseMultipart>false</parseMultipart>
+      <includeMetadata>false</includeMetadata>
+      <binaryMimeTypes></binaryMimeTypes>
+      <binaryMimeTypesRegex>false</binaryMimeTypesRegex>
+      <responseContentType>application/fhir+json</responseContentType>
+      <responseDataTypeBinary>false</responseDataTypeBinary>
+      <responseStatusCode>${status}</responseStatusCode>
+      <responseHeaders class="linked-hash-map">
+        <entry>
+          <string>Access-Control-Allow-Origin</string>
+          <list>
+            <string>${HUB_UI_URL}</string>
+          </list>
+        </entry>
+        <entry>
+          <string>Access-Control-Allow-Methods</string>
+          <list>
+            <string>GET, POST, OPTIONS</string>
+          </list>
+        </entry>
+        <entry>
+          <string>Access-Control-Allow-Headers</string>
+          <list>
+            <string>Content-Type, Authorization, X-TechBD-Base-FHIR-URL, X-TechBD-Tenant-ID, User-Agent, X-TechBD-REMOTE-IP, X-TechBD-Override-Request-URI, X-Correlation-ID, accept, X-TechBD-DataLake-API-URL,  X-TechBD-HealthCheck, X-TechBD-Validation-Severity-Level, X-SHIN-NY-IG-Version</string>
+          </list>
+        </entry>
+        <entry>
+          <string>Access-Control-Expose-Headers</string>
+          <list>
+            <string>Location, X-TechBD-Tenant-ID, User-Agent, X-TechBD-REMOTE-IP, X-TechBD-Override-Request-URI,X-Correlation-ID,X-TechBD-HealthCheck</string>
+          </list>
+        </entry>
+      </responseHeaders>
+      <responseHeadersVariable></responseHeadersVariable>
+      <useResponseHeadersVariable>false</useResponseHeadersVariable>
+      <charset>DEFAULT_ENCODING</charset>
+      <contextPath>/</contextPath>
+      <timeout>300000</timeout>
+      <requestHeaderSize>8192</requestHeaderSize>
+      <staticResources>
+        <com.mirth.connect.connectors.http.HttpStaticResource>
+          <contextPath>/healthcheck</contextPath>
+          <resourceType>CUSTOM</resourceType>
+          <value>Ok</value>
+          <contentType>text/plain</contentType>
+        </com.mirth.connect.connectors.http.HttpStaticResource>
+      </staticResources>
+    </properties>
+    <transformer version="26.6.0">
+      <elements>
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
+          <name>lookup_manager</name>
+          <sequenceNumber>0</sequenceNumber>
+          <enabled>true</enabled>
+          <script>var __li = channelMap.get(&apos;interactionId&apos;);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: STEP lookup_manager - START. requestedPath=&quot; + channelMap.get(&apos;requestedPath&apos;));
+logger.info(&quot;HTTP request validation started.&quot;);
+
+/********************************************
+    1 FETCH JDBC SECRET (JSON secret)
+********************************************/
+
+try {
+
+	var username = LookupHelper.get(&quot;Config-sensitive&quot;, &quot;MC_JDBC_USERNAME&quot;);
+	var password = LookupHelper.get(&quot;Config-sensitive&quot;, &quot;MC_JDBC_PASSWORD&quot;);
+
+	channelMap.put(&quot;JDBC_USERNAME&quot;, username);
+	channelMap.put(&quot;JDBC_PASSWORD&quot;, password);
+     globalMap.put(&quot;JDBC_USERNAME&quot;, username);
+     globalMap.put(&quot;JDBC_PASSWORD&quot;, password);
+     logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [1/10] JDBC credentials loaded. usernamePresent=&quot; + (username != null &amp;&amp; username !== &quot;&quot;) + &quot;, passwordPresent=&quot; + (password != null &amp;&amp; password !== &quot;&quot;));
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [1/10] Error processing JDBC secret: &quot; + e.message);
+}
+
+/********************************************
+    2 FETCH DATA LEDGER API KEY (Plain text)
+********************************************/
+
+try {
+    var dataLedgerKey = LookupHelper.get(&quot;Config-sensitive&quot;, &quot;TECHBD_NYEC_DATALEDGER_API_KEY&quot;);
+
+     channelMap.put(&quot;TECHBD_NYEC_DATALEDGER_API_KEY&quot;, dataLedgerKey);
+     globalMap.put(&quot;TECHBD_NYEC_DATALEDGER_API_KEY&quot;, dataLedgerKey);
+     logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [2/10] Data Ledger API key loaded. present=&quot; + (dataLedgerKey != null &amp;&amp; dataLedgerKey !== &quot;&quot;));
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [2/10] Error processing DataLedger API Key secret: &quot; + e.message);
+}
+
+/********************************************
+    3 FETCH FHIR BUNDLE SUBMISSION API URL (Plain text)
+********************************************/
+try {
+    var fhirChannelUrl = LookupHelper.get(&quot;Config&quot;, &quot;MC_FHIR_BUNDLE_SUBMISSION_API_URL&quot;);
+
+    if (!fhirChannelUrl || fhirChannelUrl.trim() === &quot;&quot;) {
+        throw &quot;FHIR Channel URL retrieved from Lookup Manager is empty.&quot;;
+    }
+    channelMap.put(&quot;FHIR_CHANNEL_URL&quot;, fhirChannelUrl);
+    globalMap.put(&quot;fhirChannelUrl&quot;, fhirChannelUrl);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [3/10] FHIR_CHANNEL_URL loaded: &quot; + fhirChannelUrl);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [3/10] Error fetching FHIR CHANNEL URL: &quot; + e);
+    setErrorResponse(500, &quot;Failed to load FHIR CHANNEL URL&quot;);
+    throw e;
+}
+
+/********************************************
+    4 FETCH JDBC URL (Plain text)
+********************************************/
+try {
+    var jdbcUrl = LookupHelper.get(&quot;Config-sensitive&quot;, &quot;MC_JDBC_URL&quot;);
+
+    if (!jdbcUrl || jdbcUrl.trim() === &quot;&quot;) {
+        throw &quot; MC_JDBC_URL retrieved from Lookup Manager is empty.&quot;;
+    }
+    jdbcUrl = jdbcUrl.trim(); // IMPORTANT: remove trailing spaces
+     globalMap.put(&quot;jdbcUrl&quot;, jdbcUrl);
+     logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [4/10] JDBC URL loaded successfully.&quot;);
+
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [4/10] Error fetching JDBC URL: &quot; + e);
+    setErrorResponse(500, &quot;Failed to load JDBC URL&quot;);
+    throw e;
+}
+
+/********************************************
+    5 FETCH DEFAULT DATALAKE API URL (Plain text)
+********************************************/
+var rawHeader = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-DataLake-API-URL&apos;);
+var incomingHeader = rawHeader == null ? &quot;&quot; : String(rawHeader).trim();
+var allowedUrlsConfig = LookupHelper.get(
+
+    &quot;Config&quot;,
+
+    &quot;TECHBD_DEFAULT_DATALAKE_API_URL&quot;
+
+);
+
+
+if (!allowedUrlsConfig || String(allowedUrlsConfig).trim() === &quot;&quot;) {
+
+    throw &quot;TECHBD_DEFAULT_DATALAKE_API_URL is empty.&quot;;
+
+}
+allowedUrlsConfig = String(allowedUrlsConfig).trim();
+if (incomingHeader !== &quot;&quot;) {
+
+    var allowedUrls = allowedUrlsConfig.split(&quot;,&quot;);
+    var isAllowed = false;
+    for (var i = 0; i &lt; allowedUrls.length; i++) {
+
+        var allowedUrl = String(allowedUrls[i]).trim();
+        logger.info(
+
+            &quot;Comparing incoming=[&quot; +
+
+            incomingHeader +
+
+            &quot;] with allowed=[&quot; +
+
+            allowedUrl +
+
+            &quot;]&quot;
+
+        );
+        if (incomingHeader === allowedUrl) {
+
+            isAllowed = true;
+
+            break;
+
+        }
+
+    }
+    if (!isAllowed) {
+
+        logger.error(
+
+            &quot;Rejected DataLake API URL. Incoming: &quot; +
+
+            incomingHeader +
+
+            &quot;, Allowed URLs: &quot; +
+
+            allowedUrlsConfig
+
+        );
+        setErrorResponse(
+
+            400,
+
+            &quot;Invalid X-TechBD-DataLake-API-URL. Only approved DataLake URL is allowed.&quot;
+
+        );
+        throw &quot;SSRF validation failed&quot;;
+
+    }
+    datalakeApiUrl = incomingHeader;
+
+} else {
+
+    // Use first URL from whitelist as default
+
+    datalakeApiUrl = String(
+
+        allowedUrlsConfig.split(&quot;,&quot;)[0]
+
+    ).trim();
+
+}
+channelMap.put(&quot;DATALAKE_API_URL&quot;, datalakeApiUrl);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [5/10] DATALAKE_API_URL resolved: &quot; + datalakeApiUrl);
+/********************************************
+    6 FETCH DATA LAKE API KEY (Plain text)
+********************************************/
+
+try {
+    var dataLakeApiKey = LookupHelper.get(&quot;Config-sensitive&quot;, &quot;TECHBD_NYEC_DATALAKE_API_KEY&quot;);
+
+    channelMap.put(&quot;DATA_LAKE_API_KEY&quot;, dataLakeApiKey);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [6/10] DataLake API key loaded. present=&quot; + (dataLakeApiKey != null &amp;&amp; dataLakeApiKey !== &quot;&quot;));
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [6/10] Error processing DataLake API Key secret: &quot; + e.message);
+}
+
+
+/********************************************
+    7 FETCH FHIR BUNDLE VALIDATION API URL (Plain text)
+********************************************/
+try {
+    var fhirApiUrl = LookupHelper.get(&quot;Config&quot;, &quot;BL_FHIR_BUNDLE_VALIDATION_API_URL&quot;);
+
+    if (!fhirApiUrl || fhirApiUrl.trim() === &quot;&quot;) {
+        throw &quot; BL FHIR Bundle Validation API URL retrieved from Lookup Manager is empty.&quot;;
+    }
+	fhirApiUrl = fhirApiUrl + &quot;/Bundle/$validate&quot;;
+    channelMap.put(&quot;FHIR_API_URL&quot;, fhirApiUrl);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [7/10] FHIR_API_URL resolved: &quot; + fhirApiUrl);
+
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [7/10] Error fetching FHIR API URL: &quot; + e);
+    setErrorResponse(500, &quot;Failed to load FHIR API URL&quot;);
+    throw e;
+}
+
+/********************************************
+    8 FETCH DATA LEDGER API URL (Plain text)
+********************************************/
+
+try {
+    var dataLedgerApiUrl = LookupHelper.get(&quot;Config&quot;, &quot;DATA_LEDGER_API_URL&quot;);
+
+     channelMap.put(&quot;DATA_LEDGER_API_URL&quot;, dataLedgerApiUrl);
+     globalMap.put(&quot;DATA_LEDGER_API_URL&quot;, dataLedgerApiUrl);
+     logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [8/10] DATA_LEDGER_API_URL resolved: &quot; + dataLedgerApiUrl);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [8/10] Error processing DataLedger API URL secret: &quot; + e.message);
+}
+
+/********************************************
+    9 FETCH DATA LEDGER TRACKING (Plain text)
+********************************************/
+
+try {
+    var dataLedgerTracking = LookupHelper.get(&quot;Config&quot;, &quot;DATA_LEDGER_TRACKING&quot;);
+
+    channelMap.put(&quot;DATA_LEDGER_TRACKING&quot;, dataLedgerTracking);
+    channelMap.put(&quot;dataLedgerTracking&quot;, dataLedgerTracking);
+    globalMap.put(&quot;DATA_LEDGER_TRACKING&quot;, dataLedgerTracking);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [9/10] DATA_LEDGER_TRACKING resolved: &quot; + dataLedgerTracking);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [9/10] Error processing DataLedger Tracking secret: &quot; + e.message);
+}
+
+/********************************************
+    9 FETCH DATA LEDGER DIAGNOSTICS (Plain text)
+********************************************/
+
+try {
+    var dataLedgerDiagnostics = LookupHelper.get(&quot;Config&quot;, &quot;DATA_LEDGER_DIAGNOSTICS&quot;);
+
+    channelMap.put(&quot;DATA_LEDGER_DIAGNOSTICS&quot;, dataLedgerDiagnostics);
+    channelMap.put(&quot;dataLedgerDiagnostics&quot;, dataLedgerDiagnostics);
+    globalMap.put(&quot;DATA_LEDGER_DIAGNOSTICS&quot;, dataLedgerDiagnostics);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [9/10] DATA_LEDGER_DIAGNOSTICS resolved: &quot; + dataLedgerDiagnostics);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [9/10] Error processing DataLedger diagnostics secret: &quot; + e.message);
+}
+
+/********************************************
+    10 FETCH HUB UI URL (Plain text)
+********************************************/
+try {
+    var hubUiUrl = LookupHelper.get(&quot;Config&quot;, &quot;HUB_UI_URL&quot;);
+
+
+    if (!hubUiUrl || hubUiUrl.trim() === &quot;&quot;) {
+        throw &quot;HUB UI URL retrieved from Lookup Manager is empty.&quot;;
+    }
+    hubUiUrl = hubUiUrl.trim();
+    channelMap.put(&quot;HUB_UI_URL&quot;, hubUiUrl);
+    globalMap.put(&quot;HUB_UI_URL&quot;, hubUiUrl);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [10/10] HUB_UI_URL resolved: &quot; + hubUiUrl);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - [10/10] Error fetching HUB UI URL: &quot; + e);
+    setErrorResponse(500, &quot;Failed to load HUB UI URL&quot;);
+    throw e;
+}
+
+/*******************************
+    Processing Agent Loader
+********************************/
+
+try {
+	//value is either true or false
+    var processingFeatureEnable = LookupHelper.get(&quot;Config&quot;, &quot;ORG_TECHBD_PROCESSING_AGENT_FEATURE_ENABLED&quot;);
+
+    channelMap.put(&quot;ORG_TECHBD_PROCESSING_AGENT_FEATURE_ENABLED&quot;, processingFeatureEnable);
+    globalMap.put(&quot;ORG_TECHBD_PROCESSING_AGENT_FEATURE_ENABLED&quot;, processingFeatureEnable);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - Processing Agent Loader: featureEnabled=&quot; + processingFeatureEnable);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - Error fetching processing feature enable flag: &quot; + e.message);
+}
+
+try {
+	//values will be comma seperated tenant ids eg:abc,xyz,test
+    var processingAgentTenantIds = LookupHelper.get(&quot;Config&quot;, &quot;ORG_TECHBD_PROCESSING_AGENT_TENANT_IDS&quot;);
+
+    channelMap.put(&quot;ORG_TECHBD_PROCESSING_AGENT_TENANT_IDS&quot;, processingAgentTenantIds);
+    globalMap.put(&quot;ORG_TECHBD_PROCESSING_AGENT_TENANT_IDS&quot;, processingAgentTenantIds);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - Processing Agent Loader: tenantIds=&quot; + processingAgentTenantIds);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - Error fetching processing agent tenant ids: &quot; + e.message);
+}
+
+try {
+	//value is TXD
+    var processingAgentValue = LookupHelper.get(&quot;Config&quot;, &quot;ORG_TECHBD_PROCESSING_AGENT_VALUE&quot;);
+
+    channelMap.put(&quot;ORG_TECHBD_PROCESSING_AGENT_VALUE&quot;, processingAgentValue);
+    globalMap.put(&quot;ORG_TECHBD_PROCESSING_AGENT_VALUE&quot;, processingAgentValue);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - Processing Agent Loader: agentValue=&quot; + processingAgentValue);
+
+} catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: lookup_manager - Error fetching processing agent value: &quot; + e.message);
+}
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __li + &quot; ]: STEP lookup_manager - END.&quot;);
+/********************************************
+    DONE
+********************************************/</script>
+        </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
+          <name>FHIR Validation</name>
+          <sequenceNumber>1</sequenceNumber>
+          <enabled>true</enabled>
+          <script>// Use logger.info with a single string (no channelMap arg)
+var __fvLi = channelMap.get(&apos;interactionId&apos;);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: STEP FHIR Validation - START.&quot;);
+
+var requestedPath = channelMap.get(&apos;requestedPath&apos;);
+channelMap.put(&quot;requestUri&quot;, requestedPath);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - requestedPath=&quot; + requestedPath);
+
+
+if (
+    requestedPath == &quot;/&quot;
+) {
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - path is root, nothing to do, returning.&quot;);
+    return;
+}
+logger.info(&quot;requestedPath&quot;+requestedPath);
+
+if (requestedPath == &quot;/tenants&quot; || requestedPath == &quot;/tenants/&quot;) {
+
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - handling /tenants lookup.&quot;);
+    importPackage(java.sql);
+
+    var conn = null;
+    var stmt = null;
+    var rs = null;
+
+    try {
+
+        conn = DriverManager.getConnection(
+            globalMap.get(&quot;jdbcUrl&quot;),
+            globalMap.get(&quot;jdbcUsername&quot;),
+            globalMap.get(&quot;jdbcPassword&quot;)
+        );
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - /tenants DB connection established.&quot;);
+
+        stmt = conn.createStatement();
+
+        rs = stmt.executeQuery(
+            &quot;SELECT * FROM techbd_udi_ingress.get_active_tenants()&quot;
+        );
+
+        var tenants = [];
+
+        while (rs.next()) {
+
+            tenants.push({
+                tenantId: rs.getString(&quot;p_tenant_id&quot;),
+                tenantName: rs.getString(&quot;p_tenant_name&quot;),
+                tenantType: rs.getString(&quot;p_tenant_type&quot;)
+            });
+
+        }
+
+        channelMap.put(&quot;tenantResponse&quot;, JSON.stringify(tenants));
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - /tenants returned &quot; + tenants.length + &quot; active tenant(s).&quot;);
+
+    } finally {
+
+        if (rs != null) rs.close();
+        if (stmt != null) stmt.close();
+        if (conn != null) conn.close();
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - /tenants DB connection closed.&quot;);
+    }
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: STEP FHIR Validation - END (tenants).&quot;);
+    return;
+}
+
+// This step is reached only for the historical-replay Bundle path (filter already
+// restricted methods/paths), so the remainder handles that submission.
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - handling historical-replay Bundle submission.&quot;);
+var fhirJson  = connectorMessage.getRawData();
+channelMap.put(&apos;fhirJson&apos;, fhirJson);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __fvLi + &quot; ]: FHIR Validation - fhirJson captured, length=&quot; + (fhirJson != null ? String(fhirJson).length : 0));
+
+
+var interactionId = channelMap.get(&apos;interactionId&apos;);
+var validationSeverityLevel = channelMap.get(&apos;validationSeverityLevel&apos;);
+var source = channelMap.get(&apos;source&apos;);
+var igVersion = channelMap.get(&apos;igVersion&apos;);
+var elaboration = channelMap.get(&apos;elaboration&apos;);
+var groupInteractionId = channelMap.get(&apos;groupInteractionId&apos;);
+var masterInteractionId = channelMap.get(&apos;masterInteractionId&apos;);
+var healthCheck = channelMap.get(&apos;healthCheck&apos;);
+
+
+channelMap.put(&apos;interactionId&apos;, interactionId);
+channelMap.put(&quot;validationSeverityLevel&quot;,validationSeverityLevel);
+channelMap.put(&apos;source&apos;,source);
+channelMap.put(&apos;igVersion&apos;, igVersion);
+channelMap.put(&apos;elaboration&apos;, elaboration);
+channelMap.put(&apos;groupInteractionId&apos;, groupInteractionId);
+channelMap.put(&apos;masterInteractionId&apos;, masterInteractionId);
+
+var tenantId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Tenant-ID&apos;);
+channelMap.put(&apos;tenantId&apos;, tenantId);
+
+var userAgent = channelMap.get(&apos;userAgent&apos;);
+channelMap.put(&apos;userAgent&apos;, userAgent);
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + interactionId + &quot; ]: FHIR Validation - context: tenantId=&quot; + tenantId + &quot;, source=&quot; + source + &quot;, igVersion=&quot; + igVersion + &quot;, validationSeverityLevel=&quot; + validationSeverityLevel + &quot;, ooSize=&quot; + channelMap.get(&apos;ooSize&apos;) + &quot;, dataLedgerParam=&quot; + channelMap.get(&apos;dataLedgerParam&apos;) + &quot;, groupInteractionId=&quot; + groupInteractionId + &quot;, masterInteractionId=&quot; + masterInteractionId);
+
+channelMap.put(&quot;endpoint&quot;, &quot;submission&quot;);
+responseMap.put(&apos;status&apos;, &apos;200&apos;); // Set HTTP status 200
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + interactionId + &quot; ]: STEP FHIR Validation - END (submission ready to forward to dest_bundle).&quot;);</script>
+        </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
+      </elements>
+      <inboundTemplate encoding="base64"></inboundTemplate>
+      <outboundTemplate encoding="base64"></outboundTemplate>
+      <inboundDataType>RAW</inboundDataType>
+      <outboundDataType>RAW</outboundDataType>
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+          <splitType>JavaScript</splitType>
+          <batchScript></batchScript>
+        </batchProperties>
+      </inboundProperties>
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+          <splitType>JavaScript</splitType>
+          <batchScript></batchScript>
+        </batchProperties>
+      </outboundProperties>
+    </transformer>
+    <filter version="26.6.0">
+      <elements>
+        <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.6.0">
+          <name>Http url and method validation</name>
+          <sequenceNumber>0</sequenceNumber>
+          <enabled>true</enabled>
+          <script>var httpMethod = String(sourceMap.get(&apos;method&apos;)).toUpperCase();
+var contextPath = String(connectorMessage.getSourceMap().get(&apos;contextPath&apos;)).replace(/\/$/, &apos;&apos;);
+
+/**
+ * Util function to generate JSON string
+ */
+function createJsonResponse(status, message) {
+    return JSON.stringify({ status: status, message: message });
+}
+
+/**
+ * Util function to set error response
+ */
+function setErrorResponse(statusCode, errorMessage) {
+    responseMap.put(&apos;status&apos;, String(statusCode));
+    responseMap.put(&apos;message&apos;, errorMessage);
+    responseMap.put(&apos;finalResponse&apos;, createJsonResponse(statusCode, errorMessage));
+}
+
+logger.info(
+    &quot;DEBUG -&gt; Method inside fhir historical-replay channel: &quot; + httpMethod +
+    &quot;, Path: &quot; + contextPath
+);
+
+/* =====================================
+   1 ROOT ENDPOINT
+===================================== */
+if (contextPath === &apos;&apos;) {
+
+   if (httpMethod === &apos;GET&apos;) {
+
+    logger.info(&quot;DEBUG -&gt; Filter: routing to ROOT endpoint, method=GET -&gt; 200 OK, short-circuit&quot;);
+    responseMap.put(&apos;responseStatusCode&apos;, 200);
+    responseMap.put(&apos;responseContentType&apos;, &apos;application/json&apos;);
+    responseMap.put(&apos;responseBody&apos;, JSON.stringify({
+        status: 200,
+        message: &quot;OK&quot;
+    }));
+
+   return false;
+}
+
+    // Method not allowed for /
+    logger.info(&quot;DEBUG -&gt; Filter: ROOT endpoint hit with unsupported method=&quot; + httpMethod);
+    return methodNotAllowed();
+}
+
+/* =====================================
+   2 HEALTHCHECK
+===================================== */
+if (contextPath === &apos;/healthcheck&apos;) {
+
+    if (httpMethod === &apos;GET&apos;) {
+         logger.info(&quot;DEBUG -&gt; Filter: routing to HEALTHCHECK endpoint -&gt; 200 OK, short-circuit&quot;);
+         responseMap.put(&apos;responseStatusCode&apos;, 200);
+	    responseMap.put(&apos;responseContentType&apos;, &apos;application/json&apos;);
+	    responseMap.put(&apos;responseBody&apos;, JSON.stringify({
+	        status: 200,
+	        message: &quot;OK&quot;
+	    }));
+	
+	   return false;
+    }
+
+    logger.info(&quot;DEBUG -&gt; Filter: HEALTHCHECK endpoint hit with unsupported method=&quot; + httpMethod);
+    return methodNotAllowed();
+}
+
+/* =====================================
+   3 TENANTS
+===================================== */
+
+if (contextPath === &apos;/tenants&apos; || contextPath === &apos;/tenants/&apos;) {
+
+    if (httpMethod === &apos;GET&apos;) {
+        logger.info(&quot;DEBUG -&gt; Filter: routing to TENANTS endpoint -&gt; passing through to transformer&quot;);
+        channelMap.put(&quot;endpoint&quot;, &quot;tenants&quot;);
+        return true;
+    }
+
+    logger.info(&quot;DEBUG -&gt; Filter: TENANTS endpoint hit with unsupported method=&quot; + httpMethod);
+    return methodNotAllowed();
+}
+
+/* =====================================
+   4 HISTORICAL REPLAY BUNDLE
+===================================== */
+if (contextPath === &apos;/historical-replay/Bundle/&apos; || contextPath === &apos;/historical-replay/Bundle&apos;) {
+
+    if (httpMethod === &apos;POST&apos; || httpMethod === &apos;OPTIONS&apos;) {
+        logger.info(&quot;DEBUG -&gt; Filter: routing to HISTORICAL-REPLAY BUNDLE endpoint, method=&quot; + httpMethod + &quot; -&gt; passing through to transformer&quot;);
+        return true;
+    }
+
+    logger.info(&quot;DEBUG -&gt; Filter: HISTORICAL-REPLAY BUNDLE endpoint hit with unsupported method=&quot; + httpMethod);
+    return methodNotAllowed();
+}
+
+
+
+/* =====================================
+   INVALID PATH -&gt; 404
+===================================== */
+logger.info(&quot;DEBUG -&gt; Filter: no route matched for path=&quot; + contextPath + &quot;, method=&quot; + httpMethod + &quot; -&gt; 404&quot;);
+return notFound();
+
+
+
+
+/* =====================================
+   Helper Functions
+===================================== */
+
+function methodNotAllowed() {
+
+    var errorResponse = &quot;Method Not Allowed.&quot;;
+    logger.error(&quot;DEBUG -&gt; Filter: returning 405 - &quot; + errorResponse);
+
+    responseMap.put(&apos;responseStatusCode&apos;, 405);
+    responseMap.put(&apos;responseContentType&apos;, &apos;application/json&apos;);
+    responseMap.put(&apos;responseBody&apos;, JSON.stringify(errorResponse));
+
+    setErrorResponse(405, errorResponse);
+
+    throw &quot;Invalid method&quot;;
+}
+
+function notFound() {
+
+    var errorResponse = &quot;Not Found: Invalid endpoint.&quot;;
+    logger.error(&quot;DEBUG -&gt; Filter: returning 404 - &quot; + errorResponse);
+
+    responseMap.put(&apos;responseStatusCode&apos;, 404);
+    responseMap.put(&apos;responseContentType&apos;, &apos;application/json&apos;);
+    responseMap.put(&apos;responseBody&apos;, JSON.stringify(errorResponse));
+
+    setErrorResponse(404, errorResponse);
+
+    throw &quot;Invalid endpoint&quot;;
+}</script>
+        </com.mirth.connect.plugins.javascriptrule.JavaScriptRule>
+      </elements>
+    </filter>
+    <transportName>HTTP Listener</transportName>
+    <mode>SOURCE</mode>
+    <enabled>true</enabled>
+    <waitForPrevious>true</waitForPrevious>
+  </sourceConnector>
+  <destinationConnectors>
+    <connector version="26.6.0">
+      <metaDataId>1</metaDataId>
+      <name>dest_bundle</name>
+      <properties class="com.mirth.connect.connectors.http.HttpDispatcherProperties" version="26.6.0">
+        <pluginProperties>
+          <com.mirth.connect.plugins.ssl.SSLSettingsProperties version="26.6.0">
+  <sslEnabled>false</sslEnabled>
+            <mutualTlsEnabled>true</mutualTlsEnabled>
+            <mutualTlsMigrated>true</mutualTlsMigrated>
+            <clientCertValidationEnabled>true</clientCertValidationEnabled>
+            <clientCertOptionalEnabled>false</clientCertOptionalEnabled>
+            <serverCertValidationEnabled>true</serverCertValidationEnabled>
+            <verifyHostname>false</verifyHostname>
+            <keystorePath/>
+            <keystorePassword/>
+            <certAlias/>
+            <certPassword/>
+            <truststorePath/>
+            <truststorePassword/>
+            <tls13>true</tls13>
+            <tls12>true</tls12>
+            <tls11>false</tls11>
+            <keystoreType/>
+            <truststoreType/>
+            <keystoreSettingFromSystem>false</keystoreSettingFromSystem>
+            <keystoreUid/>
+            <myCertificateAlias/>
+            <truststoreSettingFromSystem>false</truststoreSettingFromSystem>
+            <truststoreUid/>
+            <validationMode>pkix</validationMode>
+            <revocationMode>disabled</revocationMode>
+            <softFailIfResponderUnavailable>false</softFailIfResponderUnavailable>
+            <pinnedLeafPins/>
+            <subjectSanFilterPatterns/>
+          </com.mirth.connect.plugins.ssl.SSLSettingsProperties>
+        </pluginProperties>
+        <destinationConnectorProperties version="26.6.0">
+          <queueEnabled>false</queueEnabled>
+          <sendFirst>false</sendFirst>
+          <retryIntervalMillis>10000</retryIntervalMillis>
+          <regenerateTemplate>false</regenerateTemplate>
+          <retryCount>0</retryCount>
+          <rotate>false</rotate>
+          <includeFilterTransformer>false</includeFilterTransformer>
+          <threadCount>1</threadCount>
+          <threadAssignmentVariable></threadAssignmentVariable>
+          <validateResponse>false</validateResponse>
+          <resourceIds class="linked-hash-map">
+            <entry>
+              <string>Default Resource</string>
+              <string>[Default Resource]</string>
+            </entry>
+          </resourceIds>
+          <queueBufferSize>1000</queueBufferSize>
+          <reattachAttachments>true</reattachAttachments>
+        </destinationConnectorProperties>
+        <host>${FHIR_API_URL}</host>
+        <useProxyServer>false</useProxyServer>
+        <proxyAddress></proxyAddress>
+        <proxyPort></proxyPort>
+        <method>post</method>
+        <headers class="linked-hash-map">
+          <entry>
+            <string>Access-Control-Allow-Origin</string>
+            <list>
+              <string>${HUB_UI_URL}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>Access-Control-Allow-Methods</string>
+            <list>
+              <string>GET, POST, OPTIONS</string>
+            </list>
+          </entry>
+          <entry>
+            <string>Access-Control-Allow-Headers</string>
+            <list>
+              <string>Content-Type, Authorization, X-TechBD-Base-FHIR-URL, X-TechBD-Tenant-ID, User-Agent, X-TechBD-REMOTE-IP, X-TechBD-Override-Request-URI, X-Correlation-ID, accept, X-TechBD-DataLake-API-URL, X-TechBD-HealthCheck, X-TechBD-Validation-Severity-Level, X-SHIN-NY-IG-Version</string>
+            </list>
+          </entry>
+          <entry>
+            <string>Access-Control-Expose-Headers</string>
+            <list>
+              <string>Location, X-TechBD-Tenant-ID, User-Agent, X-TechBD-REMOTE-IP, X-TechBD-Override-Request-URI,X-Correlation-ID,X-TechBD-HealthCheck</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Tenant-ID</string>
+            <list>
+              <string>${tenantId}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>Content-Type</string>
+            <list>
+              <string>application/fhir+json</string>
+            </list>
+          </entry>
+          <entry>
+            <string>User-Agent</string>
+            <list>
+              <string>${userAgent}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>Access-Control-Allow-Credentials</string>
+            <list>
+              <string>true</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Interaction-ID</string>
+            <list>
+              <string>${interactionId}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Request-URI</string>
+            <list>
+              <string>${requestUri}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Validation-Severity-Level</string>
+            <list>
+              <string>${validationSeverityLevel}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-SHIN-NY-IG-Version</string>
+            <list>
+              <string>${igVersion}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Override-Request-URI</string>
+            <list>
+              <string>${requestUri}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Source-Type</string>
+            <list>
+              <string>${source}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Elaboration</string>
+            <list>
+              <string>${elaboration}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-HealthCheck</string>
+            <list>
+              <string>${healthCheck}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Group-Interaction-ID</string>
+            <list>
+              <string>${groupInteractionId}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Master-Interaction-ID</string>
+            <list>
+              <string>${masterInteractionId}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Data-Ledger-Tracking</string>
+            <list>
+              <string>${DATA_LEDGER_TRACKING}</string>
+            </list>
+          </entry>
+          <entry>
+            <string>X-TechBD-Data-Ledger-diagnostics</string>
+            <list>
+              <string>${DATA_LEDGER_DIAGNOSTICS}</string>
+            </list>
+          </entry>
+        </headers>
+        <parameters class="linked-hash-map">
+          <entry>
+            <string>source</string>
+            <list>
+              <string>${source}</string>
+            </list>
+          </entry>
+        </parameters>
+        <useHeadersVariable>false</useHeadersVariable>
+        <headersVariable></headersVariable>
+        <useParametersVariable>false</useParametersVariable>
+        <parametersVariable></parametersVariable>
+        <responseXmlBody>false</responseXmlBody>
+        <responseParseMultipart>true</responseParseMultipart>
+        <responseIncludeMetadata>false</responseIncludeMetadata>
+        <responseBinaryMimeTypes>application/fhir+json</responseBinaryMimeTypes>
+        <responseBinaryMimeTypesRegex>true</responseBinaryMimeTypesRegex>
+        <multipart>false</multipart>
+        <useAuthentication>false</useAuthentication>
+        <authenticationType>Basic</authenticationType>
+        <usePreemptiveAuthentication>false</usePreemptiveAuthentication>
+        <username></username>
+        <password></password>
+        <content>${fhirJson}</content>
+        <contentType>application/fhir+json</contentType>
+        <dataTypeBinary>false</dataTypeBinary>
+        <charset>UTF-8</charset>
+        <socketTimeout>300000</socketTimeout>
+      </properties>
+      <transformer version="26.6.0">
+        <elements>
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
+            <name>log_dest_bundle_request</name>
+            <sequenceNumber>0</sequenceNumber>
+            <enabled>true</enabled>
+            <script>var __dbLi = channelMap.get(&apos;interactionId&apos;);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __dbLi + &quot; ]: STEP dest_bundle - about to POST to FHIR_API_URL=&quot; + channelMap.get(&apos;FHIR_API_URL&apos;) + &quot;, tenantId=&quot; + channelMap.get(&apos;tenantId&apos;) + &quot;, requestUri=&quot; + channelMap.get(&apos;requestUri&apos;) + &quot;, ooSize=&quot; + channelMap.get(&apos;ooSize&apos;) + &quot;, dataLedgerParam=&quot; + channelMap.get(&apos;dataLedgerParam&apos;));</script>
+          </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
+        </elements>
+        <inboundTemplate encoding="base64"></inboundTemplate>
+        <outboundTemplate encoding="base64"></outboundTemplate>
+        <inboundDataType>RAW</inboundDataType>
+        <outboundDataType>RAW</outboundDataType>
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </inboundProperties>
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </outboundProperties>
+      </transformer>
+      <responseTransformer version="26.6.0">
+        <elements>
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
+            <name>log_dest_bundle_response</name>
+            <sequenceNumber>0</sequenceNumber>
+            <enabled>true</enabled>
+            <script>var __dbrLi = channelMap.get(&apos;interactionId&apos;);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + __dbrLi + &quot; ]: STEP dest_bundle - response received from FHIR_API_URL.&quot;);</script>
+          </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
+        </elements>
+        <inboundDataType>RAW</inboundDataType>
+        <outboundDataType>RAW</outboundDataType>
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </inboundProperties>
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </outboundProperties>
+      </responseTransformer>
+      <filter version="26.6.0">
+        <elements>
+          <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.6.0">
+            <name>rediection</name>
+            <sequenceNumber>0</sequenceNumber>
+            <enabled>true</enabled>
+            <script>var path = String(channelMap.get(&quot;requestedPath&quot;)).replace(/\/$/, &quot;&quot;);
+return path != &quot;/tenants&quot;;</script>
+          </com.mirth.connect.plugins.javascriptrule.JavaScriptRule>
+        </elements>
+      </filter>
+      <transportName>HTTP Sender</transportName>
+      <mode>DESTINATION</mode>
+      <enabled>true</enabled>
+      <waitForPrevious>true</waitForPrevious>
+    </connector>
+    <connector version="26.6.0">
+      <metaDataId>3</metaDataId>
+      <name>dest_datalake</name>
+      <properties class="com.mirth.connect.connectors.js.JavaScriptDispatcherProperties" version="26.6.0">
+        <pluginProperties/>
+        <destinationConnectorProperties version="26.6.0">
+          <queueEnabled>false</queueEnabled>
+          <sendFirst>false</sendFirst>
+          <retryIntervalMillis>10000</retryIntervalMillis>
+          <regenerateTemplate>false</regenerateTemplate>
+          <retryCount>0</retryCount>
+          <rotate>false</rotate>
+          <includeFilterTransformer>false</includeFilterTransformer>
+          <threadCount>1</threadCount>
+          <threadAssignmentVariable></threadAssignmentVariable>
+          <validateResponse>false</validateResponse>
+          <resourceIds class="linked-hash-map">
+            <entry>
+              <string>Default Resource</string>
+              <string>[Default Resource]</string>
+            </entry>
+          </resourceIds>
+          <queueBufferSize>1000</queueBufferSize>
+          <reattachAttachments>true</reattachAttachments>
+        </destinationConnectorProperties>
+        <script>// ------------------------------------------------------------
+// Resolve Processing Agent (Same logic as Java service)
+// ------------------------------------------------------------
+function resolveProcessingAgent(tenantId) {
+
+    var featureEnabled = String(globalMap.get(&quot;ORG_TECHBD_PROCESSING_AGENT_FEATURE_ENABLED&quot;));
+    var tenantIds = String(globalMap.get(&quot;ORG_TECHBD_PROCESSING_AGENT_TENANT_IDS&quot;));
+    var value = String(globalMap.get(&quot;ORG_TECHBD_PROCESSING_AGENT_VALUE&quot;));
+    tenantId = String(tenantId);
+
+    logger.info(&quot;Feature Flag: &quot; + featureEnabled+&quot;Tenant IDs Config: &quot; + tenantIds+&quot;Configured Value: &quot; + value+&quot;Incoming TenantId: [&quot; + tenantId + &quot;]&quot;);
+
+
+    if (!tenantId || featureEnabled !== &quot;true&quot;) {
+        logger.info(&quot;Feature disabled or tenantId missing&quot;);
+        return tenantId;
+    }
+
+    var incomingTenant = tenantId.trim().toLowerCase();
+    var tenantList = tenantIds.split(&quot;,&quot;);
+
+
+    for (var i = 0; i &lt; tenantList.length; i++) {
+
+        var configTenant = String(tenantList[i]).trim().toLowerCase();
+
+        if (configTenant === incomingTenant) {
+            logger.info(&quot;Tenant matched. Returning value: &quot; + value);
+            return value;
+        }
+    }
+
+    return tenantId;
+}
+
+
+// ------------------------------------------------------------
+// Apache HttpClient Imports
+// ------------------------------------------------------------
+var DefaultHttpClient = Packages.org.apache.http.impl.client.DefaultHttpClient;
+var HttpPost = Packages.org.apache.http.client.methods.HttpPost;
+var StringEntity = Packages.org.apache.http.entity.StringEntity;
+var EntityUtils = Packages.org.apache.http.util.EntityUtils;
+
+// ------------------------------------------------------------
+// Get Required Values
+// ------------------------------------------------------------
+var datalakeApiUrl = channelMap.get(&quot;DATALAKE_API_URL&quot;);
+var tenantId = channelMap.get(&apos;tenantId&apos;);
+var apiKey = channelMap.get(&quot;DATA_LAKE_API_KEY&quot;);
+
+if (!datalakeApiUrl) {
+    throw &quot;DATALAKE_API_URL is missing&quot;;
+}
+
+if (!tenantId) {
+    throw &quot;Tenant ID is missing&quot;;
+}
+
+if (!apiKey) {
+    throw &quot;DATA_LAKE_API_KEY is missing&quot;;
+}
+
+// ------------------------------------------------------------
+// Build Final URL
+// ------------------------------------------------------------
+
+var processingAgent = resolveProcessingAgent(tenantId);
+var finalUrl = datalakeApiUrl + &quot;?processingAgent=&quot; + processingAgent;
+logger.info(&quot;Calling DataLake URL: &quot; + finalUrl);
+
+// ------------------------------------------------------------
+// Create HTTP Client
+// ------------------------------------------------------------
+var client = new DefaultHttpClient();
+var post = new HttpPost(finalUrl);
+
+// ------------------------------------------------------------
+// Set Headers
+// ------------------------------------------------------------
+post.setHeader(&quot;X-TechBD-Tenant-ID&quot;, tenantId);
+post.setHeader(&quot;Content-Type&quot;, &quot;application/fhir+json&quot;);
+post.setHeader(&quot;x-api-key&quot;, apiKey);
+
+// ------------------------------------------------------------
+// Set Request Body
+// ------------------------------------------------------------
+var payloadMsg = channelMap.get(&apos;updatedFhirJson&apos;);
+var payload = payloadMsg;
+post.setEntity(new StringEntity(payload, &quot;UTF-8&quot;));
+
+// ------------------------------------------------------------
+// Execute Request
+// ------------------------------------------------------------
+var statusCode = 500;
+var statusText = &quot;&quot;;
+var responseBody = &quot;&quot;;
+dataLakeErrorMessage = &quot;&quot;;
+
+try {
+
+    var response = client.execute(post);
+
+    var statusLine = response.getStatusLine();
+    statusCode = statusLine.getStatusCode();
+    statusText = statusLine.getReasonPhrase();
+
+    if (response.getEntity() != null) {
+        responseBody = EntityUtils.toString(response.getEntity(), &quot;UTF-8&quot;);
+    }
+
+    logger.info(&quot;DataLake Status Code: &quot; + statusCode+&quot;DataLake Status Text: &quot; + statusText+&quot;DataLake Response Body: &quot; + responseBody);
+
+} catch (e) {
+
+    logger.error(&quot;Error calling DataLake API: &quot; + e);
+    var bundleAsyncInteractionId = channelMap.get(&quot;interactionId&quot;);
+    var dataLakeApiBaseURL = datalakeApiUrl;
+
+    logger.error(
+        &quot;NYEC_API_CALL_FAILED &quot; +
+        &quot;REGISTER State Fail&quot; +
+        &quot; : Register State Failure - Exception while sending FHIR payload to datalake URL &quot; +
+        dataLakeApiBaseURL +
+        &quot; for interaction id &quot; +
+        bundleAsyncInteractionId +
+        &quot; error: &quot; + e
+    );
+
+    statusCode = 500;
+
+    var errMsg = &quot;&quot;;
+    if (e.javaException) {
+        errMsg = e.javaException.getMessage();
+    } else if (e.message) {
+        errMsg = e.message;
+    } else {
+        errMsg = e.toString();
+    }
+
+    logger.info(&quot;Error Message: &quot; + errMsg);
+
+    // Detect UnknownHostException
+    if (e.javaException &amp;&amp; e.javaException instanceof java.net.UnknownHostException) {
+        var host = String(datalakeApiUrl).replace(/^https?:\/\//, &apos;&apos;).split(&quot;/&quot;)[0];
+        errMsg = &quot;Failed to resolve &apos;&quot; + host + &quot;&apos;&quot;;
+    }
+
+    statusText = &quot;Exception&quot;;
+
+    // keep original body
+    responseBody = e.toString();
+
+    // store clean message
+    dataLakeErrorMessage = errMsg;
+}
+
+// ------------------------------------------------------------
+// Store For Postprocessor
+// ------------------------------------------------------------
+channelMap.put(&quot;datalake_status_code&quot;, statusCode);
+channelMap.put(&quot;datalake_status_text&quot;, statusText);
+channelMap.put(&quot;datalake_response_body&quot;, responseBody);
+channelMap.put(&quot;datalake_response_message&quot;, dataLakeErrorMessage);
+
+return;</script>
+      </properties>
+      <transformer version="26.6.0">
+        <elements>
+          <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="26.6.0">
+            <name>destination_datalake</name>
+            <sequenceNumber>0</sequenceNumber>
+            <enabled>true</enabled>
+            <script>// ---------------------- BEGIN: integrated helper + usage block ----------------------
+logger.info(&quot;DESTINATION STARTS ###&quot;);
+
+var Instant = Packages.java.time.Instant;
+var Duration = Packages.java.time.Duration;
+
+
+
+
+var source = channelMap.get(&quot;source&quot;);
+var interactionId = channelMap.get(&quot;interactionId&quot;);
+var validationSeverityLevel = channelMap.get(&quot;validationSeverityLevel&quot;);
+var saveFHIRPayload = globalMap.get(&apos;saveFHIRPayload&apos;);
+var sendDataLedgerSync = globalMap.get(&apos;sendDataLedgerSync&apos;);
+var tenantId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Tenant-ID&apos;);
+var actionDiscard = &quot;&quot;;
+channelMap.put(&apos;isActionDiscard&apos;, &quot;discard&quot;);
+
+var requestUri = channelMap.get(&quot;requestUri&quot;);
+
+// ---- Historical Replay params (set in preprocessor) ----
+var ooSizeParam = channelMap.get(&apos;ooSize&apos;);
+if (ooSizeParam == null || ooSizeParam === &apos;&apos;) { ooSizeParam = &apos;full&apos;; }
+var dataLedgerParamFlag = channelMap.get(&apos;dataLedgerParam&apos;);
+if (dataLedgerParamFlag == null || dataLedgerParamFlag === &apos;&apos;) { dataLedgerParamFlag = &apos;true&apos;; }
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: destination_datalake STARTS | tenantId=&quot; + tenantId + &quot;, requestUri=&quot; + requestUri + &quot;, ooSize=&quot; + ooSizeParam + &quot;, dataLedgerParam=&quot; + dataLedgerParamFlag + &quot;, validationSeverityLevel=&quot; + validationSeverityLevel);
+
+
+// Safe single-parse helper (handles java.lang.String)
+function parseOnceMaybeString(v) {
+    if (v === null || v === undefined) return null;
+    try {
+        if (typeof v === &apos;string&apos;) return JSON.parse(v);
+        if (v &amp;&amp; v.getClass &amp;&amp; v.getClass().getName &amp;&amp; (v.getClass().getName().indexOf(&apos;String&apos;) !== -1 || v.getClass().getName().indexOf(&apos;StringBuilder&apos;) !== -1)) {
+            return JSON.parse(v.toString());
+        }
+        if (typeof v === &apos;object&apos;) return v;
+    } catch (e) {
+        try { logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: parseOnceMaybeString: JSON.parse failed: &quot; + e); } catch(ignore){}
+        return null;
+    }
+    return null;
+}
+
+
+
+// extractIssueAndDisposition(operationOutcomePayload, severityLevel)
+// severityLevel controls the threshold used to filter issue[] (fatal / fatal+error / fatal+error+warning / all)
+function extractIssueAndDisposition(operationOutcomePayload, severityLevel) {
+    if (operationOutcomePayload === null || operationOutcomePayload === undefined) {
+        try { logger.warn(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: extractIssueAndDisposition: operationOutcomePayload is null/undefined&quot;); } catch(e){}
+        return null;
+    }
+    var payloadObj = parseOnceMaybeString(operationOutcomePayload);
+    if (!payloadObj &amp;&amp; operationOutcomePayload &amp;&amp; typeof operationOutcomePayload === &apos;object&apos;) payloadObj = operationOutcomePayload;
+    if (!payloadObj || typeof payloadObj !== &apos;object&apos;) {
+        try { logger.warn(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: extractIssueAndDisposition: payload not parseable as object&quot;); } catch(e){}
+        return null;
+    }
+
+    // tolerate OperationOutcome or operationOutcome key
+    var operationOutcomeMap = payloadObj.OperationOutcome !== undefined ? payloadObj.OperationOutcome
+                             : (payloadObj.operationOutcome !== undefined ? payloadObj.operationOutcome : null);
+
+    if (!operationOutcomeMap || typeof operationOutcomeMap !== &apos;object&apos;) {
+        try { logger.warn(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:extractIssueAndDisposition: OperationOutcome map missing&quot;); } catch(e){}
+        return null;
+    }
+
+    // validationResults
+    var validationResults = operationOutcomeMap.validationResults !== undefined ? operationOutcomeMap.validationResults
+                          : (operationOutcomeMap.get ? operationOutcomeMap.get(&apos;validationResults&apos;) : null);
+
+    if (!validationResults || !(validationResults instanceof Array) || validationResults.length === 0) {
+        try { logger.warn(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: extractIssueAndDisposition: validationResults missing or empty&quot;); } catch(e){}
+        return null;
+    }
+
+    var validationResult = validationResults[0];
+    if (!validationResult || typeof validationResult !== &apos;object&apos;) {
+        try { logger.warn(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:extractIssueAndDisposition: first validationResult missing or not an object&quot;); } catch(e){}
+        return null;
+    }
+
+    var innerOperationOutcome = validationResult.operationOutcome !== undefined ? validationResult.operationOutcome
+                              : (validationResult.get ? validationResult.get(&apos;operationOutcome&apos;) : null);
+
+    var issuesRaw = innerOperationOutcome &amp;&amp; innerOperationOutcome.issue !== undefined ? innerOperationOutcome.issue
+                  : (innerOperationOutcome &amp;&amp; innerOperationOutcome.get ? innerOperationOutcome.get(&apos;issue&apos;) : null);
+
+    // severity threshold (default to &quot;error&quot; if not provided)
+	   var sev = (severityLevel &amp;&amp; String(severityLevel).trim().length &gt; 0)
+    ? String(severityLevel).trim().toLowerCase()
+    : &apos;error&apos;;
+
+
+   logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:  Severity level (sev): &quot; + sev);
+    var allowedSeverities;
+    switch (sev) {
+        case &apos;fatal&apos;:
+            allowedSeverities = new Set([&apos;fatal&apos;]);
+            break;
+        case &apos;warning&apos;:
+            allowedSeverities = new Set([&apos;fatal&apos;,&apos;error&apos;,&apos;warning&apos;]);
+            break;
+        case &apos;information&apos;:
+            allowedSeverities = new Set([&apos;fatal&apos;,&apos;error&apos;,&apos;warning&apos;,&apos;information&apos;]);
+            break;
+        case &apos;error&apos;:
+        default:
+            allowedSeverities = new Set([&apos;fatal&apos;,&apos;error&apos;]);
+            break;
+    }
+
+    var filteredIssues = [];
+    if (issuesRaw &amp;&amp; issuesRaw instanceof Array) {
+        for (var i = 0; i &lt; issuesRaw.length; i++) {
+            var issue = issuesRaw[i];
+            if (!issue || typeof issue !== &apos;object&apos;) continue;
+            var severity = issue.severity !== undefined ? issue.severity : (issue.get ? issue.get(&apos;severity&apos;) : null);
+            if (severity &amp;&amp; allowedSeverities.has(severity.toLowerCase())) {
+
+                filteredIssues.push(issue);
+            }
+        }
+    }
+
+    if (filteredIssues.length === 0) {
+    	var validSeverities = new Set([&apos;fatal&apos;,&apos;error&apos;,&apos;warning&apos;,&apos;information&apos;]);
+    	var displaySeverity = validSeverities.has(sev)
+      ? sev
+      : &apos;error&apos;;
+        var infoIssue = { severity: &apos;information&apos;,
+                          diagnostics: &apos;Validation successful. No issues found at or above severity level: &apos; + displaySeverity,
+                          code: &apos;informational&apos; };
+        filteredIssues.push(infoIssue);
+    }
+
+    var result = {};
+    try {
+        result.resourceType = operationOutcomeMap.resourceType !== undefined ? operationOutcomeMap.resourceType
+                             : (operationOutcomeMap.get ? operationOutcomeMap.get(&apos;resourceType&apos;) : undefined);
+    } catch(e) { result.resourceType = undefined; }
+
+    result.issue = filteredIssues;
+
+    try {
+        var tbd = operationOutcomeMap.techByDesignDisposition !== undefined ? operationOutcomeMap.techByDesignDisposition
+                  : (operationOutcomeMap.get ? operationOutcomeMap.get(&apos;techByDesignDisposition&apos;) : null);
+        if (tbd) result.techByDesignDisposition = tbd;
+    } catch(e) {}
+
+    return result;
+}
+
+// applyOoSizeFilter(result, ooSize) - JS mirror of the Java
+// HistoricalReplayService#applyOoSizeFilter method. Operates on the FULL parsed
+// dest_bundle response (root object with an &quot;OperationOutcome&quot; key containing
+// &quot;validationResults&quot;), NOT on the flattened object extractIssueAndDisposition()
+// returns - that function is unchanged and continues to only affect what gets
+// forwarded to DataLake above.
+//  - ooSize &quot;full&quot; (default), or result == null -&gt; returned unchanged.
+//  - ooSize &quot;none&quot; -&gt; returns null (caller responds with just the interactionId).
+//  - ooSize &quot;lite&quot; -&gt; keeps only fatal/error issues inside every
+//        OperationOutcome.validationResults[*].operationOutcome.issue array.
+//  - any other/unexpected shape -&gt; fail-open, returned unchanged.
+function applyOoSizeFilter(result, ooSize) {
+    var normalizedOoSize = (ooSize != null &amp;&amp; String(ooSize).trim() !== &apos;&apos;) ? String(ooSize).trim().toLowerCase() : &apos;full&apos;;
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter STARTS -&gt; normalizedOoSize=&quot; + normalizedOoSize + &quot;, resultIsNull=&quot; + (result == null));
+
+    if (normalizedOoSize === &apos;full&apos; || result == null) {
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter: full (or null result) -&gt; returning result unchanged&quot;);
+        return result;
+    }
+    if (normalizedOoSize === &apos;none&apos;) {
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter: none -&gt; returning null&quot;);
+        return null;
+    }
+    if (normalizedOoSize !== &apos;lite&apos; || typeof result !== &apos;object&apos;) {
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter: not lite, or result not an object -&gt; returning result unchanged&quot;);
+        return result;
+    }
+
+    // lite: keep only error/fatal issues inside OperationOutcome.validationResults[*].operationOutcome.issue
+    try {
+        var root = {};
+        for (var rk in result) { if (Object.prototype.hasOwnProperty.call(result, rk)) root[rk] = result[rk]; }
+
+        var ooObj = root[&apos;OperationOutcome&apos;];
+        if (!ooObj || typeof ooObj !== &apos;object&apos;) {
+            logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter: lite - no OperationOutcome present, returning result unchanged&quot;);
+            return result;
+        }
+        var oo = {};
+        for (var ok in ooObj) { if (Object.prototype.hasOwnProperty.call(ooObj, ok)) oo[ok] = ooObj[ok]; }
+
+        var vrObj = oo[&apos;validationResults&apos;];
+        if (!(vrObj instanceof Array)) {
+            logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter: lite - validationResults missing/not an array, returning result unchanged&quot;);
+            return result;
+        }
+
+        var filteredVr = [];
+        for (var i = 0; i &lt; vrObj.length; i++) {
+            var vrItem = vrObj[i];
+            if (!vrItem || typeof vrItem !== &apos;object&apos;) {
+                filteredVr.push(vrItem);
+                continue;
+            }
+            var vr = {};
+            for (var vk in vrItem) { if (Object.prototype.hasOwnProperty.call(vrItem, vk)) vr[vk] = vrItem[vk]; }
+
+            var innerOoObj = vr[&apos;operationOutcome&apos;];
+            if (innerOoObj &amp;&amp; typeof innerOoObj === &apos;object&apos;) {
+                var innerOo = {};
+                for (var ik in innerOoObj) { if (Object.prototype.hasOwnProperty.call(innerOoObj, ik)) innerOo[ik] = innerOoObj[ik]; }
+
+                var issuesObj = innerOo[&apos;issue&apos;];
+                if (issuesObj instanceof Array) {
+                    var errorsOnly = [];
+                    for (var j = 0; j &lt; issuesObj.length; j++) {
+                        var iss = issuesObj[j];
+                        if (iss &amp;&amp; typeof iss === &apos;object&apos;) {
+                            var sev = String(iss[&apos;severity&apos;]);
+                            if (sev.toLowerCase() === &apos;error&apos; || sev.toLowerCase() === &apos;fatal&apos;) {
+                                errorsOnly.push(iss);
+                            }
+                        }
+                    }
+                    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter: lite - validationResults[&quot; + i + &quot;] issue count &quot; + issuesObj.length + &quot; -&gt; &quot; + errorsOnly.length + &quot; after filtering to fatal/error&quot;);
+                    innerOo[&apos;issue&apos;] = errorsOnly;
+                }
+                vr[&apos;operationOutcome&apos;] = innerOo;
+            }
+            filteredVr.push(vr);
+        }
+        oo[&apos;validationResults&apos;] = filteredVr;
+        root[&apos;OperationOutcome&apos;] = oo;
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter ENDS -&gt; lite filtering applied successfully&quot;);
+        return root;
+    } catch (e) {
+        logger.warn(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter failed, returning original unfiltered result: &quot; + e.message);
+        return result;
+    }
+}
+
+// appendToBundlePayload(payload, extractedOutcome) mirror of your Java method
+function appendToBundlePayload(payload, extractedOutcome) {
+    var bundleObj = parseOnceMaybeString(payload);
+    if (!bundleObj &amp;&amp; payload &amp;&amp; typeof payload === &apos;object&apos;) bundleObj = payload;
+    if (!bundleObj || typeof bundleObj !== &apos;object&apos;) {
+        bundleObj = { entry: [] };
+        try { logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: appendToBundlePayload: created new bundle because payload was missing/unparseable&quot;); } catch(e){}
+    }
+    if (!bundleObj.entry || !(bundleObj.entry instanceof Array)) bundleObj.entry = [];
+
+    var parsedOutcome = (extractedOutcome === null || extractedOutcome === undefined) ? null : extractedOutcome;
+    // if outcome could be a string, try parse once (function above)
+    var tryParsed = parseOnceMaybeString(parsedOutcome);
+    if (tryParsed) parsedOutcome = tryParsed;
+    if (!parsedOutcome &amp;&amp; parsedOutcome !== null &amp;&amp; typeof parsedOutcome === &apos;object&apos;) parsedOutcome = parsedOutcome;
+
+    var newEntry = { resource: parsedOutcome };
+    bundleObj.entry.push(newEntry);
+
+    // return shallow copy (similar to Java new HashMap&lt;&gt;(payload) and put entry)
+    var finalPayload = {};
+    for (var k in bundleObj) {
+        if (Object.prototype.hasOwnProperty.call(bundleObj, k)) finalPayload[k] = bundleObj[k];
+    }
+    return finalPayload;
+}
+
+
+function isActionDiscard(updatedPayload) {
+    // helper to read property from Java Map or JS object
+    function getProp(obj, key) {
+        if (obj == null) return null;
+        if (typeof obj.get === &apos;function&apos;) {
+            try { return obj.get(key); } catch(e) { return null; }
+        }
+        return obj[key];
+    }
+
+    // helper to iterate a java.util.List or JS Array
+    function iterateList(list, fn) {
+        if (list == null) return false;
+        try {
+            if (typeof list.size === &apos;function&apos; &amp;&amp; typeof list.get === &apos;function&apos;) {
+                for (var i = 0; i &lt; list.size(); i++) {
+                    if (fn(list.get(i), i)) return true;
+                }
+                return false;
+            } else if (Array.isArray(list)) {
+                for (var j = 0; j &lt; list.length; j++) {
+                    if (fn(list[j], j)) return true;
+                }
+                return false;
+            } else if (typeof list.iterator === &apos;function&apos;) {
+                var it = list.iterator();
+                var idx = 0;
+                while (it.hasNext()) {
+                    if (fn(it.next(), idx++)) return true;
+                }
+                return false;
+            }
+        } catch(e) {
+            logger.error(&quot;iterateList error: &quot; + e);
+        }
+        return false;
+    }
+
+    // normalize payload: if string try parse
+    var obj = updatedPayload;
+    if (typeof updatedPayload === &apos;string&apos;) {
+        try {
+            obj = JSON.parse(updatedPayload);
+        } catch (e) {
+            logger.info(&quot;isActionDiscard: payload is not valid JSON string&quot;);
+            return false;
+        }
+    }
+
+    // if payload itself is OperationOutcome (rare)
+    var maybeOp = getProp(obj, &apos;OperationOutcome&apos;);
+    if (maybeOp) {
+        // if OperationOutcome is an object that contains techByDesignDisposition
+        var dispositions = getProp(maybeOp, &apos;techByDesignDisposition&apos;);
+        if (iterateList(dispositions, function(d) {
+            var action = getProp(d, &apos;action&apos;);
+            return action != null &amp;&amp; String(action).trim().toLowerCase() === &apos;discard&apos;;
+        })) return true;
+    }
+
+    // If this is a Bundle with entries, look in each entry.resource
+    var entries = getProp(obj, &apos;entry&apos;);
+    if (entries) {
+        var found = iterateList(entries, function(entry) {
+            var resource = getProp(entry, &apos;resource&apos;);
+            if (!resource) return false;
+            var rType = getProp(resource, &apos;resourceType&apos;);
+            // check if this resource is OperationOutcome
+            if (rType &amp;&amp; String(rType).toLowerCase() === &apos;operationoutcome&apos;) {
+                var dispositions = getProp(resource, &apos;techByDesignDisposition&apos;);
+                return iterateList(dispositions, function(d) {
+                    var action = getProp(d, &apos;action&apos;);
+                    return action != null &amp;&amp; String(action).trim().toLowerCase() === &apos;discard&apos;;
+                });
+            }
+            return false;
+        });
+        if (found) return true;
+    }
+
+    // Also check top-level techByDesignDisposition if present directly on payload
+    var topDispositions = getProp(obj, &apos;techByDesignDisposition&apos;);
+    if (topDispositions) {
+        if (iterateList(topDispositions, function(d) {
+            var action = getProp(d, &apos;action&apos;);
+            return action != null &amp;&amp; String(action).trim().toLowerCase() === &apos;discard&apos;;
+        })) return true;
+    }
+
+    return false;
+}
+
+
+
+
+// ---------------------- usage: extract rawResponseMsg, call functions and persist ----------------------
+
+// 1) extract rawResponseMsg safely from responseMap
+var destName = &apos;dest_bundle&apos;;
+var rawResponseMsg = null;
+try {
+    var destResp = responseMap.get(destName);
+    if (destResp) {
+        if (typeof destResp.getMessage === &apos;function&apos;) {
+            rawResponseMsg = destResp.getMessage();
+        } else if (destResp.message !== undefined) {
+            rawResponseMsg = destResp.message;
+        } else {
+            rawResponseMsg = destResp.toString();
+        }
+    } else {
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:No response found in responseMap for &quot; + destName);
+    }
+} catch (e) {
+    rawResponseMsg = null;
+    try { logger.warn(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:Error while extracting rawResponseMsg: &quot; + e); } catch(ignore){}
+}
+
+// 2) get rawFhir
+var rawFhir = null;
+try { rawFhir = channelMap.get(&apos;fhirJson&apos;); } catch(e) { rawFhir = null; }
+
+// 3) call extractIssueAndDisposition for the payload forwarded to DataLake
+// (this filter is unchanged and continues to use the X-TechBD-Validation-Severity-Level header)
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Calling extractIssueAndDisposition (DataLake-forward filter) with validationSeverityLevel=&quot; + validationSeverityLevel);
+var extractedPayload = null;
+try {
+    extractedPayload = extractIssueAndDisposition(rawResponseMsg, validationSeverityLevel);
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: extractIssueAndDisposition returned &quot; + (extractedPayload == null ? &quot;null&quot; : &quot;a result&quot;) + &quot; for DataLake forward&quot;);
+} catch (e) {
+    try { logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:extractIssueAndDisposition threw: &quot; + e); } catch(ignore){}
+    extractedPayload = null;
+}
+
+
+try{
+var bundleJson = JSON.parse(rawFhir);
+// Extract bundle id
+var bundleId = bundleJson.id ;
+var dataId = interactionId;
+
+	if (bundleId != null &amp;&amp; bundleId.toString().trim().length &gt; 0) {
+		 dataId = bundleId;
+	}
+	logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Resolved dataId=&quot; + dataId + &quot; (bundle.id present=&quot; + (bundleId != null) + &quot;)&quot;);
+}catch (e) {
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Invalid JSON payload received, aborting: &quot; + e);
+    var rawErrorResponse = JSON.stringify({
+        error: &quot;Invalid JSON payload&quot;,
+        message: e.toString()
+    });
+    responseMap.put(&apos;finalResponse&apos;, rawResponseMsg);
+    throw rawErrorResponse;
+}
+
+
+// 4) append to bundle if we got something
+if (extractedPayload) {
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: extractedPayload present -&gt; appending to bundle and continuing forward/DataLedger/DB flow&quot;);
+    try {
+        var updatedPayload = appendToBundlePayload(rawFhir, extractedPayload);
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: appendToBundlePayload complete&quot;);
+
+		if (isActionDiscard(JSON.stringify(updatedPayload))) {
+			logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: isActionDiscard=true -&gt; will skip DataLedger/DB-forward for this interaction&quot;);
+			channelMap.put(&apos;finalResponse&apos;, JSON.stringify(updatedPayload));
+			channelMap.put(&apos;isActionDiscard&apos;, &quot;discard&quot;);
+			actionDiscard = &quot;discard&quot;;
+		}
+		
+		if (updatedPayload == null) {
+			channelMap.put(&apos;finalResponse&apos;, JSON.stringify(updatedPayload));
+			channelMap.put(&apos;isActionDiscard&apos;, &quot;discard&quot;);
+		}
+        
+	if( actionDiscard != &quot;discard&quot;){
+        // persist updated bundle back (try channelMap first, fallback to responseMap)
+        try {
+            var updatedStr = JSON.stringify(updatedPayload);
+            channelMap.put(&apos;updatedFhirJson&apos;, updatedStr);
+            try {
+		responseMap.put(&apos;updatedFhirJson&apos;, updatedStr);
+
+
+		logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: DATA LEDGER STARTS&quot;);
+		
+		var currentTimestampBegin = new Date().toISOString().replace(/\.(\d{3})Z$/, function(match, millis) {
+	    // Add 3 more random digits to simulate microseconds
+	    var micros = millis + (Math.floor(Math.random() * 1000)).toString().padStart(3, &apos;0&apos;);
+	    return &apos;.&apos; + micros + &apos;Z&apos;;
+	   });
+		//save Datakledger starts
+	var payloadDataLedger = JSON.stringify({
+	        executedAt: currentTimestampBegin,
+	        actor: &quot;TechBD&quot;,
+	        action: &quot;sent&quot;,
+	        destination: &quot;NYeC&quot;,
+	        dataId: dataId,
+	        payloadType: &quot;hrsnBundle&quot;
+	    });
+	    	    
+		var trackingEnabled = channelMap.get(&quot;DATA_LEDGER_TRACKING&quot;);
+
+		// Historical-replay: honor the dataLedger query parameter in addition to the
+		// existing DATA_LEDGER_TRACKING config. dataLedger=false always skips the call,
+		// dataLedger=true/omitted behaves exactly as today.
+		if (trackingEnabled != null &amp;&amp; trackingEnabled.toLowerCase() == &quot;true&quot; &amp;&amp; dataLedgerParamFlag !== &quot;false&quot;) {
+		    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:data ledger api call -BEGIN received&quot;);
+		    try {
+		        sendDataLedgerSync(payloadDataLedger,interactionId);
+		    } catch (e) {
+		        logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:Error occurred while sending data to Data Ledger: &quot; + e.message);
+		    }
+		    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:data ledger api call -END received&quot;);
+		} else {
+		    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:DATA_LEDGER_TRACKING is not true or dataLedger query param is false; skipping Data Ledger sync. dataLedgerParam=&quot; + dataLedgerParamFlag);
+		}
+		logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: DATA LEDGER ENDS&quot;);
+		//save Datakledger ends
+		channelMap.put(&apos;isActionDiscard&apos;, &quot;&quot;);
+		
+		// Save to DB starts
+		var operation = &quot;saveForwardFHIRPayload&quot;;
+		
+		try{
+			logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: REGISTER State Forward : BEGIN for inteaction id  : &quot;+interactionId + &quot; tenant id : &quot; + tenantId);
+			var start = Instant.now();
+			
+		     var operation = &quot;saveForwardFHIRPayload&quot;;
+		     var result = saveFHIRPayload(
+			   interactionId,
+			   tenantId,
+			   requestUri ,
+			   JSON.stringify(updatedPayload),
+			   operation,source
+			);
+			var end = Instant.now();
+			var elapsedMillis = Duration.between(start, end).toMillis();
+			logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:REGISTER State Forward : END for interaction id: &quot;+interactionId + &quot; tenant id: &quot; + tenantId + &quot;. Time taken: &quot;+ elapsedMillis);
+		} catch (e) {
+			LOG.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:ERROR:: REGISTER State Forward CALL for interaction id : &quot;+interactionId + &quot; tenant id : &quot; + tenantId );
+			var errorMsg;
+	            if (e instanceof JavaException) {
+	                errorMsg = &quot;ERROR:: REGISTER State Forward CALL for interaction id : &quot;+interactionId + &quot; tenant id : &quot; + tenantId + &quot; :  &quot; + e.toString();
+	                throw errorMessage;
+	            } else {
+	                errorMsg = &quot;Unexpected error during saving: &quot; + e.message;
+	                throw errorMessage;
+	            }
+		}
+
+		/// Save to DB ends
+
+
+            }
+            catch (e) { responseMap.put(&apos;updatedFhirJson&apos;, updatedStr); logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Saved updated bundle to responseMap.updatedFhirJson&quot;); }
+        } catch (e) {
+            try { responseMap.put(&apos;updatedFhirJson&apos;, updatedStr); logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Saved updated bundle object to responseMap.updatedFhirJson&quot;); } catch(ignore){}
+        }
+	} // isActionDiscard
+
+        // ---- Historical Replay: build the client-facing response based on ooSize ----
+        // Mirrors HistoricalReplayService#applyOoSizeFilter (Java) plus the controller&apos;s
+        // &quot;if (filtered == null) return interactionId-only 200&quot; check:
+        //  - full (default), or a null/unparseable result -&gt; unchanged (raw OperationOutcome).
+        //  - lite -&gt; keeps only fatal/error issues inside each
+        //           OperationOutcome.validationResults[*].operationOutcome.issue entry.
+        //  - none -&gt; applyOoSizeFilter returns null explicitly.
+        //  - Whenever the filtered result is null (ooSize=none, or nothing to return),
+        //    respond HTTP 200 with just {&quot;interactionId&quot;: ...} and no OperationOutcome body.
+        logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Building historical-replay client response. ooSize=&quot; + ooSizeParam + &quot;, dataLedgerParam=&quot; + dataLedgerParamFlag);
+        try {
+            var parsedRawResponse = parseOnceMaybeString(rawResponseMsg);
+            if (!parsedRawResponse &amp;&amp; rawResponseMsg &amp;&amp; typeof rawResponseMsg === &apos;object&apos;) {
+                parsedRawResponse = rawResponseMsg;
+            }
+            logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: parsedRawResponse is &quot; + (parsedRawResponse == null ? &quot;null/unparseable&quot; : &quot;parsed OK&quot;));
+
+            var filteredResult = null;
+            try {
+                filteredResult = applyOoSizeFilter(parsedRawResponse, ooSizeParam);
+            } catch (eFilter) {
+                logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: applyOoSizeFilter threw, falling back to raw response: &quot; + eFilter);
+                filteredResult = parsedRawResponse;
+            }
+
+            if (filteredResult == null) {
+                logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Historical Replay returning HTTP 200 with EMPTY BODY | interactionId=&quot; + interactionId);
+                responseMap.put(&apos;finalResponse&apos;, JSON.stringify({ interactionId: interactionId }));
+            } else {
+                logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Historical Replay returning HTTP 200 with OperationOutcome body for ooSize=&quot; + ooSizeParam);
+                responseMap.put(&apos;finalResponse&apos;, JSON.stringify(filteredResult));
+            }
+        } catch(eResp){
+            logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Unexpected error building historical-replay response, falling back to raw response: &quot; + eResp);
+            responseMap.put(&apos;finalResponse&apos;, rawResponseMsg);
+        }
+    } catch (e) {
+        try { logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Failed to append extractedPayload: &quot; + e); } catch(ignore){}
+    }
+} else {
+    try { logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: No extractedPayload produced — nothing appended.&quot;); } catch(ignore){}
+}
+
+logger.info(&quot;DESTINATION ENDS ###&quot;);
+
+// ---------------------- END block ----------------------</script>
+          </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
+        </elements>
+        <inboundTemplate encoding="base64"></inboundTemplate>
+        <outboundTemplate encoding="base64"></outboundTemplate>
+        <inboundDataType>RAW</inboundDataType>
+        <outboundDataType>RAW</outboundDataType>
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </inboundProperties>
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </outboundProperties>
+      </transformer>
+      <responseTransformer version="26.6.0">
+        <elements/>
+        <inboundDataType>RAW</inboundDataType>
+        <outboundDataType>RAW</outboundDataType>
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </inboundProperties>
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.raw.RawDataTypeProperties" version="26.6.0">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.raw.RawBatchProperties" version="26.6.0">
+            <splitType>JavaScript</splitType>
+            <batchScript></batchScript>
+          </batchProperties>
+        </outboundProperties>
+      </responseTransformer>
+      <filter version="26.6.0">
+        <elements>
+          <com.mirth.connect.plugins.javascriptrule.JavaScriptRule version="26.6.0">
+            <name>redirection</name>
+            <sequenceNumber>0</sequenceNumber>
+            <enabled>true</enabled>
+            <script>var path = String(channelMap.get(&quot;requestedPath&quot;)).replace(/\/$/, &quot;&quot;);
+return path != &quot;/tenants&quot;;</script>
+          </com.mirth.connect.plugins.javascriptrule.JavaScriptRule>
+        </elements>
+      </filter>
+      <transportName>JavaScript Writer</transportName>
+      <mode>DESTINATION</mode>
+      <enabled>true</enabled>
+      <waitForPrevious>true</waitForPrevious>
+    </connector>
+  </destinationConnectors>
+  <preprocessingScript>// Modify the message variable below to pre process data
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;]: STEP Preprocessor - START.&quot;);
+
+var requestedPath = sourceMap.get(&apos;contextPath&apos;);
+
+// Read both headers
+var overridePath = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Override-Request-URI&apos;);
+var requestUri = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Request-URI&apos;);
+
+// Use whichever is present and non-empty (first check override, otherwise requestUri)
+var effectivePath = (overridePath &amp;&amp; overridePath.trim() !== &apos;&apos;)
+    ? overridePath.trim()
+    : (requestUri &amp;&amp; requestUri.trim() !== &apos;&apos;)
+        ? requestUri.trim()
+        : null;
+
+// If we found a usable override path, apply it
+if (effectivePath !== null) {
+    requestedPath = effectivePath;
+}
+
+channelMap.put(&quot;requestedPath&quot;, requestedPath);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;]: Preprocessor - contextPath=&quot; + sourceMap.get(&apos;contextPath&apos;) + &quot;, overridePath=&quot; + overridePath + &quot;, X-TechBD-Request-URI=&quot; + requestUri + &quot;, resolved requestedPath=&quot; + requestedPath);
+
+
+
+if (
+    requestedPath == &quot;/&quot; ||
+    requestedPath == &quot;/healthcheck&quot; ||
+    requestedPath == &quot;/tenants&quot;||
+    requestedPath == &quot;/tenants/&quot;
+) {
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;]: Preprocessor - requestedPath=&quot; + requestedPath + &quot; needs no body/tenant validation, short-circuit return.&quot;);
+    return;
+}
+
+// ---- REQUEST BODY VALIDATION ----
+if (requestedPath != &quot;/tenants&quot; || requestedPath != &quot;/tenants/&quot;) {
+
+if (message == null || String(message).trim() === &quot;&quot;) {
+    var errorMessage = &quot;Validation Error: Required request body is missing&quot;;
+    logger.error(errorMessage);
+    setErrorResponse(400, errorMessage);
+    throw errorMessage;
+}
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;]: Preprocessor - request body present, length=&quot; + String(message).length);
+}
+channelMap.put(&apos;channelName&apos;,channelName);
+
+
+var incomingInteractionId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Interaction-ID&apos;);
+var incomingCorrelationId = $(&apos;headers&apos;).getHeader(&apos;X-Correlation-ID&apos;);
+
+var interactionId;
+
+if (incomingInteractionId != null &amp;&amp; incomingInteractionId.trim() !== &apos;&apos;) {
+    interactionId = incomingInteractionId;
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;]: Preprocessor - using incoming X-TechBD-Interaction-ID: &quot; + interactionId);
+} else if (incomingCorrelationId != null &amp;&amp; incomingCorrelationId.trim() !== &apos;&apos;) {
+    interactionId = incomingCorrelationId;
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;]: Preprocessor - using incoming X-Correlation-ID as interactionId: &quot; + interactionId);
+} else {
+    interactionId = generateUuid();
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;]: Preprocessor - generated new interactionId: &quot; + interactionId);
+}
+
+
+channelMap.put(&apos;interactionId&apos;, interactionId);
+
+var groupInteractionId = &quot;&quot;;
+var incomingGroupId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Group-Interaction-ID&apos;);
+
+if (incomingGroupId != null &amp;&amp; incomingGroupId.trim() !== &apos;&apos;) {
+    groupInteractionId = incomingGroupId.trim();
+}
+
+var masterInteractionId = &quot;&quot;;
+var incomingMasterId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Master-Interaction-ID&apos;);
+
+if (incomingMasterId != null &amp;&amp; incomingMasterId.trim() !== &apos;&apos;) {
+    masterInteractionId = incomingMasterId.trim();
+}
+
+channelMap.put(&quot;groupInteractionId&quot;, groupInteractionId);
+channelMap.put(&quot;masterInteractionId&quot;, masterInteractionId);
+globalMap.put(&quot;groupInteractionId&quot;, groupInteractionId);
+globalMap.put(&quot;masterInteractionId&quot;, masterInteractionId);
+
+
+// Get the URI from sourceMap
+var uri = sourceMap.get(&apos;uri&apos;);
+var getQueryParameter = globalMap.get(&apos;getQueryParam&apos;);
+//Extract &apos;source&apos;
+var source = getQueryParameter(uri, &apos;source&apos;);
+
+if (!source || source.trim() === &apos;&apos;) {
+    var headerSource = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Source-Type&apos;);
+    if (headerSource &amp;&amp; headerSource.trim() !== &apos;&apos;) {
+        source = headerSource.trim();
+    } else {
+        source = &apos;FHIR&apos;;
+    }
+}
+
+// Store back for further use
+channelMap.put(&apos;source&apos;, source);
+
+// ---- Historical Replay Query Parameters ----
+// ooSize: full (default) | lite | none
+//var ooSizeParam = getQueryParameter(uri, &apos;ooSize&apos;);
+//if (ooSizeParam != null) { ooSizeParam = ooSizeParam.trim().toLowerCase(); }
+//if (ooSizeParam !== &apos;lite&apos; &amp;&amp; ooSizeParam !== &apos;none&apos; &amp;&amp; ooSizeParam !== &apos;full&apos;) {
+//    ooSizeParam = &apos;full&apos;;
+//}
+//**********************************
+
+var ooSizeParam = getQueryParameter(uri, &apos;ooSize&apos;);
+
+if (ooSizeParam == null || ooSizeParam.trim() === &apos;&apos;) {
+    ooSizeParam = &apos;full&apos;;
+} else {
+    ooSizeParam = ooSizeParam.trim().toLowerCase();
+
+    if (ooSizeParam !== &apos;lite&apos; &amp;&amp;
+        ooSizeParam !== &apos;none&apos; &amp;&amp;
+        ooSizeParam !== &apos;full&apos;) {
+
+        setErrorResponse(
+            400,
+            &quot;Invalid ooSize. Allowed values are: full, lite, none.&quot;
+        );
+
+        throw &quot;Invalid ooSize parameter&quot;;
+    }
+}
+
+channelMap.put(&apos;ooSize&apos;, ooSizeParam);
+
+// dataLedger: true (default) | false
+var dataLedgerParam = getQueryParameter(uri, &apos;dataLedger&apos;);
+if (dataLedgerParam != null) { dataLedgerParam = dataLedgerParam.trim().toLowerCase(); }
+if (dataLedgerParam !== &apos;true&apos; &amp;&amp; dataLedgerParam !== &apos;false&apos;) {
+    dataLedgerParam = &apos;true&apos;;
+}
+channelMap.put(&apos;dataLedgerParam&apos;, dataLedgerParam);
+
+logger.info(&quot;Historical Replay params -&gt; ooSize: &quot; + ooSizeParam + &quot;, dataLedger: &quot; + dataLedgerParam);
+
+
+var tenantId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Tenant-ID&apos;);
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: tenantid: &quot; + tenantId);
+channelMap.put(&apos;tenantId&apos;, tenantId);
+
+
+var userAgent = $(&apos;headers&apos;).getHeader(&apos;User-Agent&apos;);
+channelMap.put(&apos;userAgent&apos;, userAgent);
+
+
+
+
+var severity = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Validation-Severity-Level&apos;)
+            || $(&apos;headers&apos;).getHeader(&apos;x-techbd-validation-severity-level&apos;);
+
+var validationSeverityLevel = &quot;error&quot;;
+var incomingSeverity = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Validation-Severity-Level&apos;);
+
+
+// If header has valid value, use it; otherwise keep default
+if (incomingSeverity != null &amp;&amp; incomingSeverity.trim() !== &apos;&apos;) {
+    validationSeverityLevel = incomingSeverity;
+}
+
+channelMap.put(&quot;validationSeverityLevel&quot;,validationSeverityLevel);
+
+
+var igVersion = &quot;&quot;;
+var incomingIgVersion = $(&apos;headers&apos;).getHeader(&apos;X-SHIN-NY-IG-Version&apos;);
+
+if (incomingIgVersion != null &amp;&amp; incomingIgVersion.trim() !== &apos;&apos;) {
+    igVersion = incomingIgVersion;
+}
+
+channelMap.put(&apos;igVersion&apos;, igVersion);
+
+var elaboration = &quot;&quot;;
+var incomingElaboration = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Elaboration&apos;);
+
+// If header has valid value, use it; otherwise keep default (empty string or any fallback)
+if (incomingElaboration != null &amp;&amp; incomingElaboration.trim() !== &apos;&apos;) {
+    elaboration = incomingElaboration.trim();
+}
+
+function getValue(value) {
+    return (value == null || String(value).trim() === &apos;&apos;) ? null : String(value).trim();
+}
+
+if (source === &apos;FHIR&apos;) {
+
+    var elaborationObj = {
+        headers: {
+            &quot;OverrideRequestURI&quot;: $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Override-Request-URI&apos;),
+            &quot;RequestURI&quot;: channelMap.get(&quot;requestedPath&quot;),
+            &quot;InteractionID&quot;: channelMap.get(&apos;interactionId&apos;),
+            &quot;CorrelationID&quot;: $(&apos;headers&apos;).getHeader(&apos;X-Correlation-ID&apos;),
+            &quot;GroupInteractionID&quot;: getValue(channelMap.get(&quot;groupInteractionId&quot;)),
+            &quot;MasterInteractionID&quot;: getValue(channelMap.get(&quot;masterInteractionId&quot;)),
+            &quot;SourceType&quot;: $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Source-Type&apos;),
+            &quot;TenantID&quot;: $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Tenant-ID&apos;),
+            &quot;ValidationSeverityLevel&quot;: $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Validation-Severity-Level&apos;),
+            &quot;SHINNYIGVersion&quot;: $(&apos;headers&apos;).getHeader(&apos;X-SHIN-NY-IG-Version&apos;)
+        }
+    };
+
+    elaboration = JSON.stringify(elaborationObj);
+
+}
+
+channelMap.put(&quot;elaboration&quot;, elaboration);
+
+
+var healthCheck = &quot;&quot;;
+var incomingHealthCheck = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-HealthCheck&apos;);
+
+if (incomingHealthCheck != null &amp;&amp; incomingHealthCheck.trim() !== &apos;&apos;) {
+    healthCheck = incomingHealthCheck.trim();
+}
+
+channelMap.put(&quot;healthCheck&quot;, healthCheck);
+logger.info(&quot;**************[FhirBundleHistoricalReplay] incomingHealthCheck raw: &quot; + incomingHealthCheck + &quot; | healthCheck stored: &quot; + healthCheck);
+
+
+// Check if the header is null or empty
+if (tenantId == null || String(tenantId).trim() === &quot;&quot;) {
+    // Log the error for debugging
+    var errorMessage = &apos;Bad Request: Missing required header X-TechBD-Tenant-ID&apos;;
+    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: &quot; + errorMessage);
+    setErrorResponse(400, errorMessage); // Set the HTTP response status to 400 (Bad Request)
+    throw errorMessage; // Stop further processing by throwing an exception
+}
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: STEP Preprocessor - END. tenantId validated, proceeding to filter/transformer.&quot;);
+
+return message;</preprocessingScript>
+  <postprocessingScript>var Instant = Packages.java.time.Instant;
+var Duration = Packages.java.time.Duration;
+
+var chlName = channelMap.get(&apos;channelName&apos;);
+var interactionId = channelMap.get(&quot;interactionId&quot;);
+var isActionDiscard = channelMap.get(&quot;isActionDiscard&quot;);
+var requestUri = channelMap.get(&quot;requestUri&quot;);;
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: STEP Postprocessor - START. isActionDiscard=&quot; + isActionDiscard + &quot;, ooSize=&quot; + channelMap.get(&apos;ooSize&apos;) + &quot;, dataLedgerParam=&quot; + channelMap.get(&apos;dataLedgerParam&apos;));
+
+var requestedPath = channelMap.get(&apos;requestedPath&apos;);
+logger.info(&quot;requestedPath&quot;+requestedPath);
+if (
+    requestedPath == &quot;/&quot; ||
+    requestedPath == &quot;/healthcheck&quot;
+) {
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Postprocessor - requestedPath=&quot; + requestedPath + &quot;, nothing further to do, returning.&quot;);
+    return;
+}
+
+
+if (requestedPath == &quot;/tenants&quot; || requestedPath == &quot;/tenants/&quot;) {
+
+    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Postprocessor - returning /tenants response.&quot;);
+    var body = String(channelMap.get(&quot;tenantResponse&quot;));
+
+    responseMap.put(&quot;responseStatusCode&quot;, 200);
+    responseMap.put(&quot;responseContentType&quot;, &quot;application/json&quot;);
+    responseMap.put(&quot;finalResponse&quot;, body);
+
+    return;
+}
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Postprocessor STARTS.&quot;);
+
+
+// ------------------------------------------------------------------
+// Get DataLake Response from channelMap (NOT responseMap anymore)
+// ------------------------------------------------------------------
+
+var responseDataLakeStatus = channelMap.get(&quot;datalake_status_code&quot;);
+var responseDataLakeData = channelMap.get(&quot;datalake_response_body&quot;);
+var responseDataLakeStatusText = channelMap.get(&quot;datalake_status_text&quot;);
+var dataLakeErrorMessage = channelMap.get(&quot;datalake_response_message&quot;);
+var destinationDataLakeName = &quot;dest_datalake&quot;;
+
+logger.info(&quot;DataLake HTTP Status: &quot; + responseDataLakeStatus+&quot; DataLake HTTP Status Text: &quot; + responseDataLakeStatusText+&quot; DataLake Response Body: &quot; + responseDataLakeData);
+	
+	// Check if the response exists
+if (responseDataLakeStatusText &amp;&amp; isActionDiscard != &quot;discard&quot;) {
+
+
+
+var saveFHIRPayload = globalMap.get(&apos;saveFHIRPayload&apos;);
+var tenantId = $(&apos;headers&apos;).getHeader(&apos;X-TechBD-Tenant-ID&apos;);
+var source = channelMap.get(&quot;source&quot;);
+
+var datalakeApiUrl = channelMap.get(&apos;DATALAKE_API_URL&apos;);
+		
+
+
+		var status = &quot;&quot;;
+		
+		try {
+
+			 
+    
+		    // Validate DataLake API URL first
+		    if (!datalakeApiUrl || datalakeApiUrl.trim() === &apos;&apos;) {
+		        responseDataLakeData = JSON.stringify({
+		            status: &quot;failure&quot;,
+		            error: &quot;DataLake API URL is empty or missing&quot;,
+		            message: &quot;DataLake API URL is empty or missing&quot;,
+		            tenantId: tenantId,
+		            rootCause: &quot;Invalid configuration&quot;,
+		            mostSpecificCause: &quot;Missing DataLake API URL&quot;,
+		            dataLakeApiBaseURL: datalakeApiUrl
+		        });
+		    }
+		    else if (!/^https?:\/\//i.test(datalakeApiUrl)) {
+		        responseDataLakeData = JSON.stringify({
+		            status: &quot;failure&quot;,
+		            error: &quot;Invalid DataLake API URL scheme. Failed to resolve &apos;&quot; + datalakeApiUrl + &quot;&apos;&quot;,
+		            message: &quot;Failed to resolve &apos;&quot; + datalakeApiUrl + &quot;&apos;&quot;,
+		            tenantId: tenantId,
+		            rootCause: &quot;Invalid URL scheme : DataLake API URL must start with http or https&quot;,
+		            mostSpecificCause: &quot;Unsupported protocol in DataLake API URL&quot;,
+		            dataLakeApiBaseURL: datalakeApiUrl
+		        });
+		    }
+
+			// --------------------------------------------------------------
+			// 2 HTTP Error Handling (&gt;=400)
+			// --------------------------------------------------------------
+			else if (responseDataLakeStatus &gt;= 400) {
+				var httpMessage = responseDataLakeStatus + &quot; &quot; + responseDataLakeStatusText + &quot; from POST &quot; + datalakeApiUrl;
+
+			    var finalMessage = httpMessage;
+			
+			    // Only for server errors
+				if (responseDataLakeStatus &gt;= 500) {
+				
+				    // 1 First priority: message already extracted earlier
+				    if (dataLakeErrorMessage &amp;&amp; String(dataLakeErrorMessage).trim() !== &quot;&quot;) {
+				
+				        finalMessage = dataLakeErrorMessage;
+				
+				    }
+				
+				    // 2 Second priority: try parsing API response
+				    else if (responseDataLakeData) {
+				
+				        try {
+				            var errObj = JSON.parse(responseDataLakeData);
+				
+				            if (errObj &amp;&amp; errObj.message &amp;&amp; String(errObj.message).trim() !== &quot;&quot;) {
+				                finalMessage = errObj.message;
+				            }
+				
+				        } catch (ignore) {
+				            logger.warn(&quot;Response not JSON, using HTTP message&quot;);
+				        }
+				
+				    }
+				}
+    
+
+				responseDataLakeData = JSON.stringify({
+					status: &quot;failure&quot;,
+					dataLakeApiBaseURL: datalakeApiUrl,
+					error: responseDataLakeStatus+&quot; &quot;+responseDataLakeStatusText+&quot; from POST &quot; + datalakeApiUrl,
+					message: finalMessage,
+					tenantId: tenantId,
+					statusCode: responseDataLakeStatus,
+					statusText: responseDataLakeStatusText,
+					responseBody: responseDataLakeData,
+					rootCause: null,
+					mostSpecificCause: responseDataLakeStatus+&quot; &quot;+responseDataLakeStatusText+&quot; from POST &quot; + datalakeApiUrl
+				});
+			}
+
+			 // Parse DataLake response if present
+			    if (responseDataLakeData &amp;&amp; responseDataLakeData.trim() !== &quot;&quot;) {
+			        var dlResponse = JSON.parse(responseDataLakeData);
+			        status = (dlResponse.status || &quot;&quot;).toLowerCase();
+			    }
+		
+		   
+		    
+		} catch (e) {
+
+			logger.error(&quot;Invalid JSON from DataLake: &quot; + e);
+
+			responseDataLakeData = JSON.stringify({
+				status: &quot;failure&quot;,
+				error: e.toString(),
+				message: &quot;Failed to resolve &quot;+datalakeApiUrl,
+				tenantId: tenantId,
+				statusCode: responseDataLakeStatus,
+				statusText: responseDataLakeStatusText,
+				responseBody: responseDataLakeData,
+				rootCause: &quot;JSON parsing error&quot;,
+				mostSpecificCause: e.message || e.toString(),
+				dataLakeApiBaseURL: datalakeApiUrl
+			});
+
+			status = &quot;failure&quot;;
+		}
+
+
+
+		
+
+		
+		if (status === &quot;success&quot;) {
+		   
+		    var operation = &quot;saveForwardFHIRSuccess&quot;;
+		logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:  saveForwardFHIRSuccess - FHIR Data Lake Complete Payload save &quot;);
+		
+		try{
+			logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: REGISTER State Complete : BEGIN for inteaction id  : &quot;+interactionId + &quot; tenant id : &quot; + tenantId + &quot; requestUri : &quot; + requestUri);
+			var start = Instant.now();
+			
+		     var operation = &quot;saveForwardFHIRSuccess&quot;;
+		     var result = saveFHIRPayload(
+			   interactionId,
+			   tenantId,
+			   requestUri,
+			   responseDataLakeData ,
+			   operation,source
+			);
+			var end = Instant.now();
+			var elapsedMillis = Duration.between(start, end).toMillis();
+			logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: REGISTER State Complete : END for interaction id: &quot;+interactionId + &quot; tenant id: &quot; + tenantId + &quot;. Time taken: &quot;+ elapsedMillis);
+		} catch (e) {
+			LOG.error(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: ERROR:: REGISTER State Complete CALL for interaction id : &quot;+interactionId + &quot; tenant id : &quot; + tenantId );
+			var errorMsg;
+	            if (e instanceof JavaException) {
+	                errorMsg = &quot;ERROR:: REGISTER State Complete CALL for interaction id : &quot;+interactionId + &quot; tenant id : &quot; + tenantId + &quot; :  &quot; + e.toString();
+	                throw errorMessage;
+	            } else {
+	                errorMsg = &quot;Unexpected error during saving: &quot; + e.message;
+	                throw errorMessage;
+	            }
+		}
+		} else {
+		    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: error - status: &quot; + status);
+		    var operation = &quot;saveForwardFHIRFailure&quot;;
+		logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:  saveForwardFHIRFailure - FHIR Data Lake Forward Payload save &quot;);
+		
+		try{
+			logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: REGISTER State Fail : BEGIN for inteaction id  : &quot;+interactionId + &quot; tenant id : &quot; + tenantId);
+			var start = Instant.now();
+
+		
+		     var operation = &quot;saveForwardFHIRFailure&quot;;
+		     var result = saveFHIRPayload(
+			   interactionId,
+			   tenantId,
+			   requestUri,
+			   responseDataLakeData ,
+			   operation,source
+			);
+			var end = Instant.now();
+			var elapsedMillis = Duration.between(start, end).toMillis();
+			logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: REGISTER State Fail : END for interaction id: &quot;+interactionId + &quot; tenant id: &quot; + tenantId + &quot;. Time taken: &quot;+ elapsedMillis);
+		} catch (e) {
+			LOG.error(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: ERROR:: REGISTER State Fail CALL for interaction id : &quot;+interactionId + &quot; tenant id : &quot; + tenantId );
+			var errorMsg;
+	            if (e instanceof JavaException) {
+	                errorMsg = &quot;ERROR:: REGISTER State Fail CALL for interaction id : &quot;+interactionId + &quot; tenant id : &quot; + tenantId + &quot; :  &quot; + e.toString();
+	                throw errorMessage;
+	            } else {
+	                errorMsg = &quot;Unexpected error during saving: &quot; + e.message;
+	                throw errorMessage;
+	            }
+		}
+		}
+		
+		
+
+
+		
+
+	} else {
+	    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: response found for destination Data Lake: &quot; + destinationDataLakeName);
+	}
+
+logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + chlName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Postprocessor ENDS.&quot;);
+
+return;
+</postprocessingScript>
+  <deployScript>// This script executes once when the channel is deployed
+// You only have access to the globalMap and globalChannelMap here to persist data
+
+var PGobject = Packages.org.postgresql.util.PGobject;
+
+function toJsonb(value) {
+    var jsonbObj = new PGobject();
+    jsonbObj.setType(&quot;jsonb&quot;);
+
+	if (typeof value === &quot;object&quot;) {
+        value = JSON.stringify(value);
+    }
+    
+    jsonbObj.setValue(value);
+    logger.info(&quot;jsonbObj: &quot; + jsonbObj);
+    return jsonbObj;
+}
+
+function saveFHIRPayload(interactionId, tenantId, requestUri, payloadJson, operation,source) {
+	
+	logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:tenantId: &quot; + tenantId);
+	logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:requestUri: &quot; + requestUri);
+	logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: operation: &quot; + operation);
+	
+	var DriverManager = java.sql.DriverManager;
+	var conn = null;
+	var stmt = null;
+  var groupInteractionId = globalMap.get(&quot;groupInteractionId&quot;);
+  var masterInteractionId = globalMap.get(&quot;masterInteractionId&quot;);
+	logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; + interactionId
+        + &quot; ]: groupInteractionId: &quot; + groupInteractionId
+        + &quot;, masterInteractionId: &quot; + masterInteractionId);
+	try {
+	    
+
+	    var jdbcUrl = globalMap.get(&apos;jdbcUrl&apos;);
+		if(jdbcUrl != null) {
+		    globalMap.put(&apos;jdbcUrl&apos;, jdbcUrl);
+		} else {
+		    var errorMessage = &apos;MC_JDBC_URL variable is not set&apos;;
+		    logger.error(errorMessage);
+		    setErrorResponse(500, errorMessage); // Set the HTTP response status to 500 (Server error)
+		    throw errorMessage; // Stop further processing by throwing an exception
+		}
+		
+		var jdbcUsername = globalMap.get(&apos;JDBC_USERNAME&apos;);
+		if(jdbcUsername != null) {
+		    globalMap.put(&apos;jdbcUsername&apos;, jdbcUsername);
+		} else {
+		    var errorMessage = &apos;MC_JDBC_USERNAME variable is not set&apos;;
+		    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: &quot; +errorMessage);
+		    setErrorResponse(500, errorMessage); // Set the HTTP response status to 500 (Server error)
+		    throw errorMessage; // Stop further processing by throwing an exception
+		}
+		
+		var jdbcPassword = globalMap.get(&apos;JDBC_PASSWORD&apos;);
+		if(jdbcPassword != null) {
+		    globalMap.put(&apos;jdbcPassword&apos;, jdbcPassword);
+		   
+		} else {
+		    var errorMessage = &apos;MC_JDBC_PASSWORD variable is not set&apos;;
+		    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: &quot;  + errorMessage);
+		    setErrorResponse(500, errorMessage); // Set the HTTP response status to 500 (Server error)
+		    throw errorMessage; // Stop further processing by throwing an exception
+		}
+
+	    // Database connection details
+		var dbUrl = globalMap.get(&apos;jdbcUrl&apos;);
+		var dbUser = globalMap.get(&apos;jdbcUsername&apos;);
+		var dbPassword = globalMap.get(&apos;jdbcPassword&apos;);
+
+	    conn = DriverManager.getConnection(dbUrl, dbUser, dbPassword);
+
+	    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Database connection established successfully.&quot;);
+	
+		var sql =
+		  &quot;select techbd_udi_ingress.register_interaction_fhir_request(&quot; +
+		  &quot;?::text, ?::text, ?::jsonb, ?::jsonb, ?::text, ?::text, ?::jsonb, &quot; +
+		  &quot;?::text, ?::text, ?::text, ?::text, ?::text, ?::text, ?::text, ?::text, ?::text, &quot; +
+		  &quot;?::timestamptz, ?::text, ?::boolean, ?::text, ?::text, ?::text, ?::text, ?::text, ?::jsonb, ?::text&quot; +
+		  &quot;)&quot;;
+
+	 // prepareCall(sql) done before
+		stmt = conn.prepareCall(sql);
+		
+		// 1. p_interaction_id
+		stmt.setString(1, interactionId);
+		
+		// 2. p_interaction_key  (you stated second is requestUri)
+		stmt.setString(2, requestUri);
+		
+		// 3. p_nature jsonb -- include tenantId inside nature as you did
+		var natureObj;
+		if (operation === &quot;saveForwardFHIRPayload&quot;) {
+		  natureObj = { nature: &apos;Forward HTTP Request&apos;, tenant_id: tenantId };
+		} else if (operation === &quot;saveForwardFHIRSuccess&quot;) {
+		  natureObj = { nature: &apos;Forwarded HTTP Response&apos;, tenant_id: tenantId };
+		} else if (operation === &quot;saveForwardFHIRFailure&quot;) {
+		  natureObj = { nature: &apos;Forwarded HTTP Response Error&apos;, tenant_id: tenantId };
+		} else {
+		  natureObj = { nature: operation || &apos;UNKNOWN&apos;, tenant_id: tenantId };
+		}
+		stmt.setObject(3, toJsonb(JSON.stringify(natureObj)), java.sql.Types.OTHER);
+		// 4. p_payload jsonb: set payload JSON or NULL for og case
+		if (operation === &quot;saveForwardFHIRPayload&quot;) {
+		   stmt.setObject(4, toJsonb(payloadJson), java.sql.Types.OTHER);
+		} else {
+		  // if payloadJson is already a JSON string
+		  stmt.setObject(4, payloadJson, java.sql.Types.OTHER);
+		}
+		
+		// 5. p_payload_text text (if you want to store as raw text) — choose either text or null
+		stmt.setNull(5, java.sql.Types.VARCHAR);
+		
+		// 6. p_rule_namespace text
+		stmt.setNull(6, java.sql.Types.VARCHAR);
+		
+		// 7. p_elaboration jsonb
+		stmt.setNull(7, java.sql.Types.OTHER);
+		
+		// 8. p_content_type text
+		stmt.setNull(8, java.sql.Types.VARCHAR);
+		
+		// 9. p_from_state text  (you were setting these earlier to &quot;DISPOSITION&quot;/&quot;FORWARD&quot;, etc.)
+		if (operation === &quot;saveForwardFHIRPayload&quot;) {
+		  stmt.setString(9, &quot;DISPOSITION&quot;);
+		  stmt.setString(10, &quot;FORWARD&quot;);
+		} else if (operation === &quot;saveForwardFHIRSuccess&quot;) {
+		  stmt.setString(9, &quot;FORWARD&quot;);
+		  stmt.setString(10, &quot;COMPLETE&quot;);
+		} else if (operation === &quot;saveForwardFHIRFailure&quot;) {
+		  stmt.setString(9, &quot;FORWARD&quot;);
+		  stmt.setString(10, &quot;FAIL&quot;);
+		} else {
+		  stmt.setNull(9, java.sql.Types.VARCHAR);
+		  stmt.setNull(10, java.sql.Types.VARCHAR);
+		}
+		
+		// 11. p_state_transition_reason
+		stmt.setNull(11, java.sql.Types.VARCHAR);
+		
+		// 12. p_user_id
+		stmt.setNull(12, java.sql.Types.VARCHAR);
+		
+		// 13. p_user_name
+		stmt.setNull(13, java.sql.Types.VARCHAR);
+		
+		// 14. p_user_session
+		stmt.setNull(14, java.sql.Types.VARCHAR);
+		
+		// 15. p_user_role
+		stmt.setNull(15, java.sql.Types.VARCHAR);
+		
+		// 16. p_created_by
+		stmt.setNull(16, java.sql.Types.VARCHAR);
+		
+		// 17. p_created_at (timestamp with time zone)
+		stmt.setNull(17, java.sql.Types.TIMESTAMP_WITH_TIMEZONE);
+		
+	
+		var featureEnabled = String(globalMap.get(&quot;ORG_TECHBD_PROCESSING_AGENT_FEATURE_ENABLED&quot;)).toLowerCase() === &quot;true&quot;;
+		var configuredTenants = globalMap.get(&quot;ORG_TECHBD_PROCESSING_AGENT_TENANT_IDS&quot;);
+		var configuredAgentValue = globalMap.get(&quot;ORG_TECHBD_PROCESSING_AGENT_VALUE&quot;);
+		
+		var processingAgentFinal = tenantId;
+		
+		if (featureEnabled &amp;&amp; configuredTenants != null) {
+		    var tenantList = String(configuredTenants)
+		        .split(&quot;,&quot;)
+		        .map(function(t) { return t.trim().toUpperCase(); });
+		
+		    if (tenantId != null &amp;&amp; tenantList.indexOf(String(tenantId).toUpperCase()) !== -1) {
+		        processingAgentFinal = configuredAgentValue; // TXD
+		    }
+		}
+		
+		var provenanceString =
+		    &quot;channel:&quot; + channelName +
+		    &quot;, script:deploy&quot;;
+		
+		// ONLY for Forward HTTP Request
+		if (operation === &quot;saveForwardFHIRPayload&quot;) {
+		    provenanceString += &quot;, processingAgent:&quot; + processingAgentFinal;
+		}
+		// 18. p_provenance
+		stmt.setString(18, provenanceString);
+
+		// 19. p_hub_upsert_behavior boolean
+		stmt.setNull(19, java.sql.Types.BOOLEAN);
+		
+		// 20. p_source_hub_interaction_id
+		stmt.setString(20, masterInteractionId);
+		
+		// 21. p_origin
+		stmt.setNull(21, java.sql.Types.VARCHAR);
+		
+		// 22. p_source_type
+		stmt.setString(22, source);
+		
+		// 23. p_group_hub_interaction_id
+		var normalizedSource = source ? String(source).trim().toUpperCase() : null;
+		if (normalizedSource === &apos;CSV&apos;){
+			stmt.setString(23, groupInteractionId);
+			}
+		else{
+		stmt.setNull(23, java.sql.Types.VARCHAR);
+		}
+		
+		// 24. p_request_source
+		stmt.setNull(24, java.sql.Types.VARCHAR);
+		
+		// 25. p_additional_details jsonb
+			if (operation === &quot;saveForwardFHIRSuccess&quot; || operation === &quot;saveForwardFHIRFailure&quot;) {	
+			var endTime = java.time.Instant.now();
+			var finishIso;
+			if (endTime instanceof java.time.Instant) {
+			    finishIso = endTime.toString(); // good ISO format e.g. 2025-11-12T14:09:47.637109646Z
+			} else if (typeof endTime === &apos;string&apos;) {
+			    finishIso = endTime;
+			} else {
+			    finishIso = (new Date()).toISOString();
+			}
+		
+		var additionalDetailsObj = {
+		  request: {
+		    &quot;X-Observability-Metric-Interaction-Finish-Time&quot;: finishIso
+		  }
+		};
+		stmt.setObject(25, toJsonb(additionalDetailsObj), java.sql.Types.OTHER);
+		} else{
+		stmt.setNull(25, java.sql.Types.OTHER);
+		}
+		
+		// 26. p_techbd_version_number text
+		stmt.setNull(26, java.sql.Types.VARCHAR);
+		
+		// execute
+		var result = stmt.execute();
+	
+	} catch (e) {
+	    logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Error executing stored procedure: &quot; + e);
+	} finally {
+	    if (stmt != null) stmt.close();
+	    if (conn != null) conn.close();
+	    logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]:  DB connection closed.&quot;);
+	}
+}
+
+globalMap.put(&apos;saveFHIRPayload&apos;, saveFHIRPayload);
+
+
+
+function sendDataLedgerSync(payload,interactionId) {
+    
+    
+    var apiUrl = globalMap.get(&quot;DATA_LEDGER_API_URL&quot;);
+    var dataLedgerApiKey = globalMap.get(&quot;TECHBD_NYEC_DATALEDGER_API_KEY&quot;);
+
+    if (apiUrl == null) {
+        throw new Error(&quot;Environment variable DATA_LEDGER_API_URL is not set.&quot;);
+    }
+    if (dataLedgerApiKey == null) {
+        throw new Error(&quot;Environment variable &apos;TECHBD_NYEC_DATALEDGER_API_KEY&apos; is not set.&quot;);
+    }
+
+    try {
+        var HttpClients = org.apache.http.impl.client.HttpClients;
+        var HttpPost = org.apache.http.client.methods.HttpPost;
+        var StringEntity = org.apache.http.entity.StringEntity;
+        var EntityUtils = org.apache.http.util.EntityUtils;
+
+        var httpClient = HttpClients.createDefault();
+        var httpPost = new HttpPost(apiUrl);
+
+        httpPost.setHeader(&quot;Content-Type&quot;, &quot;application/json&quot;);
+        httpPost.setHeader(&quot;Accept&quot;, &quot;application/json&quot;);
+       
+        if (dataLedgerApiKey != null) {
+        	httpPost.setHeader(&quot;x-api-key&quot;, dataLedgerApiKey); // Add x-api-key header
+        }
+
+        var entity = new StringEntity(payload, &quot;UTF-8&quot;);
+        httpPost.setEntity(entity);
+
+        
+        try {
+        	var response = httpClient.execute(httpPost);
+            var statusCode = response.getStatusLine().getStatusCode();
+            logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: sendDataLedgerSync response status: &quot; + statusCode);
+            var responseBody = EntityUtils.toString(response.getEntity());
+
+            if (statusCode &gt;= 200 &amp;&amp; statusCode &lt; 300) {
+                logger.info(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Data Ledger API Response: &quot; + responseBody);
+                return {
+                    statusCode: statusCode,
+                    body: responseBody
+                };
+            } else {
+                logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Data Ledger API Error. Status: &quot; + statusCode + &quot;, Response: &quot; + responseBody);
+                throw new Error(&quot;Request failed with status &quot; + statusCode);
+            }
+        } finally {
+            EntityUtils.consumeQuietly(response.getEntity());
+             httpClient.close();
+        }
+    } catch (error) {
+        logger.error(&quot;[CHANNEL: 1115 TECHBD &quot; + channelName + &quot;][INTERACTION ID: &quot; +interactionId +&quot; ]: Data Ledger API Request Failed: &quot; + error.message);
+        throw error;
+    }
+}
+
+globalMap.put(&apos;sendDataLedgerSync&apos;, sendDataLedgerSync);
+
+// Function to extract a query param from the URI
+function getQueryParam(uriString, paramName) {
+    if (!uriString) return null;
+    var regex = new RegExp(&apos;[?&amp;]&apos; + paramName + &apos;=([^&amp;]*)&apos;, &apos;i&apos;);
+    var match = uriString.match(regex);
+    return (match &amp;&amp; match[1]) ? decodeURIComponent(match[1]) : null;
+}
+globalMap.put(&apos;getQueryParam&apos;, getQueryParam);
+
+return;</deployScript>
+  <undeployScript>// This script executes once when the channel is undeployed
+// You only have access to the globalMap and globalChannelMap here to persist data
+return;</undeployScript>
+  <properties version="26.6.0">
+    <clearGlobalChannelMap>true</clearGlobalChannelMap>
+    <messageStorageMode>DEVELOPMENT</messageStorageMode>
+    <encryptData>false</encryptData>
+    <encryptAttachments>false</encryptAttachments>
+    <encryptCustomMetaData>false</encryptCustomMetaData>
+    <removeContentOnCompletion>false</removeContentOnCompletion>
+    <removeOnlyFilteredOnCompletion>false</removeOnlyFilteredOnCompletion>
+    <removeAttachmentsOnCompletion>false</removeAttachmentsOnCompletion>
+    <initialState>STARTED</initialState>
+    <storeAttachments>false</storeAttachments>
+    <metaDataColumns>
+      <metaDataColumn>
+        <name>SOURCE</name>
+        <type>STRING</type>
+        <mappingName>message_source</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>TYPE</name>
+        <type>STRING</type>
+        <mappingName>message_type</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDTENANTID</name>
+        <type>STRING</type>
+        <mappingName>tenantId</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XSHINNYIGVERSION</name>
+        <type>STRING</type>
+        <mappingName>igVersion</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDSOURCETYPE</name>
+        <type>STRING</type>
+        <mappingName>source</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDMASTERINTERACTIONID</name>
+        <type>STRING</type>
+        <mappingName>masterInteractionId</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDELABORATION</name>
+        <type>STRING</type>
+        <mappingName>elaboration</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDGROUPINTERACTIONID</name>
+        <type>STRING</type>
+        <mappingName>groupInteractionId</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDINTERACTIONID</name>
+        <type>STRING</type>
+        <mappingName>interactionId</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDOVERRIDEREQUESTURI</name>
+        <type>STRING</type>
+        <mappingName>requestUri</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDDATALEDGERTRACKING</name>
+        <type>STRING</type>
+        <mappingName>dataLedgerTracking</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDDATALEDGERDIAGNOSTICS</name>
+        <type>STRING</type>
+        <mappingName>dataLedgerDiagnostics</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>XTECHBDVALIDATIONSEVERITYLEVEL</name>
+        <type>STRING</type>
+        <mappingName>validationSeverityLevel</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>OOSIZE</name>
+        <type>STRING</type>
+        <mappingName>ooSize</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>DATALEDGERPARAM</name>
+        <type>STRING</type>
+        <mappingName>dataLedgerParam</mappingName>
+      </metaDataColumn>
+    </metaDataColumns>
+    <attachmentProperties version="26.6.0">
+      <type>None</type>
+      <properties/>
+    </attachmentProperties>
+    <resourceIds class="linked-hash-map">
+      <entry>
+        <string>Default Resource</string>
+        <string>[Default Resource]</string>
+      </entry>
+    </resourceIds>
+  </properties>
+  <exportData>
+    <metadata>
+      <enabled>true</enabled>
+      <lastModified>
+        <time>1786379095904</time>
+        <timezone>Asia/Calcutta</timezone>
+      </lastModified>
+      <pruningSettings>
+        <archiveEnabled>true</archiveEnabled>
+        <pruneErroredMessages>false</pruneErroredMessages>
+      </pruningSettings>
+      <userId>10</userId>
+    </metadata>
+  </exportData>
+</channel>

--- a/integration-artifacts/version.json
+++ b/integration-artifacts/version.json
@@ -16,6 +16,13 @@
     },
     {
       "type": "FHIR",
+      "channel": "FhirBundleHistoricalReplay.xml",
+      "version": "0.1.0",
+      "editedby": "jewelbonnie",
+      "date": "2026-08-11"
+    },
+    {
+      "type": "FHIR",
       "channel": "FhirBundleReplay.xml",
       "version": "0.1.5",
       "editedby": "Nikhithaprojects9696",
@@ -115,9 +122,9 @@
     {
       "type": "Router",
       "channel": "RouterChannel.xml",
-      "version": "0.2.25",
-      "editedby": "abhiramisanthosh90",
-      "date": "2026-07-20"
+      "version": "0.2.26",
+      "editedby": "jewelbonnie",
+      "date": "2026-08-11"
     },
     {
       "type": "MCO",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <revision>0.2037.0</revision>
+        <revision>0.2039.0</revision>
         <java.version>21</java.version>
         <spring-boot.version>3.3.3</spring-boot.version>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Implemented Historical FHIR Bundle Replay submission support in Nexus.

- Added support for submitting historical FHIR bundles for replay processing.
- Integrated replay submission with the Nexus processing workflow.
- Updated request handling and routing for historical replay submissions.
- Added configurable Data Ledger and OperationOutcome handling.
- Completed functional and end-to-end testing.

Related ticket: #1515